### PR TITLE
feat: NyxEditor WYSIWYG component

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -2,3 +2,4 @@
 
 ## Feedback
 - [feedback_package_manager.md](feedback_package_manager.md) — Use pnpm (not yarn) for running scripts in this project
+- [feedback_branch_naming.md](feedback_branch_naming.md) — Git branch naming: use feat/, fix/, chore/ prefixes (not date-prefixed branches)

--- a/.claude/memory/feedback_branch_naming.md
+++ b/.claude/memory/feedback_branch_naming.md
@@ -1,0 +1,11 @@
+---
+name: feedback_branch_naming
+description: Git branch naming convention — use feat/ prefix, not date-prefixed branches
+type: feedback
+---
+
+Use standard Git branch naming: `feat/feature-name`, `fix/bug-name`, etc.
+
+**Why:** Date-prefixed branches (e.g. `20260317-nyx-editor`) are not the convention here. The user corrected this explicitly.
+
+**How to apply:** Always use `feat/`, `fix/`, `chore/`, `docs/` etc. prefixes when creating new branches.

--- a/docs/specs/components/NyxEditor.spec.md
+++ b/docs/specs/components/NyxEditor.spec.md
@@ -47,9 +47,12 @@ NyxEditor provides an opinionated but flexible rich-text editing experience. It 
 
 ## v-model
 
-`defineModel<string>()` — binds to the serialized content string. Format depends on the `format` prop:
-- `markdown`: a Markdown string (e.g. `# Hello\n\n**world**`)
-- `html`: an HTML string (e.g. `<h1>Hello</h1><p><strong>world</strong></p>`)
+| Binding | Type | Default | Description |
+|---|---|---|---|
+| `v-model` | `string` | `''` | Serialized content — Markdown or HTML depending on `format` |
+| `v-model:source` | `boolean` | `false` | When `true`, shows a raw source `<textarea>` instead of the formatted editor |
+
+The source toggle button (top-right corner of the editor) also drives `v-model:source`.
 
 ## Keyboard behaviour
 

--- a/docs/specs/components/NyxEditor.spec.md
+++ b/docs/specs/components/NyxEditor.spec.md
@@ -1,0 +1,104 @@
+# NyxEditor
+
+> A WYSIWYG rich-text editor built on Tiptap, supporting Markdown and HTML output in two distinct UI modes.
+
+## Purpose and scope
+
+NyxEditor provides an opinionated but flexible rich-text editing experience. It is designed for use cases where consumers need a first-class editing surface without managing Tiptap directly.
+
+**Use when:**
+- You need an embeddable editor that produces Markdown or HTML content
+- You want a clean, distraction-free writing experience (`zen` mode)
+- You want a full toolbar surface reminiscent of word processors (`toolbar` mode)
+
+**Do not use when:**
+- You need a plain `<textarea>` — use `NyxTextarea` instead
+- You need custom Tiptap extensions not provided by NyxEditor
+
+## Internal architecture
+
+- Uses `useEditor` and `EditorContent` from `@tiptap/vue-3`
+- Extensions loaded: `StarterKit` always; `Markdown` (from `tiptap-markdown`) when `format` is `markdown`
+- **Zen mode**: uses `BubbleMenu` from `@tiptap/vue-3` — a floating toolbar that appears on text selection
+- **Toolbar mode**: renders a fixed `<div class="nyx-editor__toolbar">` above the editor content
+- v-model syncs bi-directionally via `onUpdate` (editor → model) and a `watch` (model → editor)
+- `useNyxProps` is used for visual prop integration (theme, size, variant, pixel)
+
+## Props
+
+| Prop | Type | Default | Description |
+|---|---|---|---|
+| `mode` | `NyxEditorMode` | `NyxEditorMode.Zen` | UI mode: `zen` (bubble menu) or `toolbar` (top bar) |
+| `format` | `NyxEditorFormat` | `NyxEditorFormat.Markdown` | Output format: `markdown` or `html` |
+| `theme` | `NyxTheme` | `NyxTheme.Default` | Colour theme |
+| `size` | `NyxSize` | `NyxSize.Medium` | Size scale |
+| `variant` | `NyxVariant` | `NyxVariant.Outline` | Fill style |
+| `pixel` | `boolean` | `false` | Pixel-art mode |
+| `disabled` | `boolean` | `false` | Makes the editor read-only |
+| `placeholder` | `string` | `''` | Placeholder shown when editor is empty |
+
+## Emits
+
+| Event | Payload | When |
+|---|---|---|
+| `change` | `string` | Fired on every editor content update, payload is the serialized content (MD or HTML) |
+| `focus` | `FocusEvent` | Editor receives focus |
+| `blur` | `FocusEvent` | Editor loses focus |
+
+## v-model
+
+`defineModel<string>()` — binds to the serialized content string. Format depends on the `format` prop:
+- `markdown`: a Markdown string (e.g. `# Hello\n\n**world**`)
+- `html`: an HTML string (e.g. `<h1>Hello</h1><p><strong>world</strong></p>`)
+
+## Keyboard behaviour
+
+Inherited from Tiptap/ProseMirror defaults:
+- `Mod+B` — Toggle bold
+- `Mod+I` — Toggle italic
+- `Mod+Z` / `Mod+Shift+Z` — Undo / Redo
+- Standard browser text-editing shortcuts
+
+No custom key bindings added at the NyxEditor level.
+
+## Accessibility
+
+- The editor root element is a `<div>` with `role="textbox"` and `aria-multiline="true"` applied by Tiptap
+- Toolbar buttons include `aria-label` attributes
+- `disabled` prop maps to Tiptap's `editable: false`, which prevents all input
+
+## Mode names
+
+| Mode | Value | Description |
+|---|---|---|
+| Zen | `zen` | Clean surface; a floating `BubbleMenu` appears on text selection with common formatting controls. No persistent UI chrome. |
+| Toolbar | `toolbar` | A persistent toolbar above the editor surface, styled after word processors (Google Docs / Word). Contains buttons for all supported formatting operations. |
+
+## Toolbar actions
+
+Both the bubble menu (zen) and the toolbar (toolbar) expose the same formatting actions:
+
+| Action | Icon label | Tiptap command |
+|---|---|---|
+| Bold | **B** | `toggleBold` |
+| Italic | *I* | `toggleItalic` |
+| Strike | ~~S~~ | `toggleStrike` |
+| Inline code | `<>` | `toggleCode` |
+| Heading 1 | `H1` | `toggleHeading({ level: 1 })` |
+| Heading 2 | `H2` | `toggleHeading({ level: 2 })` |
+| Heading 3 | `H3` | `toggleHeading({ level: 3 })` |
+| Bullet list | `• List` | `toggleBulletList` |
+| Ordered list | `1. List` | `toggleOrderedList` |
+| Blockquote | `"` | `toggleBlockquote` |
+| Code block | `{ }` | `toggleCodeBlock` |
+| Undo | `←` | `undo` (toolbar only) |
+| Redo | `→` | `redo` (toolbar only) |
+
+The bubble menu omits Undo/Redo and list/blockquote/code-block actions to keep the floating UI compact.
+
+## Known limitations
+
+- HTML output format is implemented but HTML → editor round-tripping depends on Tiptap's built-in HTML parser. Custom HTML produced outside Tiptap may not parse correctly.
+- No image upload support.
+- No collaborative editing support.
+- Tiptap extensions beyond `StarterKit` and `tiptap-markdown` are not exposed — consumers who need them must integrate Tiptap directly.

--- a/docs/specs/components/NyxEditor.spec.md
+++ b/docs/specs/components/NyxEditor.spec.md
@@ -18,9 +18,9 @@ NyxEditor provides an opinionated but flexible rich-text editing experience. It 
 ## Internal architecture
 
 - Uses `useEditor` and `EditorContent` from `@tiptap/vue-3`
-- Extensions loaded: `StarterKit` always; `Markdown` (from `tiptap-markdown`) when `format` is `markdown`
-- **Zen mode**: uses `BubbleMenu` from `@tiptap/vue-3` — a floating toolbar that appears on text selection
-- **Toolbar mode**: renders a fixed `<div class="nyx-editor__toolbar">` above the editor content
+- Extensions loaded: `StarterKit`, `Underline`, `TaskList`, `TaskItem` always; `Markdown` (from `tiptap-markdown`) when `format` is `markdown`
+- **Zen mode**: custom bubble menu — listens to `onSelectionUpdate`, reads `window.getSelection().getRangeAt(0).getBoundingClientRect()` to position a `<Teleport>`-ed `div` above the selection. `@mousedown` on the bubble sets a `suppressNextHide` flag (cleared with `requestAnimationFrame`) so that clicking a formatting button does not collapse the bubble before the command fires.
+- **Toolbar mode**: renders a fixed `<div class="nyx-editor__toolbar">` above the editor content. _(See Known Limitations — not yet rendering in Storybook.)_
 - v-model syncs bi-directionally via `onUpdate` (editor → model) and a `watch` (model → editor)
 - `useNyxProps` is used for visual prop integration (theme, size, variant, pixel)
 
@@ -56,6 +56,7 @@ NyxEditor provides an opinionated but flexible rich-text editing experience. It 
 Inherited from Tiptap/ProseMirror defaults:
 - `Mod+B` — Toggle bold
 - `Mod+I` — Toggle italic
+- `Mod+U` — Toggle underline
 - `Mod+Z` / `Mod+Shift+Z` — Undo / Redo
 - Standard browser text-editing shortcuts
 
@@ -64,41 +65,45 @@ No custom key bindings added at the NyxEditor level.
 ## Accessibility
 
 - The editor root element is a `<div>` with `role="textbox"` and `aria-multiline="true"` applied by Tiptap
-- Toolbar buttons include `aria-label` attributes
+- All bubble and toolbar buttons include `aria-label` attributes
 - `disabled` prop maps to Tiptap's `editable: false`, which prevents all input
 
 ## Mode names
 
 | Mode | Value | Description |
 |---|---|---|
-| Zen | `zen` | Clean surface; a floating `BubbleMenu` appears on text selection with common formatting controls. No persistent UI chrome. |
+| Zen | `zen` | Clean surface; a custom floating bubble menu appears on text selection with common formatting controls. No persistent UI chrome. |
 | Toolbar | `toolbar` | A persistent toolbar above the editor surface, styled after word processors (Google Docs / Word). Contains buttons for all supported formatting operations. |
 
-## Toolbar actions
+## Bubble menu actions (zen mode)
 
-Both the bubble menu (zen) and the toolbar (toolbar) expose the same formatting actions:
+Order: **B** **I** **U** ~~S~~ `<>` | UL OL ☐ | H1 H2 H3 P
 
-| Action | Icon label | Tiptap command |
+| Action | Label | Tiptap command |
 |---|---|---|
-| Bold | **B** | `toggleBold` |
-| Italic | *I* | `toggleItalic` |
-| Strike | ~~S~~ | `toggleStrike` |
+| Bold | `B` | `toggleBold` |
+| Italic | `I` | `toggleItalic` |
+| Underline | `U` | `toggleUnderline` |
+| Strikethrough | `S` | `toggleStrike` |
 | Inline code | `<>` | `toggleCode` |
+| Bullet list | `UL` | `toggleBulletList` |
+| Ordered list | `OL` | `toggleOrderedList` |
+| Task list | `☐` | `toggleTaskList` |
 | Heading 1 | `H1` | `toggleHeading({ level: 1 })` |
 | Heading 2 | `H2` | `toggleHeading({ level: 2 })` |
 | Heading 3 | `H3` | `toggleHeading({ level: 3 })` |
-| Bullet list | `• List` | `toggleBulletList` |
-| Ordered list | `1. List` | `toggleOrderedList` |
-| Blockquote | `"` | `toggleBlockquote` |
-| Code block | `{ }` | `toggleCodeBlock` |
-| Undo | `←` | `undo` (toolbar only) |
-| Redo | `→` | `redo` (toolbar only) |
+| Paragraph | `P` | `setParagraph` |
 
-The bubble menu omits Undo/Redo and list/blockquote/code-block actions to keep the floating UI compact.
+## Toolbar actions (toolbar mode)
+
+Same set as the bubble menu, plus Undo / Redo at the trailing edge.
+
+> **TODO**: Toolbar mode is not currently rendering in Storybook. The `v-if="props.mode === 'toolbar'"` condition and the toolbar markup are implemented but require investigation. Deferred — not needed short-term.
 
 ## Known limitations
 
+- **Toolbar mode not rendering** — see TODO above.
 - HTML output format is implemented but HTML → editor round-tripping depends on Tiptap's built-in HTML parser. Custom HTML produced outside Tiptap may not parse correctly.
 - No image upload support.
 - No collaborative editing support.
-- Tiptap extensions beyond `StarterKit` and `tiptap-markdown` are not exposed — consumers who need them must integrate Tiptap directly.
+- Tiptap extensions beyond those bundled (`StarterKit`, `Underline`, `TaskList`, `TaskItem`, `tiptap-markdown`) are not exposed — consumers who need them must integrate Tiptap directly.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nyx",
-  "version": "0.0.0",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nyx",
-      "version": "0.0.0",
+      "version": "1.3.0",
       "dependencies": {
         "pinia": "^2.3.1",
         "vue": "^3.5.13",

--- a/package.json
+++ b/package.json
@@ -77,6 +77,9 @@
     "access": "public"
   },
   "dependencies": {
+    "@tiptap/extension-task-item": "^3.20.4",
+    "@tiptap/extension-task-list": "^3.20.4",
+    "@tiptap/extension-underline": "^3.20.4",
     "@tiptap/starter-kit": "^3.20.4",
     "@tiptap/vue-3": "^3.20.4",
     "tiptap-markdown": "^0.9.0",
@@ -85,12 +88,12 @@
   "devDependencies": {
     "@chromatic-com/storybook": "3.2.4",
     "@playwright/test": "^1.50.1",
-    "@storybook/addon-docs": "^8.5.6",
+    "@storybook/addon-docs": "8.5.6",
     "@storybook/addon-essentials": "8.5.6",
     "@storybook/addon-interactions": "8.5.6",
     "@storybook/addon-onboarding": "8.5.6",
     "@storybook/blocks": "8.5.6",
-    "@storybook/cli": "^8.5.6",
+    "@storybook/cli": "8.5.6",
     "@storybook/test": "8.5.6",
     "@storybook/vue3": "8.5.6",
     "@storybook/vue3-vite": "8.5.6",

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "@tiptap/extension-underline": "^3.20.4",
     "@tiptap/starter-kit": "^3.20.4",
     "@tiptap/vue-3": "^3.20.4",
+    "lucide-vue-next": "^0.577.0",
     "tiptap-markdown": "^0.9.0",
     "vue": "^3.5.13"
   },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "nyx-kit",
   "homepage": "http://nyxkit.github.io/nyx-kit",
   "author": "Arne Decant <hello@arnedecant.be>",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "private": false,
   "license": "MIT",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -77,6 +77,9 @@
     "access": "public"
   },
   "dependencies": {
+    "@tiptap/starter-kit": "^3.20.4",
+    "@tiptap/vue-3": "^3.20.4",
+    "tiptap-markdown": "^0.9.0",
     "vue": "^3.5.13"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,15 @@ importers:
 
   .:
     dependencies:
+      '@tiptap/starter-kit':
+        specifier: ^3.20.4
+        version: 3.20.4
+      '@tiptap/vue-3':
+        specifier: ^3.20.4
+        version: 3.20.4(@floating-ui/dom@1.7.6)(@tiptap/core@3.20.4(@tiptap/pm@3.20.4))(@tiptap/pm@3.20.4)(vue@3.5.30(typescript@5.7.3))
+      tiptap-markdown:
+        specifier: ^0.9.0
+        version: 0.9.0(@tiptap/core@3.20.4(@tiptap/pm@3.20.4))
       vue:
         specifier: ^3.5.13
         version: 3.5.30(typescript@5.7.3)
@@ -1076,6 +1085,15 @@ packages:
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@floating-ui/core@1.7.5':
+    resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
+
+  '@floating-ui/dom@1.7.6':
+    resolution: {integrity: sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==}
+
+  '@floating-ui/utils@0.2.11':
+    resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
+
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
     engines: {node: '>=18.18.0'}
@@ -1289,6 +1307,9 @@ packages:
 
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
+
+  '@remirror/core-constants@3.0.0':
+    resolution: {integrity: sha512-42aWfPrimMfDKDi4YegyS7x+/0tlzaqwPQCULLanv3DMIlu96KTJR0fM5isWX2UViOqlGnX6YFgqWepcX+XMNg==}
 
   '@rollup/pluginutils@5.3.0':
     resolution: {integrity: sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==}
@@ -1719,6 +1740,153 @@ packages:
     peerDependencies:
       '@testing-library/dom': '>=7.21.4'
 
+  '@tiptap/core@3.20.4':
+    resolution: {integrity: sha512-3i/DG89TFY/b34T5P+j35UcjYuB5d3+9K8u6qID+iUqNPiza015HPIZLuPfE5elNwVdV3EXIoPo0LLeBLgXXAg==}
+    peerDependencies:
+      '@tiptap/pm': ^3.20.4
+
+  '@tiptap/extension-blockquote@3.20.4':
+    resolution: {integrity: sha512-9sskyyhYj2oKat//lyZVXCp9YrPt4oJAZnGHYWXS0xlskjsLElrfKKlM4vpbhGss3VrhQRoEGqWLnIaJYPF1zw==}
+    peerDependencies:
+      '@tiptap/core': ^3.20.4
+
+  '@tiptap/extension-bold@3.20.4':
+    resolution: {integrity: sha512-Md7/mNAeJCY+VLJc8JRGI+8XkVPKiOGB1NgqQPdh3aYtxXQDChQOZoJEQl6TuudDxZ85bLZB67NjZlx3jo8/0g==}
+    peerDependencies:
+      '@tiptap/core': ^3.20.4
+
+  '@tiptap/extension-bubble-menu@3.20.4':
+    resolution: {integrity: sha512-EXywPlI8wjPcAb8ozymgVhjtMjFrnhtoyNTy8ZcObdpUi5CdO9j892Y7aPbKe5hLhlDpvJk7rMfir4FFKEmfng==}
+    peerDependencies:
+      '@tiptap/core': ^3.20.4
+      '@tiptap/pm': ^3.20.4
+
+  '@tiptap/extension-bullet-list@3.20.4':
+    resolution: {integrity: sha512-1RTGrur1EKoxfnLZ3M6xeNj8GITAz74jH2DHGcjLsd2Xr7Q7BozGaIq6GkkvKguMwbI1zCOxTHFCpUETXAIQQA==}
+    peerDependencies:
+      '@tiptap/extension-list': ^3.20.4
+
+  '@tiptap/extension-code-block@3.20.4':
+    resolution: {integrity: sha512-Zlw3FrXTy01+o1yISeX/LC+iJeHA+ym602bMXGmtA6lyl7QSOSO7WExweJ6xeJGhbCjldwT5al6fkRAs8iGJZg==}
+    peerDependencies:
+      '@tiptap/core': ^3.20.4
+      '@tiptap/pm': ^3.20.4
+
+  '@tiptap/extension-code@3.20.4':
+    resolution: {integrity: sha512-7j8Hi964bH1SZ9oLdZC1fkqWz27mliSDV7M8lmL/M14+Qw42D/VOAKS4Aw9OCFtHMlTsjLR6qsoVxL8Lpkt6NA==}
+    peerDependencies:
+      '@tiptap/core': ^3.20.4
+
+  '@tiptap/extension-document@3.20.4':
+    resolution: {integrity: sha512-zF1CIFVLt8MfSpWWnPwtGyxPOsT0xYM2qJKcXf2yZcTG37wDKmUi6heG53vGigIavbQlLaAFvs+1mNdOu2x/0A==}
+    peerDependencies:
+      '@tiptap/core': ^3.20.4
+
+  '@tiptap/extension-dropcursor@3.20.4':
+    resolution: {integrity: sha512-TgMwvZ8myXYdmd6bUV7qkpZXv7ZUiSmX/8eo+iPEzYo2CnDLAGvDKgC50nfq/g87SDvfBgPuAiBfFvsMQQWaTw==}
+    peerDependencies:
+      '@tiptap/extensions': ^3.20.4
+
+  '@tiptap/extension-floating-menu@3.20.4':
+    resolution: {integrity: sha512-AaPTFhoO8DBIElJyd/RTVJjkctvJuL+GHURX0npbtTxXq5HXbebVwf2ARNR7jMd/GThsmBaNJiGxZg4A2oeDqQ==}
+    peerDependencies:
+      '@floating-ui/dom': ^1.0.0
+      '@tiptap/core': ^3.20.4
+      '@tiptap/pm': ^3.20.4
+
+  '@tiptap/extension-gapcursor@3.20.4':
+    resolution: {integrity: sha512-JJ6f1iQ1e0s4kISgq55U3UYGwWV/N9f0PYMtB6e3L+SBQjXnywaLK0g6vfN6IvTCC2vdIuqeSOX8VlSO97sJLw==}
+    peerDependencies:
+      '@tiptap/extensions': ^3.20.4
+
+  '@tiptap/extension-hard-break@3.20.4':
+    resolution: {integrity: sha512-gJbq58d8zB1gzyqVEopowej5CpW4/Fpg6oGJvlZxaCukqd0gJRWGC89K+jE62YA1Td4sfcKrekKvN7jm2y/ZUg==}
+    peerDependencies:
+      '@tiptap/core': ^3.20.4
+
+  '@tiptap/extension-heading@3.20.4':
+    resolution: {integrity: sha512-xsnkmTGggJc5P2iCwS1lv8KFG31xC/GNPJKoi/3UH67j/lKDhA3AdtshsLeyv2FKtTtYDb8oV0IqzHB1MM6a7w==}
+    peerDependencies:
+      '@tiptap/core': ^3.20.4
+
+  '@tiptap/extension-horizontal-rule@3.20.4':
+    resolution: {integrity: sha512-y6joCi49haAA0bo3EGUY+dWUMHH1GPUc84hxrBY/0pMs+Bn+kQ1+DQJErZDTWGJrlHPWU/yekBZT72SNdp0DNA==}
+    peerDependencies:
+      '@tiptap/core': ^3.20.4
+      '@tiptap/pm': ^3.20.4
+
+  '@tiptap/extension-italic@3.20.4':
+    resolution: {integrity: sha512-4ZqiWr7cmqPFux8tj1ZLiYytyWf343IvQemNX6AvVWvscrJcrfj3YX4Le2BA0RW3A3M6RpLQXXozuF8vxYFDeQ==}
+    peerDependencies:
+      '@tiptap/core': ^3.20.4
+
+  '@tiptap/extension-link@3.20.4':
+    resolution: {integrity: sha512-JNDSkWrVdb8NSvbQXwHWvK5tCMbTWwOHFOweknQZ1JPK4dei9FJVofYQaHyW4bJBdcCjds3NZSnXE8DM9iAWmg==}
+    peerDependencies:
+      '@tiptap/core': ^3.20.4
+      '@tiptap/pm': ^3.20.4
+
+  '@tiptap/extension-list-item@3.20.4':
+    resolution: {integrity: sha512-QoTc5RACXaZF+vIIBBxjGO7D0oWFUDgBKJCpvUZ0CoGGKosnfe4a9I5THFyLj4201cf0oUqgf1oZhTqETGxlVw==}
+    peerDependencies:
+      '@tiptap/extension-list': ^3.20.4
+
+  '@tiptap/extension-list-keymap@3.20.4':
+    resolution: {integrity: sha512-RIqXM649+8IP7p/KVfaGlJiwjCylm1m6OPlaoM3K8O7oEOGRQzNeexexECCD2jsXRxew4E+vBNMD2orXqJmu8A==}
+    peerDependencies:
+      '@tiptap/extension-list': ^3.20.4
+
+  '@tiptap/extension-list@3.20.4':
+    resolution: {integrity: sha512-X+5plTKhOioNcQ4KsAFJJSb/3+zR8Xhdpow4HzXtoV1KcbdDey1fhZdpsfkbrzCL0s6/wAgwZuAchCK7HujurQ==}
+    peerDependencies:
+      '@tiptap/core': ^3.20.4
+      '@tiptap/pm': ^3.20.4
+
+  '@tiptap/extension-ordered-list@3.20.4':
+    resolution: {integrity: sha512-3budNL8BgBon3TcXZ4hjT0YpFvx1Ka3uSIECKDxHgES+OQcR+6cagxSb60gFEccf3Dr0PIwcVTY6g14lC1qKRQ==}
+    peerDependencies:
+      '@tiptap/extension-list': ^3.20.4
+
+  '@tiptap/extension-paragraph@3.20.4':
+    resolution: {integrity: sha512-lm6fOScWuZAF/Sfp97igUwFd3L1QHIVLAWP5NVdh0DTLrEIt4rMBmsww+yOpMQRhvz2uTgMbMXynrimhzi/QVw==}
+    peerDependencies:
+      '@tiptap/core': ^3.20.4
+
+  '@tiptap/extension-strike@3.20.4':
+    resolution: {integrity: sha512-It1Px9uDGTsVqyyg6cy7DigLoenljpQwqdI0jssM7QclZrHnsrye9fZxBBiiuCzzV1305MxKgHvratkHwqmVNA==}
+    peerDependencies:
+      '@tiptap/core': ^3.20.4
+
+  '@tiptap/extension-text@3.20.4':
+    resolution: {integrity: sha512-jchJcBZixDEO2J66Zx5dchsI2mA6IYsROqF8P1poxL4ienH7RVQRCTsBNnSfIeOtREKKWeOU/tEs5fcpvvGwIQ==}
+    peerDependencies:
+      '@tiptap/core': ^3.20.4
+
+  '@tiptap/extension-underline@3.20.4':
+    resolution: {integrity: sha512-0OjMc3FDujX16G+jhvqcY/mLot8SrNtDu8ggUwNLAfiI/QIvMVgk7giFD71DATC/4Nb8i/iwAEegTD8MxBIXCg==}
+    peerDependencies:
+      '@tiptap/core': ^3.20.4
+
+  '@tiptap/extensions@3.20.4':
+    resolution: {integrity: sha512-8p6hVT65DjuQjtEdlH6ewX9SOJHlVQAOee3sWIJQmeJNRnZNvqPIBLleebUqDiljNTpxBv6s6QWkSTKgf3btwg==}
+    peerDependencies:
+      '@tiptap/core': ^3.20.4
+      '@tiptap/pm': ^3.20.4
+
+  '@tiptap/pm@3.20.4':
+    resolution: {integrity: sha512-rCHYSBToilBEuI6PtjziHDdRkABH/XqwJ7dG4Amn/SD3yGiZKYCiEApQlTUS2zZeo8DsLeuqqqB4vEOeD4OEPg==}
+
+  '@tiptap/starter-kit@3.20.4':
+    resolution: {integrity: sha512-WcyK6hsTl8eBsQhQ+d9Sq8fYZKOYdL+D45MyH3hz583elXqJlW3h3JPFYb0o87gddGxn8Mm57OA/gA1zEdeDMw==}
+
+  '@tiptap/vue-3@3.20.4':
+    resolution: {integrity: sha512-OL0lXt6geUu5P+uavOz3PIFfLE6pW4qbdS9gy+ZOZMIHVgcH7isz2V2PjCOOTLY3mb2LWBHVvJIZdfwhQQ0+0Q==}
+    peerDependencies:
+      '@floating-ui/dom': ^1.0.0
+      '@tiptap/core': ^3.20.4
+      '@tiptap/pm': ^3.20.4
+      vue: ^3.0.0
+
   '@tsconfig/node22@22.0.5':
     resolution: {integrity: sha512-hLf2ld+sYN/BtOJjHUWOk568dvjFQkHnLNa6zce25GIH+vxKfvTgm3qpaH6ToF5tu/NN0IH66s+Bb5wElHrLcw==}
 
@@ -1748,6 +1916,24 @@ packages:
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
+  '@types/linkify-it@3.0.5':
+    resolution: {integrity: sha512-yg6E+u0/+Zjva+buc3EIb+29XEg4wltq7cSmd4Uc2EE/1nUVmxyzpX6gUXD0V8jIrG0r7YeOGVIbYRkxeooCtw==}
+
+  '@types/linkify-it@5.0.0':
+    resolution: {integrity: sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==}
+
+  '@types/markdown-it@13.0.9':
+    resolution: {integrity: sha512-1XPwR0+MgXLWfTn9gCsZ55AHOKW1WN+P9vr0PaQh5aerR9LLQXUbjfEAFhjmEmyoYFWAyuN2Mqkn40MZ4ukjBw==}
+
+  '@types/markdown-it@14.1.2':
+    resolution: {integrity: sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==}
+
+  '@types/mdurl@1.0.5':
+    resolution: {integrity: sha512-6L6VymKTzYSrEf4Nev4Xa1LCHKrlTlYCBMTlQKFuddo1CvQcE52I0mwfOJayueUC7MJuXOeHTcIU683lzd0cUA==}
+
+  '@types/mdurl@2.0.0':
+    resolution: {integrity: sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==}
 
   '@types/mdx@2.0.13':
     resolution: {integrity: sha512-+OWZQfAYyio6YkJb3HLxDrvnx6SWWDbC0zVPfBRzUk0/nqoDyf6dNxQi3eArPe8rJ473nobTMQ/8Zk+LxJ+Yuw==}
@@ -2322,6 +2508,9 @@ packages:
     resolution: {integrity: sha512-kLQo+bwn7RX53wF5lK40Uel4tEwsdBf4nmAzuAcu8SBDII1+nk9W9JRpIIxSb8uMOEFEgnk7F1DOa8SWaRChvg==}
     hasBin: true
 
+  crelt@1.0.6:
+    resolution: {integrity: sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==}
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
@@ -2438,6 +2627,10 @@ packages:
 
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
+
+  entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
 
   entities@6.0.1:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
@@ -3102,6 +3295,12 @@ packages:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
 
+  linkify-it@5.0.0:
+    resolution: {integrity: sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==}
+
+  linkifyjs@4.3.2:
+    resolution: {integrity: sha512-NT1CJtq3hHIreOianA8aSXn6Cw0JzYOuDQbOrSPe7gqFnCpKP++MQe3ODgO3oh2GJFORkAAdqredOa60z63GbA==}
+
   local-pkg@1.1.2:
     resolution: {integrity: sha512-arhlxbFRmoQHl33a0Zkle/YWlmNwoyt6QNZEIJcqNbdrsix5Lvc4HyyI3EnwxTYlZYc32EbYrQ8SzEZ7dqgg9A==}
     engines: {node: '>=14'}
@@ -3162,9 +3361,19 @@ packages:
   map-or-similar@1.5.0:
     resolution: {integrity: sha512-0aF7ZmVon1igznGI4VS30yugpduQW3y3GkcgGJOp7d8x8QrizhigUxjI/m2UojsXXto+jLAH3KSz+xOJTiORjg==}
 
+  markdown-it-task-lists@2.1.1:
+    resolution: {integrity: sha512-TxFAc76Jnhb2OUu+n3yz9RMu4CwGfaT788br6HhEDlvWfdeJcLUsxk1Hgw2yJio0OXsxv7pyIPmvECY7bMbluA==}
+
+  markdown-it@14.1.1:
+    resolution: {integrity: sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==}
+    hasBin: true
+
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
+
+  mdurl@2.0.0:
+    resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
 
   memoizerific@1.11.3:
     resolution: {integrity: sha512-/EuHYwAPdLtXwAwSZkh/Gutery6pD2KYd44oQLhAvQp/50mpyduZh8Q7PYHXTCJ+wuXxt7oij2LXyIJOOYFPog==}
@@ -3313,6 +3522,9 @@ packages:
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
+
+  orderedmap@2.1.1:
+    resolution: {integrity: sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==}
 
   oxlint@0.15.15:
     resolution: {integrity: sha512-oQNc1mAHrrbKiXyKJMGs9VCZfwGfLy7YiQKa4qupi71X/u4xyWqOh36YKXqWOXnmm2y7vfWFpGZlhJPAa9tMqA==}
@@ -3501,6 +3713,64 @@ packages:
     resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
     engines: {node: '>= 6'}
 
+  prosemirror-changeset@2.4.0:
+    resolution: {integrity: sha512-LvqH2v7Q2SF6yxatuPP2e8vSUKS/L+xAU7dPDC4RMyHMhZoGDfBC74mYuyYF4gLqOEG758wajtyhNnsTkuhvng==}
+
+  prosemirror-collab@1.3.1:
+    resolution: {integrity: sha512-4SnynYR9TTYaQVXd/ieUvsVV4PDMBzrq2xPUWutHivDuOshZXqQ5rGbZM84HEaXKbLdItse7weMGOUdDVcLKEQ==}
+
+  prosemirror-commands@1.7.1:
+    resolution: {integrity: sha512-rT7qZnQtx5c0/y/KlYaGvtG411S97UaL6gdp6RIZ23DLHanMYLyfGBV5DtSnZdthQql7W+lEVbpSfwtO8T+L2w==}
+
+  prosemirror-dropcursor@1.8.2:
+    resolution: {integrity: sha512-CCk6Gyx9+Tt2sbYk5NK0nB1ukHi2ryaRgadV/LvyNuO3ena1payM2z6Cg0vO1ebK8cxbzo41ku2DE5Axj1Zuiw==}
+
+  prosemirror-gapcursor@1.4.1:
+    resolution: {integrity: sha512-pMdYaEnjNMSwl11yjEGtgTmLkR08m/Vl+Jj443167p9eB3HVQKhYCc4gmHVDsLPODfZfjr/MmirsdyZziXbQKw==}
+
+  prosemirror-history@1.5.0:
+    resolution: {integrity: sha512-zlzTiH01eKA55UAf1MEjtssJeHnGxO0j4K4Dpx+gnmX9n+SHNlDqI2oO1Kv1iPN5B1dm5fsljCfqKF9nFL6HRg==}
+
+  prosemirror-inputrules@1.5.1:
+    resolution: {integrity: sha512-7wj4uMjKaXWAQ1CDgxNzNtR9AlsuwzHfdFH1ygEHA2KHF2DOEaXl1CJfNPAKCg9qNEh4rum975QLaCiQPyY6Fw==}
+
+  prosemirror-keymap@1.2.3:
+    resolution: {integrity: sha512-4HucRlpiLd1IPQQXNqeo81BGtkY8Ai5smHhKW9jjPKRc2wQIxksg7Hl1tTI2IfT2B/LgX6bfYvXxEpJl7aKYKw==}
+
+  prosemirror-markdown@1.13.4:
+    resolution: {integrity: sha512-D98dm4cQ3Hs6EmjK500TdAOew4Z03EV71ajEFiWra3Upr7diytJsjF4mPV2dW+eK5uNectiRj0xFxYI9NLXDbw==}
+
+  prosemirror-menu@1.3.0:
+    resolution: {integrity: sha512-TImyPXCHPcDsSka2/lwJ6WjTASr4re/qWq1yoTTuLOqfXucwF6VcRa2LWCkM/EyTD1UO3CUwiH8qURJoWJRxwg==}
+
+  prosemirror-model@1.25.4:
+    resolution: {integrity: sha512-PIM7E43PBxKce8OQeezAs9j4TP+5yDpZVbuurd1h5phUxEKIu+G2a+EUZzIC5nS1mJktDJWzbqS23n1tsAf5QA==}
+
+  prosemirror-schema-basic@1.2.4:
+    resolution: {integrity: sha512-ELxP4TlX3yr2v5rM7Sb70SqStq5NvI15c0j9j/gjsrO5vaw+fnnpovCLEGIcpeGfifkuqJwl4fon6b+KdrODYQ==}
+
+  prosemirror-schema-list@1.5.1:
+    resolution: {integrity: sha512-927lFx/uwyQaGwJxLWCZRkjXG0p48KpMj6ueoYiu4JX05GGuGcgzAy62dfiV8eFZftgyBUvLx76RsMe20fJl+Q==}
+
+  prosemirror-state@1.4.4:
+    resolution: {integrity: sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==}
+
+  prosemirror-tables@1.8.5:
+    resolution: {integrity: sha512-V/0cDCsHKHe/tfWkeCmthNUcEp1IVO3p6vwN8XtwE9PZQLAZJigbw3QoraAdfJPir4NKJtNvOB8oYGKRl+t0Dw==}
+
+  prosemirror-trailing-node@3.0.0:
+    resolution: {integrity: sha512-xiun5/3q0w5eRnGYfNlW1uU9W6x5MoFKWwq/0TIRgt09lv7Hcser2QYV8t4muXbEr+Fwo0geYn79Xs4GKywrRQ==}
+    peerDependencies:
+      prosemirror-model: ^1.22.1
+      prosemirror-state: ^1.4.2
+      prosemirror-view: ^1.33.8
+
+  prosemirror-transform@1.11.0:
+    resolution: {integrity: sha512-4I7Ce4KpygXb9bkiPS3hTEk4dSHorfRw8uI0pE8IhxlK2GXsqv5tIA7JUSxtSu7u8APVOTtbUBxTmnHIxVkIJw==}
+
+  prosemirror-view@1.41.6:
+    resolution: {integrity: sha512-mxpcDG4hNQa/CPtzxjdlir5bJFDlm0/x5nGBbStB2BWX+XOQ9M8ekEG+ojqB5BcVu2Rc80/jssCMZzSstJuSYg==}
+
   proto-list@1.2.4:
     resolution: {integrity: sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==}
 
@@ -3539,6 +3809,10 @@ packages:
 
   pug@3.0.4:
     resolution: {integrity: sha512-kFfq5mMzrS7+wrl5pLJzZEzemx34OQ0w4SARfhy/3yxTlhbstsudDwJzhf1hP02yHzbjoVMSXUj/Sz6RNfMyXg==}
+
+  punycode.js@2.3.1:
+    resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
+    engines: {node: '>=6'}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -3631,6 +3905,9 @@ packages:
     resolution: {integrity: sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
+
+  rope-sequence@1.3.4:
+    resolution: {integrity: sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==}
 
   rrweb-cssom@0.8.0:
     resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
@@ -3869,6 +4146,11 @@ packages:
     resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
     engines: {node: '>=14.0.0'}
 
+  tiptap-markdown@0.9.0:
+    resolution: {integrity: sha512-dKLQ9iiuGNgrlGVjrNauF/UBzWu4LYOx5pkD0jNkmQt/GOwfCJsBuzZTsf1jZ204ANHOm572mZ9PYvGh1S7tpQ==}
+    peerDependencies:
+      '@tiptap/core': ^3.0.1
+
   tldts-core@6.1.86:
     resolution: {integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==}
 
@@ -3946,6 +4228,9 @@ packages:
     resolution: {integrity: sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  uc.micro@2.1.0:
+    resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
 
   ufo@1.6.3:
     resolution: {integrity: sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==}
@@ -4126,8 +4411,8 @@ packages:
   vue-component-type-helpers@2.2.12:
     resolution: {integrity: sha512-YbGqHZ5/eW4SnkPNR44mKVc6ZKQoRs/Rux1sxC6rdwXb4qpbOSYfDr9DsTHolOTGmIKgM9j141mZbBeg05R1pw==}
 
-  vue-component-type-helpers@3.2.5:
-    resolution: {integrity: sha512-tkvNr+bU8+xD/onAThIe7CHFvOJ/BO6XCOrxMzeytJq40nTfpGDJuVjyCM8ccGZKfAbGk2YfuZyDMXM56qheZQ==}
+  vue-component-type-helpers@3.2.6:
+    resolution: {integrity: sha512-O02tnvIfOQVmnvoWwuSydwRoHjZVt8UEBR+2p4rT35p8GAy5VTlWP8o5qXfJR/GWCN0nVZoYWsVUvx2jwgdBmQ==}
 
   vue-docgen-api@4.79.2:
     resolution: {integrity: sha512-n9ENAcs+40awPZMsas7STqjkZiVlIjxIKgiJr5rSohDP0/JCrD9VtlzNojafsA1MChm/hz2h3PDtUedx3lbgfA==}
@@ -4164,6 +4449,9 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  w3c-keyname@2.2.8:
+    resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
 
   w3c-xmlserializer@5.0.0:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
@@ -5256,6 +5544,17 @@ snapshots:
       '@eslint/core': 0.17.0
       levn: 0.4.1
 
+  '@floating-ui/core@1.7.5':
+    dependencies:
+      '@floating-ui/utils': 0.2.11
+
+  '@floating-ui/dom@1.7.6':
+    dependencies:
+      '@floating-ui/core': 1.7.5
+      '@floating-ui/utils': 0.2.11
+
+  '@floating-ui/utils@0.2.11': {}
+
   '@humanfs/core@0.19.1': {}
 
   '@humanfs/node@0.16.7':
@@ -5444,6 +5743,8 @@ snapshots:
       playwright: 1.58.2
 
   '@polka/url@1.0.0-next.29': {}
+
+  '@remirror/core-constants@3.0.0': {}
 
   '@rollup/pluginutils@5.3.0(rollup@4.59.0)':
     dependencies:
@@ -5912,7 +6213,7 @@ snapshots:
       ts-dedent: 2.2.0
       type-fest: 2.19.0
       vue: 3.5.30(typescript@5.7.3)
-      vue-component-type-helpers: 3.2.5
+      vue-component-type-helpers: 3.2.6
 
   '@testing-library/dom@10.4.0':
     dependencies:
@@ -5938,6 +6239,176 @@ snapshots:
   '@testing-library/user-event@14.5.2(@testing-library/dom@10.4.0)':
     dependencies:
       '@testing-library/dom': 10.4.0
+
+  '@tiptap/core@3.20.4(@tiptap/pm@3.20.4)':
+    dependencies:
+      '@tiptap/pm': 3.20.4
+
+  '@tiptap/extension-blockquote@3.20.4(@tiptap/core@3.20.4(@tiptap/pm@3.20.4))':
+    dependencies:
+      '@tiptap/core': 3.20.4(@tiptap/pm@3.20.4)
+
+  '@tiptap/extension-bold@3.20.4(@tiptap/core@3.20.4(@tiptap/pm@3.20.4))':
+    dependencies:
+      '@tiptap/core': 3.20.4(@tiptap/pm@3.20.4)
+
+  '@tiptap/extension-bubble-menu@3.20.4(@tiptap/core@3.20.4(@tiptap/pm@3.20.4))(@tiptap/pm@3.20.4)':
+    dependencies:
+      '@floating-ui/dom': 1.7.6
+      '@tiptap/core': 3.20.4(@tiptap/pm@3.20.4)
+      '@tiptap/pm': 3.20.4
+    optional: true
+
+  '@tiptap/extension-bullet-list@3.20.4(@tiptap/extension-list@3.20.4(@tiptap/core@3.20.4(@tiptap/pm@3.20.4))(@tiptap/pm@3.20.4))':
+    dependencies:
+      '@tiptap/extension-list': 3.20.4(@tiptap/core@3.20.4(@tiptap/pm@3.20.4))(@tiptap/pm@3.20.4)
+
+  '@tiptap/extension-code-block@3.20.4(@tiptap/core@3.20.4(@tiptap/pm@3.20.4))(@tiptap/pm@3.20.4)':
+    dependencies:
+      '@tiptap/core': 3.20.4(@tiptap/pm@3.20.4)
+      '@tiptap/pm': 3.20.4
+
+  '@tiptap/extension-code@3.20.4(@tiptap/core@3.20.4(@tiptap/pm@3.20.4))':
+    dependencies:
+      '@tiptap/core': 3.20.4(@tiptap/pm@3.20.4)
+
+  '@tiptap/extension-document@3.20.4(@tiptap/core@3.20.4(@tiptap/pm@3.20.4))':
+    dependencies:
+      '@tiptap/core': 3.20.4(@tiptap/pm@3.20.4)
+
+  '@tiptap/extension-dropcursor@3.20.4(@tiptap/extensions@3.20.4(@tiptap/core@3.20.4(@tiptap/pm@3.20.4))(@tiptap/pm@3.20.4))':
+    dependencies:
+      '@tiptap/extensions': 3.20.4(@tiptap/core@3.20.4(@tiptap/pm@3.20.4))(@tiptap/pm@3.20.4)
+
+  '@tiptap/extension-floating-menu@3.20.4(@floating-ui/dom@1.7.6)(@tiptap/core@3.20.4(@tiptap/pm@3.20.4))(@tiptap/pm@3.20.4)':
+    dependencies:
+      '@floating-ui/dom': 1.7.6
+      '@tiptap/core': 3.20.4(@tiptap/pm@3.20.4)
+      '@tiptap/pm': 3.20.4
+    optional: true
+
+  '@tiptap/extension-gapcursor@3.20.4(@tiptap/extensions@3.20.4(@tiptap/core@3.20.4(@tiptap/pm@3.20.4))(@tiptap/pm@3.20.4))':
+    dependencies:
+      '@tiptap/extensions': 3.20.4(@tiptap/core@3.20.4(@tiptap/pm@3.20.4))(@tiptap/pm@3.20.4)
+
+  '@tiptap/extension-hard-break@3.20.4(@tiptap/core@3.20.4(@tiptap/pm@3.20.4))':
+    dependencies:
+      '@tiptap/core': 3.20.4(@tiptap/pm@3.20.4)
+
+  '@tiptap/extension-heading@3.20.4(@tiptap/core@3.20.4(@tiptap/pm@3.20.4))':
+    dependencies:
+      '@tiptap/core': 3.20.4(@tiptap/pm@3.20.4)
+
+  '@tiptap/extension-horizontal-rule@3.20.4(@tiptap/core@3.20.4(@tiptap/pm@3.20.4))(@tiptap/pm@3.20.4)':
+    dependencies:
+      '@tiptap/core': 3.20.4(@tiptap/pm@3.20.4)
+      '@tiptap/pm': 3.20.4
+
+  '@tiptap/extension-italic@3.20.4(@tiptap/core@3.20.4(@tiptap/pm@3.20.4))':
+    dependencies:
+      '@tiptap/core': 3.20.4(@tiptap/pm@3.20.4)
+
+  '@tiptap/extension-link@3.20.4(@tiptap/core@3.20.4(@tiptap/pm@3.20.4))(@tiptap/pm@3.20.4)':
+    dependencies:
+      '@tiptap/core': 3.20.4(@tiptap/pm@3.20.4)
+      '@tiptap/pm': 3.20.4
+      linkifyjs: 4.3.2
+
+  '@tiptap/extension-list-item@3.20.4(@tiptap/extension-list@3.20.4(@tiptap/core@3.20.4(@tiptap/pm@3.20.4))(@tiptap/pm@3.20.4))':
+    dependencies:
+      '@tiptap/extension-list': 3.20.4(@tiptap/core@3.20.4(@tiptap/pm@3.20.4))(@tiptap/pm@3.20.4)
+
+  '@tiptap/extension-list-keymap@3.20.4(@tiptap/extension-list@3.20.4(@tiptap/core@3.20.4(@tiptap/pm@3.20.4))(@tiptap/pm@3.20.4))':
+    dependencies:
+      '@tiptap/extension-list': 3.20.4(@tiptap/core@3.20.4(@tiptap/pm@3.20.4))(@tiptap/pm@3.20.4)
+
+  '@tiptap/extension-list@3.20.4(@tiptap/core@3.20.4(@tiptap/pm@3.20.4))(@tiptap/pm@3.20.4)':
+    dependencies:
+      '@tiptap/core': 3.20.4(@tiptap/pm@3.20.4)
+      '@tiptap/pm': 3.20.4
+
+  '@tiptap/extension-ordered-list@3.20.4(@tiptap/extension-list@3.20.4(@tiptap/core@3.20.4(@tiptap/pm@3.20.4))(@tiptap/pm@3.20.4))':
+    dependencies:
+      '@tiptap/extension-list': 3.20.4(@tiptap/core@3.20.4(@tiptap/pm@3.20.4))(@tiptap/pm@3.20.4)
+
+  '@tiptap/extension-paragraph@3.20.4(@tiptap/core@3.20.4(@tiptap/pm@3.20.4))':
+    dependencies:
+      '@tiptap/core': 3.20.4(@tiptap/pm@3.20.4)
+
+  '@tiptap/extension-strike@3.20.4(@tiptap/core@3.20.4(@tiptap/pm@3.20.4))':
+    dependencies:
+      '@tiptap/core': 3.20.4(@tiptap/pm@3.20.4)
+
+  '@tiptap/extension-text@3.20.4(@tiptap/core@3.20.4(@tiptap/pm@3.20.4))':
+    dependencies:
+      '@tiptap/core': 3.20.4(@tiptap/pm@3.20.4)
+
+  '@tiptap/extension-underline@3.20.4(@tiptap/core@3.20.4(@tiptap/pm@3.20.4))':
+    dependencies:
+      '@tiptap/core': 3.20.4(@tiptap/pm@3.20.4)
+
+  '@tiptap/extensions@3.20.4(@tiptap/core@3.20.4(@tiptap/pm@3.20.4))(@tiptap/pm@3.20.4)':
+    dependencies:
+      '@tiptap/core': 3.20.4(@tiptap/pm@3.20.4)
+      '@tiptap/pm': 3.20.4
+
+  '@tiptap/pm@3.20.4':
+    dependencies:
+      prosemirror-changeset: 2.4.0
+      prosemirror-collab: 1.3.1
+      prosemirror-commands: 1.7.1
+      prosemirror-dropcursor: 1.8.2
+      prosemirror-gapcursor: 1.4.1
+      prosemirror-history: 1.5.0
+      prosemirror-inputrules: 1.5.1
+      prosemirror-keymap: 1.2.3
+      prosemirror-markdown: 1.13.4
+      prosemirror-menu: 1.3.0
+      prosemirror-model: 1.25.4
+      prosemirror-schema-basic: 1.2.4
+      prosemirror-schema-list: 1.5.1
+      prosemirror-state: 1.4.4
+      prosemirror-tables: 1.8.5
+      prosemirror-trailing-node: 3.0.0(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.6)
+      prosemirror-transform: 1.11.0
+      prosemirror-view: 1.41.6
+
+  '@tiptap/starter-kit@3.20.4':
+    dependencies:
+      '@tiptap/core': 3.20.4(@tiptap/pm@3.20.4)
+      '@tiptap/extension-blockquote': 3.20.4(@tiptap/core@3.20.4(@tiptap/pm@3.20.4))
+      '@tiptap/extension-bold': 3.20.4(@tiptap/core@3.20.4(@tiptap/pm@3.20.4))
+      '@tiptap/extension-bullet-list': 3.20.4(@tiptap/extension-list@3.20.4(@tiptap/core@3.20.4(@tiptap/pm@3.20.4))(@tiptap/pm@3.20.4))
+      '@tiptap/extension-code': 3.20.4(@tiptap/core@3.20.4(@tiptap/pm@3.20.4))
+      '@tiptap/extension-code-block': 3.20.4(@tiptap/core@3.20.4(@tiptap/pm@3.20.4))(@tiptap/pm@3.20.4)
+      '@tiptap/extension-document': 3.20.4(@tiptap/core@3.20.4(@tiptap/pm@3.20.4))
+      '@tiptap/extension-dropcursor': 3.20.4(@tiptap/extensions@3.20.4(@tiptap/core@3.20.4(@tiptap/pm@3.20.4))(@tiptap/pm@3.20.4))
+      '@tiptap/extension-gapcursor': 3.20.4(@tiptap/extensions@3.20.4(@tiptap/core@3.20.4(@tiptap/pm@3.20.4))(@tiptap/pm@3.20.4))
+      '@tiptap/extension-hard-break': 3.20.4(@tiptap/core@3.20.4(@tiptap/pm@3.20.4))
+      '@tiptap/extension-heading': 3.20.4(@tiptap/core@3.20.4(@tiptap/pm@3.20.4))
+      '@tiptap/extension-horizontal-rule': 3.20.4(@tiptap/core@3.20.4(@tiptap/pm@3.20.4))(@tiptap/pm@3.20.4)
+      '@tiptap/extension-italic': 3.20.4(@tiptap/core@3.20.4(@tiptap/pm@3.20.4))
+      '@tiptap/extension-link': 3.20.4(@tiptap/core@3.20.4(@tiptap/pm@3.20.4))(@tiptap/pm@3.20.4)
+      '@tiptap/extension-list': 3.20.4(@tiptap/core@3.20.4(@tiptap/pm@3.20.4))(@tiptap/pm@3.20.4)
+      '@tiptap/extension-list-item': 3.20.4(@tiptap/extension-list@3.20.4(@tiptap/core@3.20.4(@tiptap/pm@3.20.4))(@tiptap/pm@3.20.4))
+      '@tiptap/extension-list-keymap': 3.20.4(@tiptap/extension-list@3.20.4(@tiptap/core@3.20.4(@tiptap/pm@3.20.4))(@tiptap/pm@3.20.4))
+      '@tiptap/extension-ordered-list': 3.20.4(@tiptap/extension-list@3.20.4(@tiptap/core@3.20.4(@tiptap/pm@3.20.4))(@tiptap/pm@3.20.4))
+      '@tiptap/extension-paragraph': 3.20.4(@tiptap/core@3.20.4(@tiptap/pm@3.20.4))
+      '@tiptap/extension-strike': 3.20.4(@tiptap/core@3.20.4(@tiptap/pm@3.20.4))
+      '@tiptap/extension-text': 3.20.4(@tiptap/core@3.20.4(@tiptap/pm@3.20.4))
+      '@tiptap/extension-underline': 3.20.4(@tiptap/core@3.20.4(@tiptap/pm@3.20.4))
+      '@tiptap/extensions': 3.20.4(@tiptap/core@3.20.4(@tiptap/pm@3.20.4))(@tiptap/pm@3.20.4)
+      '@tiptap/pm': 3.20.4
+
+  '@tiptap/vue-3@3.20.4(@floating-ui/dom@1.7.6)(@tiptap/core@3.20.4(@tiptap/pm@3.20.4))(@tiptap/pm@3.20.4)(vue@3.5.30(typescript@5.7.3))':
+    dependencies:
+      '@floating-ui/dom': 1.7.6
+      '@tiptap/core': 3.20.4(@tiptap/pm@3.20.4)
+      '@tiptap/pm': 3.20.4
+      vue: 3.5.30(typescript@5.7.3)
+    optionalDependencies:
+      '@tiptap/extension-bubble-menu': 3.20.4(@tiptap/core@3.20.4(@tiptap/pm@3.20.4))(@tiptap/pm@3.20.4)
+      '@tiptap/extension-floating-menu': 3.20.4(@floating-ui/dom@1.7.6)(@tiptap/core@3.20.4(@tiptap/pm@3.20.4))(@tiptap/pm@3.20.4)
 
   '@tsconfig/node22@22.0.5': {}
 
@@ -5967,6 +6438,24 @@ snapshots:
       parse5: 7.3.0
 
   '@types/json-schema@7.0.15': {}
+
+  '@types/linkify-it@3.0.5': {}
+
+  '@types/linkify-it@5.0.0': {}
+
+  '@types/markdown-it@13.0.9':
+    dependencies:
+      '@types/linkify-it': 3.0.5
+      '@types/mdurl': 1.0.5
+
+  '@types/markdown-it@14.1.2':
+    dependencies:
+      '@types/linkify-it': 5.0.0
+      '@types/mdurl': 2.0.0
+
+  '@types/mdurl@1.0.5': {}
+
+  '@types/mdurl@2.0.0': {}
 
   '@types/mdx@2.0.13': {}
 
@@ -6622,6 +7111,8 @@ snapshots:
       recast: 0.23.11
       semver: 7.7.4
 
+  crelt@1.0.6: {}
+
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
@@ -6714,6 +7205,8 @@ snapshots:
   emoji-regex@8.0.0: {}
 
   emoji-regex@9.2.2: {}
+
+  entities@4.5.0: {}
 
   entities@6.0.1: {}
 
@@ -7472,6 +7965,12 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
 
+  linkify-it@5.0.0:
+    dependencies:
+      uc.micro: 2.1.0
+
+  linkifyjs@4.3.2: {}
+
   local-pkg@1.1.2:
     dependencies:
       mlly: 1.8.1
@@ -7528,7 +8027,20 @@ snapshots:
 
   map-or-similar@1.5.0: {}
 
+  markdown-it-task-lists@2.1.1: {}
+
+  markdown-it@14.1.1:
+    dependencies:
+      argparse: 2.0.1
+      entities: 4.5.0
+      linkify-it: 5.0.0
+      mdurl: 2.0.0
+      punycode.js: 2.3.1
+      uc.micro: 2.1.0
+
   math-intrinsics@1.1.0: {}
+
+  mdurl@2.0.0: {}
 
   memoizerific@1.11.3:
     dependencies:
@@ -7674,6 +8186,8 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
       word-wrap: 1.2.5
+
+  orderedmap@2.1.1: {}
 
   oxlint@0.15.15:
     optionalDependencies:
@@ -7835,6 +8349,109 @@ snapshots:
       kleur: 3.0.3
       sisteransi: 1.0.5
 
+  prosemirror-changeset@2.4.0:
+    dependencies:
+      prosemirror-transform: 1.11.0
+
+  prosemirror-collab@1.3.1:
+    dependencies:
+      prosemirror-state: 1.4.4
+
+  prosemirror-commands@1.7.1:
+    dependencies:
+      prosemirror-model: 1.25.4
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.11.0
+
+  prosemirror-dropcursor@1.8.2:
+    dependencies:
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.11.0
+      prosemirror-view: 1.41.6
+
+  prosemirror-gapcursor@1.4.1:
+    dependencies:
+      prosemirror-keymap: 1.2.3
+      prosemirror-model: 1.25.4
+      prosemirror-state: 1.4.4
+      prosemirror-view: 1.41.6
+
+  prosemirror-history@1.5.0:
+    dependencies:
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.11.0
+      prosemirror-view: 1.41.6
+      rope-sequence: 1.3.4
+
+  prosemirror-inputrules@1.5.1:
+    dependencies:
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.11.0
+
+  prosemirror-keymap@1.2.3:
+    dependencies:
+      prosemirror-state: 1.4.4
+      w3c-keyname: 2.2.8
+
+  prosemirror-markdown@1.13.4:
+    dependencies:
+      '@types/markdown-it': 14.1.2
+      markdown-it: 14.1.1
+      prosemirror-model: 1.25.4
+
+  prosemirror-menu@1.3.0:
+    dependencies:
+      crelt: 1.0.6
+      prosemirror-commands: 1.7.1
+      prosemirror-history: 1.5.0
+      prosemirror-state: 1.4.4
+
+  prosemirror-model@1.25.4:
+    dependencies:
+      orderedmap: 2.1.1
+
+  prosemirror-schema-basic@1.2.4:
+    dependencies:
+      prosemirror-model: 1.25.4
+
+  prosemirror-schema-list@1.5.1:
+    dependencies:
+      prosemirror-model: 1.25.4
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.11.0
+
+  prosemirror-state@1.4.4:
+    dependencies:
+      prosemirror-model: 1.25.4
+      prosemirror-transform: 1.11.0
+      prosemirror-view: 1.41.6
+
+  prosemirror-tables@1.8.5:
+    dependencies:
+      prosemirror-keymap: 1.2.3
+      prosemirror-model: 1.25.4
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.11.0
+      prosemirror-view: 1.41.6
+
+  prosemirror-trailing-node@3.0.0(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.6):
+    dependencies:
+      '@remirror/core-constants': 3.0.0
+      escape-string-regexp: 4.0.0
+      prosemirror-model: 1.25.4
+      prosemirror-state: 1.4.4
+      prosemirror-view: 1.41.6
+
+  prosemirror-transform@1.11.0:
+    dependencies:
+      prosemirror-model: 1.25.4
+
+  prosemirror-view@1.41.6:
+    dependencies:
+      prosemirror-model: 1.25.4
+      prosemirror-state: 1.4.4
+      prosemirror-transform: 1.11.0
+
   proto-list@1.2.4: {}
 
   pug-attrs@3.0.0:
@@ -7903,6 +8520,8 @@ snapshots:
       pug-parser: 6.0.0
       pug-runtime: 3.0.1
       pug-strip-comments: 2.0.0
+
+  punycode.js@2.3.1: {}
 
   punycode@2.3.1: {}
 
@@ -8013,6 +8632,8 @@ snapshots:
       '@rollup/rollup-win32-x64-gnu': 4.59.0
       '@rollup/rollup-win32-x64-msvc': 4.59.0
       fsevents: 2.3.3
+
+  rope-sequence@1.3.4: {}
 
   rrweb-cssom@0.8.0: {}
 
@@ -8233,6 +8854,14 @@ snapshots:
 
   tinyspy@4.0.4: {}
 
+  tiptap-markdown@0.9.0(@tiptap/core@3.20.4(@tiptap/pm@3.20.4)):
+    dependencies:
+      '@tiptap/core': 3.20.4(@tiptap/pm@3.20.4)
+      '@types/markdown-it': 13.0.9
+      markdown-it: 14.1.1
+      markdown-it-task-lists: 2.1.1
+      prosemirror-markdown: 1.13.4
+
   tldts-core@6.1.86: {}
 
   tldts@6.1.86:
@@ -8293,6 +8922,8 @@ snapshots:
   typescript@5.7.3: {}
 
   typescript@5.8.2: {}
+
+  uc.micro@2.1.0: {}
 
   ufo@1.6.3: {}
 
@@ -8502,7 +9133,7 @@ snapshots:
 
   vue-component-type-helpers@2.2.12: {}
 
-  vue-component-type-helpers@3.2.5: {}
+  vue-component-type-helpers@3.2.6: {}
 
   vue-docgen-api@4.79.2(vue@3.5.30(typescript@5.7.3)):
     dependencies:
@@ -8564,6 +9195,8 @@ snapshots:
       '@vue/shared': 3.5.30
     optionalDependencies:
       typescript: 5.7.3
+
+  w3c-keyname@2.2.8: {}
 
   w3c-xmlserializer@5.0.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@tiptap/vue-3':
         specifier: ^3.20.4
         version: 3.20.4(@floating-ui/dom@1.7.6)(@tiptap/core@3.20.4(@tiptap/pm@3.20.4))(@tiptap/pm@3.20.4)(vue@3.5.30(typescript@5.7.3))
+      lucide-vue-next:
+        specifier: ^0.577.0
+        version: 0.577.0(vue@3.5.30(typescript@5.7.3))
       tiptap-markdown:
         specifier: ^0.9.0
         version: 0.9.0(@tiptap/core@3.20.4(@tiptap/pm@3.20.4))
@@ -3374,6 +3377,11 @@ packages:
   lru-cache@8.0.5:
     resolution: {integrity: sha512-MhWWlVnuab1RG5/zMRRcVGXZLCXrZTgfwMikgzCegsPnG62yDQo5JnqKkrK4jO5iKqDAZGItAqN5CtKBCBWRUA==}
     engines: {node: '>=16.14'}
+
+  lucide-vue-next@0.577.0:
+    resolution: {integrity: sha512-py05bAfv9SHVJqscbiOnjcnLlEmOffA58a+7XhZuFxrs6txe1E8VoR1ngWGTYO+9aVKABAz8l3ee3PqiQN9QPA==}
+    peerDependencies:
+      vue: '>=3.0.1'
 
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
@@ -8074,6 +8082,10 @@ snapshots:
       yallist: 4.0.0
 
   lru-cache@8.0.5: {}
+
+  lucide-vue-next@0.577.0(vue@3.5.30(typescript@5.7.3)):
+    dependencies:
+      vue: 3.5.30(typescript@5.7.3)
 
   lz-string@1.5.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,15 @@ importers:
 
   .:
     dependencies:
+      '@tiptap/extension-task-item':
+        specifier: ^3.20.4
+        version: 3.20.4(@tiptap/extension-list@3.20.4(@tiptap/core@3.20.4(@tiptap/pm@3.20.4))(@tiptap/pm@3.20.4))
+      '@tiptap/extension-task-list':
+        specifier: ^3.20.4
+        version: 3.20.4(@tiptap/extension-list@3.20.4(@tiptap/core@3.20.4(@tiptap/pm@3.20.4))(@tiptap/pm@3.20.4))
+      '@tiptap/extension-underline':
+        specifier: ^3.20.4
+        version: 3.20.4(@tiptap/core@3.20.4(@tiptap/pm@3.20.4))
       '@tiptap/starter-kit':
         specifier: ^3.20.4
         version: 3.20.4
@@ -28,8 +37,8 @@ importers:
         specifier: ^1.50.1
         version: 1.58.2
       '@storybook/addon-docs':
-        specifier: ^8.5.6
-        version: 8.6.18(@types/react@19.2.14)(storybook@8.5.6(prettier@3.8.1))
+        specifier: 8.5.6
+        version: 8.5.6(@types/react@19.2.14)(storybook@8.5.6(prettier@3.8.1))
       '@storybook/addon-essentials':
         specifier: 8.5.6
         version: 8.5.6(@types/react@19.2.14)(storybook@8.5.6(prettier@3.8.1))
@@ -43,8 +52,8 @@ importers:
         specifier: 8.5.6
         version: 8.5.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@8.5.6(prettier@3.8.1))
       '@storybook/cli':
-        specifier: ^8.5.6
-        version: 8.6.18(@babel/preset-env@7.29.0(@babel/core@7.29.0))(prettier@3.8.1)
+        specifier: 8.5.6
+        version: 8.5.6(@babel/preset-env@7.29.0(@babel/core@7.29.0))(prettier@3.8.1)
       '@storybook/test':
         specifier: 8.5.6
         version: 8.5.6(storybook@8.5.6(prettier@3.8.1))
@@ -1519,11 +1528,6 @@ packages:
     peerDependencies:
       storybook: ^8.5.6
 
-  '@storybook/addon-docs@8.6.18':
-    resolution: {integrity: sha512-55ADer0yNmmeR928Y3UAv3r4i7bJSd9LwywsQ+lRol/FNe0ZcwLEz31xL+jVsqQFNnDh/imsDIp8aYapGMtfEQ==}
-    peerDependencies:
-      storybook: ^8.6.18
-
   '@storybook/addon-essentials@8.5.6':
     resolution: {integrity: sha512-CtOCbJ1TkCqvOoqrksKMTattJdIIe4N/x/o4IBNzvmaLJD0TUYbCnEsYAzm4WXTVdxQ9uJO4f/BHRkNShuHbew==}
     peerDependencies:
@@ -1576,30 +1580,18 @@ packages:
       react-dom:
         optional: true
 
-  '@storybook/blocks@8.6.18':
-    resolution: {integrity: sha512-esZv4msPQ9LxgTb8YUIZhhxVMuI6BPi5bkXtk8c7w7sWuAsqsCe/RnVInn7ooUry2gjnD4hd9+8Eqj0b8oTVoA==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      storybook: ^8.6.18
-    peerDependenciesMeta:
-      react:
-        optional: true
-      react-dom:
-        optional: true
-
   '@storybook/builder-vite@8.5.6':
     resolution: {integrity: sha512-uvNo8wAULW2+IOlsFCrszvH6juBDoOEYZIn0WLGzRKbMvLGt3j6CB6d2QjRrLs9p62ayia51fTpJfhIISM9new==}
     peerDependencies:
       storybook: ^8.5.6
       vite: ^4.0.0 || ^5.0.0 || ^6.0.0
 
-  '@storybook/cli@8.6.18':
-    resolution: {integrity: sha512-4e675ZaRORR+UY1Q6+pf0xv3JUMosNNQ0g1cmB8axVwG4wWT2baNyHNzcKrT5NpsWTziGGja97Wgi89QHp/BMA==}
+  '@storybook/cli@8.5.6':
+    resolution: {integrity: sha512-ICVAc1ldRc1rsvmcikDyB7WygXLcE08czXH5uS2gaEB31qIdj+79NY9Ha8IQZZb1U/XBaruaFjRwB1+c0lh6Bg==}
     hasBin: true
 
-  '@storybook/codemod@8.6.18':
-    resolution: {integrity: sha512-sdGzLOMjmDuqDBydr0A/1AfRpI3RwizPIM3L4duEtwF3+DKo2fRiVq7qhREBTnceZwyHGO+gPPzAdFKRBvospA==}
+  '@storybook/codemod@8.5.6':
+    resolution: {integrity: sha512-uvRLQsxyRAJxtiTpqDeYDevdmxPPL1rw30n+JyEQuee7KdysXsXeMVnOnOD1MGkkhj8Y7z1k+6gWtoX0sMArtA==}
 
   '@storybook/components@8.5.6':
     resolution: {integrity: sha512-d2mhnnce2C03lRhBEtVR9lS78YueQGBS949R3QXPsEXmrkfDMpcnFI3DIOByjnea6ZeS0+i4lYjnfiAJb0oiMQ==}
@@ -1624,23 +1616,10 @@ packages:
       prettier:
         optional: true
 
-  '@storybook/core@8.6.18':
-    resolution: {integrity: sha512-dRBP2TnX6fGdS0T2mXBHjkS/3Nlu1ra1huovZVFuM67CYMzrhM/3hX/zru1vWSC5rqY93ZaAhjMciPW4pK5mMQ==}
-    peerDependencies:
-      prettier: ^2 || ^3
-    peerDependenciesMeta:
-      prettier:
-        optional: true
-
   '@storybook/csf-plugin@8.5.6':
     resolution: {integrity: sha512-60JBEVsW8x7u4hc+NmrCE0ij36QnaitqTDsxaT8BhbDrqFUvxwUjeaEmoyMn/UCJh080fQfKc2+dqBkFfbkAww==}
     peerDependencies:
       storybook: ^8.5.6
-
-  '@storybook/csf-plugin@8.6.18':
-    resolution: {integrity: sha512-x1ioz/L0CwaelCkHci3P31YtvwayN3FBftvwQOPbvRh9qeb4Cpz5IdVDmyvSxxYwXN66uAORNoqgjTi7B4/y5Q==}
-    peerDependencies:
-      storybook: ^8.6.18
 
   '@storybook/csf@0.1.12':
     resolution: {integrity: sha512-9/exVhabisyIVL0VxTCxo01Tdm8wefIXKXfltAPTSr8cbLn5JAxGQ6QV3mjdecLGEOucfoVhAKtJfVHxEK1iqw==}
@@ -1685,13 +1664,6 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
       storybook: ^8.5.6
 
-  '@storybook/react-dom-shim@8.6.18':
-    resolution: {integrity: sha512-N4xULcAWZQTUv4jy1/d346Tyb4gufuC3UaLCuU/iVSZ1brYF4OW3ANr+096btbMxY8pR/65lmtoqr5CTGwnBvA==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
-      storybook: ^8.6.18
-
   '@storybook/test@8.5.6':
     resolution: {integrity: sha512-U4HdyAcCwc/ictwq0HWKI6j2NAUggB9ENfyH3baEWaLEI+mp4pzQMuTnOIF9TvqU7K1D5UqOyfs/hlbFxUFysg==}
     peerDependencies:
@@ -1704,11 +1676,6 @@ packages:
 
   '@storybook/theming@8.6.14':
     resolution: {integrity: sha512-r4y+LsiB37V5hzpQo+BM10PaCsp7YlZ0YcZzQP1OCkPlYXmUAFy2VvDKaFRpD8IeNPKug2u4iFm/laDEbs03dg==}
-    peerDependencies:
-      storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
-
-  '@storybook/theming@8.6.18':
-    resolution: {integrity: sha512-n6OEjEtHupa2PdTwWzRepr7cO8NkDd4rgF6BKLitRbujOspLxzMBEqdphs+QLcuiCIgf33SqmEA64QWnbSMhPw==}
     peerDependencies:
       storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
 
@@ -1856,6 +1823,16 @@ packages:
     resolution: {integrity: sha512-It1Px9uDGTsVqyyg6cy7DigLoenljpQwqdI0jssM7QclZrHnsrye9fZxBBiiuCzzV1305MxKgHvratkHwqmVNA==}
     peerDependencies:
       '@tiptap/core': ^3.20.4
+
+  '@tiptap/extension-task-item@3.20.4':
+    resolution: {integrity: sha512-mEWyAtZ61USZnKyLDxi2DtnSREfW0yUFXDOFWstNg1i6hva197BuAy6VRQMQxTOq+cFAgAt1MEZKanW0Obsa+g==}
+    peerDependencies:
+      '@tiptap/extension-list': ^3.20.4
+
+  '@tiptap/extension-task-list@3.20.4':
+    resolution: {integrity: sha512-QvLrpffkxkr7TTgMmk6fnPAE34HYrUosHiuZJpRK008MuJDOoANblS221M4lLuRE73w3KI7hd/fi2CliBcCC4A==}
+    peerDependencies:
+      '@tiptap/extension-list': ^3.20.4
 
   '@tiptap/extension-text@3.20.4':
     resolution: {integrity: sha512-jchJcBZixDEO2J66Zx5dchsI2mA6IYsROqF8P1poxL4ienH7RVQRCTsBNnSfIeOtREKKWeOU/tEs5fcpvvGwIQ==}
@@ -2337,6 +2314,9 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
   baseline-browser-mapping@2.10.8:
     resolution: {integrity: sha512-PCLz/LXGBsNTErbtB6i5u4eLpHeMfi93aUv5duMmj6caNu6IphS4q6UevDnL36sZQv9lrP11dbPKGMaXPwMKfQ==}
     engines: {node: '>=6.0.0'}
@@ -2348,6 +2328,9 @@ packages:
 
   birpc@2.9.0:
     resolution: {integrity: sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw==}
+
+  bl@4.1.0:
+    resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
@@ -2376,6 +2359,9 @@ packages:
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+
+  buffer@5.7.1:
+    resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
 
   bundle-name@4.1.0:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
@@ -2446,9 +2432,21 @@ packages:
   citty@0.1.6:
     resolution: {integrity: sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==}
 
+  cli-cursor@3.1.0:
+    resolution: {integrity: sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==}
+    engines: {node: '>=8'}
+
+  cli-spinners@2.9.2:
+    resolution: {integrity: sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==}
+    engines: {node: '>=6'}
+
   clone-deep@4.0.1:
     resolution: {integrity: sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==}
     engines: {node: '>=6'}
+
+  clone@1.0.4:
+    resolution: {integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==}
+    engines: {node: '>=0.8'}
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -2504,8 +2502,8 @@ packages:
   core-js-compat@3.48.0:
     resolution: {integrity: sha512-OM4cAF3D6VtH/WkLtWvyNC56EZVXsZdU3iqaMG2B4WvYrlqU831pc4UtG5yp0sE9z8Y02wVN7PjW5Zf9Gt0f1Q==}
 
-  create-storybook@8.6.18:
-    resolution: {integrity: sha512-kLQo+bwn7RX53wF5lK40Uel4tEwsdBf4nmAzuAcu8SBDII1+nk9W9JRpIIxSb8uMOEFEgnk7F1DOa8SWaRChvg==}
+  create-storybook@8.5.6:
+    resolution: {integrity: sha512-Oj7mhRPZ8sbqympAblOR9+Axz0AztrLM3l7GPw2VhkR8kfezQErEJ0Vm47GbGSOPk3ea7MZD1ZQjK9YbtwFpmw==}
     hasBin: true
 
   crelt@1.0.6:
@@ -2563,6 +2561,9 @@ packages:
   default-browser@5.5.0:
     resolution: {integrity: sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==}
     engines: {node: '>=18'}
+
+  defaults@1.0.4:
+    resolution: {integrity: sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==}
 
   define-data-property@1.1.4:
     resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
@@ -2790,6 +2791,10 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  execa@5.1.1:
+    resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
+    engines: {node: '>=10'}
+
   execa@9.6.1:
     resolution: {integrity: sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==}
     engines: {node: ^18.19.0 || >=20.5.0}
@@ -2938,6 +2943,10 @@ packages:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
 
+  get-stream@6.0.1:
+    resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
+    engines: {node: '>=10'}
+
   get-stream@9.0.1:
     resolution: {integrity: sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==}
     engines: {node: '>=18'}
@@ -3036,6 +3045,10 @@ packages:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
 
+  human-signals@2.1.0:
+    resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
+    engines: {node: '>=10.17.0'}
+
   human-signals@8.0.1:
     resolution: {integrity: sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==}
     engines: {node: '>=18.18.0'}
@@ -3043,6 +3056,9 @@ packages:
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
+
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -3127,6 +3143,10 @@ packages:
     engines: {node: '>=14.16'}
     hasBin: true
 
+  is-interactive@1.0.0:
+    resolution: {integrity: sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==}
+    engines: {node: '>=8'}
+
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
@@ -3149,6 +3169,10 @@ packages:
     resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
     engines: {node: '>= 0.4'}
 
+  is-stream@2.0.1:
+    resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
+    engines: {node: '>=8'}
+
   is-stream@4.0.1:
     resolution: {integrity: sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==}
     engines: {node: '>=18'}
@@ -3156,6 +3180,10 @@ packages:
   is-typed-array@1.1.15:
     resolution: {integrity: sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==}
     engines: {node: '>= 0.4'}
+
+  is-unicode-supported@0.1.0:
+    resolution: {integrity: sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==}
+    engines: {node: '>=10'}
 
   is-unicode-supported@2.1.0:
     resolution: {integrity: sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==}
@@ -3326,6 +3354,10 @@ packages:
   lodash@4.17.23:
     resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
 
+  log-symbols@4.1.0:
+    resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==}
+    engines: {node: '>=10'}
+
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
 
@@ -3382,6 +3414,9 @@ packages:
     resolution: {integrity: sha512-S3UwM3yj5mtUSEfP41UZmt/0SCoVYUcU1rkXv+BQ5Ig8ndL4sPoJNBUJERafdPb5jjHJGuMgytgKvKIf58XNBw==}
     engines: {node: '>= 0.10.0'}
 
+  merge-stream@2.0.0:
+    resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
+
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
@@ -3389,6 +3424,10 @@ packages:
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
+
+  mimic-fn@2.1.0:
+    resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
+    engines: {node: '>=6'}
 
   min-indent@1.0.1:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
@@ -3489,6 +3528,10 @@ packages:
     engines: {node: ^18.17.0 || >=20.5.0, npm: '>= 9'}
     hasBin: true
 
+  npm-run-path@4.0.1:
+    resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
+    engines: {node: '>=8'}
+
   npm-run-path@6.0.0:
     resolution: {integrity: sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==}
     engines: {node: '>=18'}
@@ -3511,6 +3554,10 @@ packages:
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
+  onetime@5.1.2:
+    resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
+    engines: {node: '>=6'}
+
   open@10.2.0:
     resolution: {integrity: sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==}
     engines: {node: '>=18'}
@@ -3522,6 +3569,10 @@ packages:
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
+
+  ora@5.4.1:
+    resolution: {integrity: sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==}
+    engines: {node: '>=10'}
 
   orderedmap@2.1.1:
     resolution: {integrity: sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==}
@@ -3538,10 +3589,6 @@ packages:
   p-limit@3.1.0:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
     engines: {node: '>=10'}
-
-  p-limit@6.2.0:
-    resolution: {integrity: sha512-kuUqqHNUqoIWp/c467RI4X6mmyuojY5jGutNU0wVTmEOOfcuwLqyMVoAi9MKi2Ak+5i9+nhmrK4ufZE8069kHA==}
-    engines: {node: '>=18'}
 
   p-locate@3.0.0:
     resolution: {integrity: sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==}
@@ -3846,6 +3893,10 @@ packages:
     resolution: {integrity: sha512-qpt8EwugBWDw2cgE2W+/3oxC+KTez2uSVR8JU9Q36TXPAGCaozfQUs59v4j4GFpWTaw0i6hAZSvOmu1J0uOEUg==}
     engines: {node: ^18.17.0 || >=20.5.0}
 
+  readable-stream@3.6.2:
+    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
+    engines: {node: '>= 6'}
+
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
@@ -3889,6 +3940,10 @@ packages:
     engines: {node: '>= 0.4'}
     hasBin: true
 
+  restore-cursor@3.1.0:
+    resolution: {integrity: sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==}
+    engines: {node: '>=8'}
+
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
@@ -3918,6 +3973,9 @@ packages:
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
   safe-regex-test@1.1.0:
     resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
@@ -4037,15 +4095,6 @@ packages:
       prettier:
         optional: true
 
-  storybook@8.6.18:
-    resolution: {integrity: sha512-p8seiSI6FiVY6P3V0pG+5v7c8pDMehMAFRWEhG5XqIBSQszzOjDnW2rNvm3odoLKfo3V3P6Cs6Hv9ILzymULyQ==}
-    hasBin: true
-    peerDependencies:
-      prettier: ^2 || ^3
-    peerDependenciesMeta:
-      prettier:
-        optional: true
-
   string-argv@0.3.2:
     resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}
     engines: {node: '>=0.6.19'}
@@ -4058,6 +4107,9 @@ packages:
     resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
     engines: {node: '>=12'}
 
+  string_decoder@1.3.0:
+    resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
+
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
@@ -4065,6 +4117,10 @@ packages:
   strip-ansi@7.2.0:
     resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
     engines: {node: '>=12'}
+
+  strip-final-newline@2.0.0:
+    resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
+    engines: {node: '>=6'}
 
   strip-final-newline@4.0.0:
     resolution: {integrity: sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==}
@@ -4460,6 +4516,9 @@ packages:
   walk-up-path@3.0.1:
     resolution: {integrity: sha512-9YlCL/ynK3CTlrSRrDxZvUauLzAswPCrsaCgilqFevUYpeEW0/3ScEjaa3kbW/T0ghhkEr7mv+fpjqn1Y1YuTA==}
 
+  wcwidth@1.0.1:
+    resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
+
   webidl-conversions@7.0.0:
     resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
     engines: {node: '>=12'}
@@ -4557,10 +4616,6 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
-
-  yocto-queue@1.2.2:
-    resolution: {integrity: sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==}
-    engines: {node: '>=12.20'}
 
   yoctocolors@2.1.2:
     resolution: {integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==}
@@ -5910,19 +5965,6 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
 
-  '@storybook/addon-docs@8.6.18(@types/react@19.2.14)(storybook@8.5.6(prettier@3.8.1))':
-    dependencies:
-      '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.2.4)
-      '@storybook/blocks': 8.6.18(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@8.5.6(prettier@3.8.1))
-      '@storybook/csf-plugin': 8.6.18(storybook@8.5.6(prettier@3.8.1))
-      '@storybook/react-dom-shim': 8.6.18(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@8.5.6(prettier@3.8.1))
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
-      storybook: 8.5.6(prettier@3.8.1)
-      ts-dedent: 2.2.0
-    transitivePeerDependencies:
-      - '@types/react'
-
   '@storybook/addon-essentials@8.5.6(@types/react@19.2.14)(storybook@8.5.6(prettier@3.8.1))':
     dependencies:
       '@storybook/addon-actions': 8.5.6(storybook@8.5.6(prettier@3.8.1))
@@ -5988,15 +6030,6 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  '@storybook/blocks@8.6.18(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@8.5.6(prettier@3.8.1))':
-    dependencies:
-      '@storybook/icons': 1.6.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      storybook: 8.5.6(prettier@3.8.1)
-      ts-dedent: 2.2.0
-    optionalDependencies:
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
-
   '@storybook/builder-vite@8.5.6(storybook@8.5.6(prettier@3.8.1))(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(sass@1.98.0))':
     dependencies:
       '@storybook/csf-plugin': 8.5.6(storybook@8.5.6(prettier@3.8.1))
@@ -6005,14 +6038,14 @@ snapshots:
       ts-dedent: 2.2.0
       vite: 6.4.1(@types/node@22.19.15)(jiti@2.6.1)(sass@1.98.0)
 
-  '@storybook/cli@8.6.18(@babel/preset-env@7.29.0(@babel/core@7.29.0))(prettier@3.8.1)':
+  '@storybook/cli@8.5.6(@babel/preset-env@7.29.0(@babel/core@7.29.0))(prettier@3.8.1)':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/types': 7.29.0
-      '@storybook/codemod': 8.6.18(storybook@8.6.18(prettier@3.8.1))
+      '@storybook/codemod': 8.5.6
       '@types/semver': 7.7.1
       commander: 12.1.0
-      create-storybook: 8.6.18
+      create-storybook: 8.5.6
       cross-spawn: 7.0.6
       envinfo: 7.21.0
       fd-package-json: 1.2.0
@@ -6022,10 +6055,9 @@ snapshots:
       globby: 14.1.0
       jscodeshift: 0.15.2(@babel/preset-env@7.29.0(@babel/core@7.29.0))
       leven: 3.1.0
-      p-limit: 6.2.0
       prompts: 2.4.2
       semver: 7.7.4
-      storybook: 8.6.18(prettier@3.8.1)
+      storybook: 8.5.6(prettier@3.8.1)
       tiny-invariant: 1.3.3
       ts-dedent: 2.2.0
     transitivePeerDependencies:
@@ -6035,12 +6067,13 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@storybook/codemod@8.6.18(storybook@8.6.18(prettier@3.8.1))':
+  '@storybook/codemod@8.5.6':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/preset-env': 7.29.0(@babel/core@7.29.0)
       '@babel/types': 7.29.0
-      '@storybook/core': 8.6.18(prettier@3.8.1)(storybook@8.6.18(prettier@3.8.1))
+      '@storybook/core': 8.5.6(prettier@3.8.1)
+      '@storybook/csf': 0.1.12
       '@types/cross-spawn': 6.0.6
       cross-spawn: 7.0.6
       es-toolkit: 1.45.1
@@ -6051,7 +6084,6 @@ snapshots:
       tiny-invariant: 1.3.3
     transitivePeerDependencies:
       - bufferutil
-      - storybook
       - supports-color
       - utf-8-validate
 
@@ -6087,33 +6119,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@storybook/core@8.6.18(prettier@3.8.1)(storybook@8.6.18(prettier@3.8.1))':
-    dependencies:
-      '@storybook/theming': 8.6.18(storybook@8.6.18(prettier@3.8.1))
-      better-opn: 3.0.2
-      browser-assert: 1.2.1
-      esbuild: 0.25.12
-      esbuild-register: 3.6.0(esbuild@0.25.12)
-      jsdoc-type-pratt-parser: 4.8.0
-      process: 0.11.10
-      recast: 0.23.11
-      semver: 7.7.4
-      util: 0.12.5
-      ws: 8.19.0
-    optionalDependencies:
-      prettier: 3.8.1
-    transitivePeerDependencies:
-      - bufferutil
-      - storybook
-      - supports-color
-      - utf-8-validate
-
   '@storybook/csf-plugin@8.5.6(storybook@8.5.6(prettier@3.8.1))':
-    dependencies:
-      storybook: 8.5.6(prettier@3.8.1)
-      unplugin: 1.16.1
-
-  '@storybook/csf-plugin@8.6.18(storybook@8.5.6(prettier@3.8.1))':
     dependencies:
       storybook: 8.5.6(prettier@3.8.1)
       unplugin: 1.16.1
@@ -6157,12 +6163,6 @@ snapshots:
       react-dom: 19.2.4(react@19.2.4)
       storybook: 8.5.6(prettier@3.8.1)
 
-  '@storybook/react-dom-shim@8.6.18(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@8.5.6(prettier@3.8.1))':
-    dependencies:
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
-      storybook: 8.5.6(prettier@3.8.1)
-
   '@storybook/test@8.5.6(storybook@8.5.6(prettier@3.8.1))':
     dependencies:
       '@storybook/csf': 0.1.12
@@ -6182,10 +6182,6 @@ snapshots:
   '@storybook/theming@8.6.14(storybook@8.5.6(prettier@3.8.1))':
     dependencies:
       storybook: 8.5.6(prettier@3.8.1)
-
-  '@storybook/theming@8.6.18(storybook@8.6.18(prettier@3.8.1))':
-    dependencies:
-      storybook: 8.6.18(prettier@3.8.1)
 
   '@storybook/vue3-vite@8.5.6(storybook@8.5.6(prettier@3.8.1))(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(sass@1.98.0))(vue@3.5.30(typescript@5.7.3))':
     dependencies:
@@ -6338,6 +6334,14 @@ snapshots:
   '@tiptap/extension-strike@3.20.4(@tiptap/core@3.20.4(@tiptap/pm@3.20.4))':
     dependencies:
       '@tiptap/core': 3.20.4(@tiptap/pm@3.20.4)
+
+  '@tiptap/extension-task-item@3.20.4(@tiptap/extension-list@3.20.4(@tiptap/core@3.20.4(@tiptap/pm@3.20.4))(@tiptap/pm@3.20.4))':
+    dependencies:
+      '@tiptap/extension-list': 3.20.4(@tiptap/core@3.20.4(@tiptap/pm@3.20.4))(@tiptap/pm@3.20.4)
+
+  '@tiptap/extension-task-list@3.20.4(@tiptap/extension-list@3.20.4(@tiptap/core@3.20.4(@tiptap/pm@3.20.4))(@tiptap/pm@3.20.4))':
+    dependencies:
+      '@tiptap/extension-list': 3.20.4(@tiptap/core@3.20.4(@tiptap/pm@3.20.4))(@tiptap/pm@3.20.4)
 
   '@tiptap/extension-text@3.20.4(@tiptap/core@3.20.4(@tiptap/pm@3.20.4))':
     dependencies:
@@ -6954,6 +6958,8 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
+  base64-js@1.5.1: {}
+
   baseline-browser-mapping@2.10.8: {}
 
   better-opn@3.0.2:
@@ -6961,6 +6967,12 @@ snapshots:
       open: 8.4.2
 
   birpc@2.9.0: {}
+
+  bl@4.1.0:
+    dependencies:
+      buffer: 5.7.1
+      inherits: 2.0.4
+      readable-stream: 3.6.2
 
   boolbase@1.0.0: {}
 
@@ -6992,6 +7004,11 @@ snapshots:
       update-browserslist-db: 1.2.3(browserslist@4.28.1)
 
   buffer-from@1.1.2: {}
+
+  buffer@5.7.1:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
 
   bundle-name@4.1.0:
     dependencies:
@@ -7056,11 +7073,19 @@ snapshots:
     dependencies:
       consola: 3.4.2
 
+  cli-cursor@3.1.0:
+    dependencies:
+      restore-cursor: 3.1.0
+
+  cli-spinners@2.9.2: {}
+
   clone-deep@4.0.1:
     dependencies:
       is-plain-object: 2.0.4
       kind-of: 6.0.3
       shallow-clone: 3.0.1
+
+  clone@1.0.4: {}
 
   color-convert@2.0.1:
     dependencies:
@@ -7106,10 +7131,24 @@ snapshots:
     dependencies:
       browserslist: 4.28.1
 
-  create-storybook@8.6.18:
+  create-storybook@8.5.6:
     dependencies:
-      recast: 0.23.11
+      '@types/semver': 7.7.1
+      commander: 12.1.0
+      execa: 5.1.1
+      fd-package-json: 1.2.0
+      find-up: 5.0.0
+      ora: 5.4.1
+      prettier: 3.8.1
+      prompts: 2.4.2
       semver: 7.7.4
+      storybook: 8.5.6(prettier@3.8.1)
+      tiny-invariant: 1.3.3
+      ts-dedent: 2.2.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
 
   crelt@1.0.6: {}
 
@@ -7153,6 +7192,10 @@ snapshots:
     dependencies:
       bundle-name: 4.1.0
       default-browser-id: 5.0.1
+
+  defaults@1.0.4:
+    dependencies:
+      clone: 1.0.4
 
   define-data-property@1.1.4:
     dependencies:
@@ -7232,13 +7275,6 @@ snapshots:
     dependencies:
       debug: 4.4.3
       esbuild: 0.24.2
-    transitivePeerDependencies:
-      - supports-color
-
-  esbuild-register@3.6.0(esbuild@0.25.12):
-    dependencies:
-      debug: 4.4.3
-      esbuild: 0.25.12
     transitivePeerDependencies:
       - supports-color
 
@@ -7442,6 +7478,18 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  execa@5.1.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      get-stream: 6.0.1
+      human-signals: 2.1.0
+      is-stream: 2.0.1
+      merge-stream: 2.0.0
+      npm-run-path: 4.0.1
+      onetime: 5.1.2
+      signal-exit: 3.0.7
+      strip-final-newline: 2.0.0
+
   execa@9.6.1:
     dependencies:
       '@sindresorhus/merge-streams': 4.0.0
@@ -7599,6 +7647,8 @@ snapshots:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
 
+  get-stream@6.0.1: {}
+
   get-stream@9.0.1:
     dependencies:
       '@sec-ant/readable-stream': 0.4.1
@@ -7720,11 +7770,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  human-signals@2.1.0: {}
+
   human-signals@8.0.1: {}
 
   iconv-lite@0.6.3:
     dependencies:
       safer-buffer: 2.1.2
+
+  ieee754@1.2.1: {}
 
   ignore@5.3.2: {}
 
@@ -7792,6 +7846,8 @@ snapshots:
     dependencies:
       is-docker: 3.0.0
 
+  is-interactive@1.0.0: {}
+
   is-number@7.0.0: {}
 
   is-plain-obj@4.1.0: {}
@@ -7811,11 +7867,15 @@ snapshots:
       has-tostringtag: 1.0.2
       hasown: 2.0.2
 
+  is-stream@2.0.1: {}
+
   is-stream@4.0.1: {}
 
   is-typed-array@1.1.15:
     dependencies:
       which-typed-array: 1.1.20
+
+  is-unicode-supported@0.1.0: {}
 
   is-unicode-supported@2.1.0: {}
 
@@ -7996,6 +8056,11 @@ snapshots:
 
   lodash@4.17.23: {}
 
+  log-symbols@4.1.0:
+    dependencies:
+      chalk: 4.1.2
+      is-unicode-supported: 0.1.0
+
   loupe@3.2.1: {}
 
   lru-cache@10.4.3: {}
@@ -8048,12 +8113,16 @@ snapshots:
 
   memorystream@0.3.1: {}
 
+  merge-stream@2.0.0: {}
+
   merge2@1.4.1: {}
 
   micromatch@4.0.8:
     dependencies:
       braces: 3.0.3
       picomatch: 2.3.1
+
+  mimic-fn@2.1.0: {}
 
   min-indent@1.0.1: {}
 
@@ -8139,6 +8208,10 @@ snapshots:
       shell-quote: 1.8.3
       which: 5.0.0
 
+  npm-run-path@4.0.1:
+    dependencies:
+      path-key: 3.1.1
+
   npm-run-path@6.0.0:
     dependencies:
       path-key: 4.0.0
@@ -8165,6 +8238,10 @@ snapshots:
     dependencies:
       wrappy: 1.0.2
 
+  onetime@5.1.2:
+    dependencies:
+      mimic-fn: 2.1.0
+
   open@10.2.0:
     dependencies:
       default-browser: 5.5.0
@@ -8187,6 +8264,18 @@ snapshots:
       type-check: 0.4.0
       word-wrap: 1.2.5
 
+  ora@5.4.1:
+    dependencies:
+      bl: 4.1.0
+      chalk: 4.1.2
+      cli-cursor: 3.1.0
+      cli-spinners: 2.9.2
+      is-interactive: 1.0.0
+      is-unicode-supported: 0.1.0
+      log-symbols: 4.1.0
+      strip-ansi: 6.0.1
+      wcwidth: 1.0.1
+
   orderedmap@2.1.1: {}
 
   oxlint@0.15.15:
@@ -8207,10 +8296,6 @@ snapshots:
   p-limit@3.1.0:
     dependencies:
       yocto-queue: 0.1.0
-
-  p-limit@6.2.0:
-    dependencies:
-      yocto-queue: 1.2.2
 
   p-locate@3.0.0:
     dependencies:
@@ -8548,6 +8633,12 @@ snapshots:
       json-parse-even-better-errors: 4.0.0
       npm-normalize-package-bin: 4.0.0
 
+  readable-stream@3.6.2:
+    dependencies:
+      inherits: 2.0.4
+      string_decoder: 1.3.0
+      util-deprecate: 1.0.2
+
   readdirp@4.1.2: {}
 
   recast@0.23.11:
@@ -8593,6 +8684,11 @@ snapshots:
       is-core-module: 2.16.1
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
+
+  restore-cursor@3.1.0:
+    dependencies:
+      onetime: 5.1.2
+      signal-exit: 3.0.7
 
   reusify@1.1.0: {}
 
@@ -8642,6 +8738,8 @@ snapshots:
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
+
+  safe-buffer@5.2.1: {}
 
   safe-regex-test@1.1.0:
     dependencies:
@@ -8756,16 +8854,6 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  storybook@8.6.18(prettier@3.8.1):
-    dependencies:
-      '@storybook/core': 8.6.18(prettier@3.8.1)(storybook@8.6.18(prettier@3.8.1))
-    optionalDependencies:
-      prettier: 3.8.1
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-
   string-argv@0.3.2: {}
 
   string-width@4.2.3:
@@ -8780,6 +8868,10 @@ snapshots:
       emoji-regex: 9.2.2
       strip-ansi: 7.2.0
 
+  string_decoder@1.3.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
@@ -8787,6 +8879,8 @@ snapshots:
   strip-ansi@7.2.0:
     dependencies:
       ansi-regex: 6.2.2
+
+  strip-final-newline@2.0.0: {}
 
   strip-final-newline@4.0.0: {}
 
@@ -9204,6 +9298,10 @@ snapshots:
 
   walk-up-path@3.0.1: {}
 
+  wcwidth@1.0.1:
+    dependencies:
+      defaults: 1.0.4
+
   webidl-conversions@7.0.0: {}
 
   webpack-virtual-modules@0.6.2: {}
@@ -9288,7 +9386,5 @@ snapshots:
   yallist@4.0.0: {}
 
   yocto-queue@0.1.0: {}
-
-  yocto-queue@1.2.2: {}
 
   yoctocolors@2.1.2: {}

--- a/src/components/NyxButton/NyxButton.vue
+++ b/src/components/NyxButton/NyxButton.vue
@@ -4,7 +4,7 @@ import { NyxSize, NyxVariant, NyxTheme, NyxShape } from '@/types'
 import type { NyxButtonProps, NyxButtonEmits } from './NyxButton.types'
 import { computed } from 'vue';
 import { isCurrentDomain } from '@/utils'
-import useNyxProps from '@/composables/useNyxProps';
+import useNyxProps from '@/composables/useNyxProps'
 
 const props = withDefaults(defineProps<NyxButtonProps>(), {
   type: 'button',

--- a/src/components/NyxEditor/NyxEditor.scss
+++ b/src/components/NyxEditor/NyxEditor.scss
@@ -1,0 +1,272 @@
+@use '../../styles/mixins.scss' as *;
+
+.nyx-editor {
+  --nyx-c-editor: var(--nyx-c-default);
+  --nyx-c-editor-highlight: var(--nyx-c-default-highlight);
+  --nyx-c-editor-alt: var(--nyx-c-default-alt);
+  --nyx-c-editor-text: var(--nyx-c-white-soft);
+  --nyx-gap-editor: var(--nyx-gap-md);
+  --nyx-pad-editor: var(--nyx-pad-md);
+  --nyx-font-size-editor: var(--nyx-font-size-md);
+  --nyx-border-size-editor: 1px;
+
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  border-radius: var(--nyx-radius-md);
+  border: var(--nyx-border-size-editor) solid transparent;
+  overflow: hidden;
+  transition: border-color 0.2s;
+
+  // Variant: outline
+  &.variant-outline {
+    background-color: transparent;
+    border-color: var(--nyx-c-editor-alt);
+    color: var(--nyx-c-editor-alt);
+  }
+
+  // Variant: solid
+  &.variant-solid {
+    background-color: var(--nyx-c-editor);
+    color: var(--nyx-c-editor-text);
+  }
+
+  // Variant: ghost
+  &.variant-ghost {
+    background-color: transparent;
+    border-color: transparent;
+    color: var(--nyx-c-editor-alt);
+
+    &:focus-within {
+      border-color: var(--nyx-c-editor-alt);
+    }
+  }
+
+  // Themes
+  &.theme-primary {
+    --nyx-c-editor: var(--nyx-c-primary);
+    --nyx-c-editor-highlight: var(--nyx-c-primary-highlight);
+    --nyx-c-editor-alt: var(--nyx-c-primary-alt);
+  }
+
+  &.theme-secondary {
+    --nyx-c-editor: var(--nyx-c-secondary);
+    --nyx-c-editor-highlight: var(--nyx-c-secondary-highlight);
+    --nyx-c-editor-alt: var(--nyx-c-secondary-alt);
+  }
+
+  &.theme-info {
+    --nyx-c-editor: var(--nyx-c-info);
+    --nyx-c-editor-highlight: var(--nyx-c-info-highlight);
+    --nyx-c-editor-alt: var(--nyx-c-info-alt);
+  }
+
+  &.theme-success {
+    --nyx-c-editor: var(--nyx-c-success);
+    --nyx-c-editor-highlight: var(--nyx-c-success-highlight);
+    --nyx-c-editor-alt: var(--nyx-c-success-alt);
+  }
+
+  &.theme-warning {
+    --nyx-c-editor: var(--nyx-c-warning);
+    --nyx-c-editor-highlight: var(--nyx-c-warning-highlight);
+    --nyx-c-editor-alt: var(--nyx-c-warning-alt);
+  }
+
+  &.theme-danger {
+    --nyx-c-editor: var(--nyx-c-danger);
+    --nyx-c-editor-highlight: var(--nyx-c-danger-highlight);
+    --nyx-c-editor-alt: var(--nyx-c-danger-alt);
+  }
+
+  // Sizes
+  &.size-xs {
+    --nyx-gap-editor: var(--nyx-gap-xs);
+    --nyx-pad-editor: var(--nyx-pad-xs);
+    --nyx-font-size-editor: var(--nyx-font-size-xs);
+  }
+
+  &.size-sm {
+    --nyx-gap-editor: var(--nyx-gap-sm);
+    --nyx-pad-editor: var(--nyx-pad-sm);
+    --nyx-font-size-editor: var(--nyx-font-size-sm);
+  }
+
+  &.size-lg {
+    --nyx-gap-editor: var(--nyx-gap-lg);
+    --nyx-pad-editor: var(--nyx-pad-lg);
+    --nyx-font-size-editor: var(--nyx-font-size-lg);
+    --nyx-border-size-editor: 2px;
+  }
+
+  &.size-xl {
+    --nyx-gap-editor: var(--nyx-gap-xl);
+    --nyx-pad-editor: var(--nyx-pad-xl);
+    --nyx-font-size-editor: var(--nyx-font-size-xl);
+    --nyx-border-size-editor: 3px;
+  }
+
+  // ─── Toolbar (toolbar mode) ──────────────────────────────────────────
+
+  &__toolbar {
+    display: flex;
+    align-items: center;
+    gap: 2px;
+    padding: calc(var(--nyx-pad-editor) * 0.5) var(--nyx-pad-editor);
+    border-bottom: var(--nyx-border-size-editor) solid var(--nyx-c-editor-alt);
+    flex-shrink: 0;
+    flex-wrap: wrap;
+  }
+
+  &__toolbar-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 2em;
+    padding: 0.25em 0.4em;
+    font-size: var(--nyx-font-size-editor);
+    background: transparent;
+    border: 1px solid transparent;
+    border-radius: var(--nyx-radius-sm);
+    color: currentColor;
+    cursor: pointer;
+    transition: background-color 0.15s, border-color 0.15s;
+
+    &:hover:not(:disabled) {
+      background-color: var(--nyx-c-editor-highlight);
+    }
+
+    &.active {
+      background-color: var(--nyx-c-editor-highlight);
+      border-color: var(--nyx-c-editor-alt);
+    }
+
+    &:disabled {
+      opacity: 0.4;
+      cursor: not-allowed;
+    }
+  }
+
+  &__toolbar-sep {
+    display: inline-block;
+    width: 1px;
+    height: 1.2em;
+    background-color: var(--nyx-c-editor-alt);
+    margin: 0 4px;
+    opacity: 0.4;
+    flex-shrink: 0;
+
+    &--grow {
+      width: auto;
+      height: auto;
+      background: none;
+      flex: 1;
+    }
+  }
+
+  // ─── Bubble menu (zen mode) ──────────────────────────────────────────
+
+  &__bubble {
+    display: flex;
+    align-items: center;
+    gap: 2px;
+    padding: 4px 6px;
+    background-color: var(--nyx-c-bg, #1a1a1a);
+    border: 1px solid var(--nyx-c-editor-alt);
+    border-radius: var(--nyx-radius-md);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  }
+
+  &__bubble-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 1.8em;
+    padding: 0.2em 0.35em;
+    font-size: var(--nyx-font-size-editor);
+    background: transparent;
+    border: 1px solid transparent;
+    border-radius: var(--nyx-radius-sm);
+    color: var(--nyx-c-editor-text, #fff);
+    cursor: pointer;
+    transition: background-color 0.15s, border-color 0.15s;
+
+    &:hover {
+      background-color: rgba(255, 255, 255, 0.1);
+    }
+
+    &.active {
+      background-color: var(--nyx-c-editor-highlight);
+      border-color: var(--nyx-c-editor-alt);
+    }
+  }
+
+  &__bubble-sep {
+    display: inline-block;
+    width: 1px;
+    height: 1.2em;
+    background-color: rgba(255, 255, 255, 0.25);
+    margin: 0 4px;
+    flex-shrink: 0;
+  }
+
+  // ─── Editor content ──────────────────────────────────────────────────
+
+  &__content {
+    flex: 1;
+
+    .tiptap {
+      min-height: 120px;
+      padding: var(--nyx-pad-editor);
+      font-size: var(--nyx-font-size-editor);
+      outline: none;
+      color: inherit;
+
+      p { margin: 0 0 0.5em; }
+      h1, h2, h3, h4, h5, h6 { font-weight: bold; margin: 0.75em 0 0.25em; }
+      h1 { font-size: 1.8em; }
+      h2 { font-size: 1.5em; }
+      h3 { font-size: 1.25em; }
+
+      ul, ol { padding-left: 1.5em; margin: 0.5em 0; }
+      li { margin: 0.2em 0; }
+
+      blockquote {
+        border-left: 3px solid var(--nyx-c-editor-alt);
+        padding-left: 1em;
+        margin: 0.5em 0;
+        opacity: 0.75;
+      }
+
+      code {
+        font-family: var(--nyx-font-family-mono, monospace);
+        background-color: rgba(255, 255, 255, 0.08);
+        border-radius: 3px;
+        padding: 0.1em 0.3em;
+        font-size: 0.9em;
+      }
+
+      pre {
+        background-color: rgba(0, 0, 0, 0.3);
+        border-radius: var(--nyx-radius-md);
+        padding: var(--nyx-pad-editor);
+        overflow-x: auto;
+        margin: 0.5em 0;
+
+        code {
+          background: none;
+          padding: 0;
+        }
+      }
+
+      p.is-editor-empty:first-child::before {
+        content: attr(data-placeholder);
+        float: left;
+        color: currentColor;
+        opacity: 0.4;
+        pointer-events: none;
+        height: 0;
+      }
+    }
+  }
+}

--- a/src/components/NyxEditor/NyxEditor.scss
+++ b/src/components/NyxEditor/NyxEditor.scss
@@ -321,8 +321,9 @@
 
 .nyx-editor__bubble {
   position: fixed;
+  top: var(--top);
+  left: var(--left);
   z-index: 9999;
-  transform: translateX(-50%) translateY(-100%);
   display: flex;
   align-items: center;
   gap: 2px;
@@ -331,7 +332,6 @@
   border: 1px solid rgba(255, 255, 255, 0.15);
   border-radius: var(--nyx-radius-md, 6px);
   box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
-  margin-top: -4px;
 }
 
 .nyx-editor__bubble-btn {
@@ -376,5 +376,5 @@
 .nyx-bubble-enter-from,
 .nyx-bubble-leave-to {
   opacity: 0;
-  transform: translateX(-50%) translateY(calc(-100% + 4px));
+  transform: translateY(4px);
 }

--- a/src/components/NyxEditor/NyxEditor.scss
+++ b/src/components/NyxEditor/NyxEditor.scss
@@ -239,33 +239,44 @@
       ol { list-style-type: decimal; padding-left: 1.5em; margin: 0.5em 0; }
       li { margin: 0.2em 0; }
 
-      // Task list
+      // Task list — override list-item display so checkbox and text sit in a row
       ul[data-type="taskList"] {
         list-style: none;
-        padding-left: 0.25em;
+        padding-left: 0;
+      }
 
-        li[data-type="taskItem"] {
-          display: flex;
-          align-items: flex-start;
-          gap: 0.5em;
+      li[data-type="taskItem"] {
+        display: flex;
+        flex-direction: row;
+        align-items: flex-start;
+        gap: 0.5em;
+        list-style: none;
+        margin: 0.2em 0;
 
-          > label {
-            flex-shrink: 0;
-            margin-top: 0.1em;
+        > label {
+          display: inline-flex;
+          align-items: center;
+          flex-shrink: 0;
+          padding-top: 0.2em;
+          cursor: pointer;
 
-            input[type="checkbox"] {
-              cursor: pointer;
-            }
+          input[type="checkbox"] {
+            cursor: pointer;
+            margin: 0;
           }
 
-          > div {
-            flex: 1;
-          }
+          // empty span tiptap renders next to the checkbox
+          > span { display: none; }
+        }
 
-          &[data-checked="true"] > div {
-            opacity: 0.6;
-            text-decoration: line-through;
-          }
+        > div {
+          flex: 1;
+          min-width: 0;
+        }
+
+        &[data-checked="true"] > div {
+          opacity: 0.6;
+          text-decoration: line-through;
         }
       }
 

--- a/src/components/NyxEditor/NyxEditor.scss
+++ b/src/components/NyxEditor/NyxEditor.scss
@@ -116,6 +116,7 @@
     border-bottom: var(--nyx-border-size-editor) solid var(--nyx-c-editor-alt);
     flex-shrink: 0;
     flex-wrap: wrap;
+    color: var(--nyx-c-editor-alt, #ccc);
   }
 
   &__toolbar-btn {
@@ -128,7 +129,7 @@
     background: transparent;
     border: 1px solid transparent;
     border-radius: var(--nyx-radius-sm);
-    color: currentColor;
+    color: inherit;
     cursor: pointer;
     transition: background-color 0.15s, border-color 0.15s;
 
@@ -162,52 +163,6 @@
       background: none;
       flex: 1;
     }
-  }
-
-  // ─── Bubble menu (zen mode) ──────────────────────────────────────────
-
-  &__bubble {
-    display: flex;
-    align-items: center;
-    gap: 2px;
-    padding: 4px 6px;
-    background-color: var(--nyx-c-bg, #1a1a1a);
-    border: 1px solid var(--nyx-c-editor-alt);
-    border-radius: var(--nyx-radius-md);
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
-  }
-
-  &__bubble-btn {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    min-width: 1.8em;
-    padding: 0.2em 0.35em;
-    font-size: var(--nyx-font-size-editor);
-    background: transparent;
-    border: 1px solid transparent;
-    border-radius: var(--nyx-radius-sm);
-    color: var(--nyx-c-editor-text, #fff);
-    cursor: pointer;
-    transition: background-color 0.15s, border-color 0.15s;
-
-    &:hover {
-      background-color: rgba(255, 255, 255, 0.1);
-    }
-
-    &.active {
-      background-color: var(--nyx-c-editor-highlight);
-      border-color: var(--nyx-c-editor-alt);
-    }
-  }
-
-  &__bubble-sep {
-    display: inline-block;
-    width: 1px;
-    height: 1.2em;
-    background-color: rgba(255, 255, 255, 0.25);
-    margin: 0 4px;
-    flex-shrink: 0;
   }
 
   // ─── Editor content ──────────────────────────────────────────────────
@@ -269,4 +224,66 @@
       }
     }
   }
+}
+
+// ─── Bubble menu — teleported to <body>, position: fixed ─────────────
+
+.nyx-editor__bubble {
+  position: fixed;
+  z-index: 9999;
+  transform: translateX(-50%) translateY(-100%);
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  padding: 4px 6px;
+  background-color: var(--nyx-c-bg, #1e1e1e);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: var(--nyx-radius-md, 6px);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
+  margin-top: -4px;
+}
+
+.nyx-editor__bubble-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.8em;
+  padding: 0.2em 0.35em;
+  font-size: 0.85rem;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  color: #fff;
+  cursor: pointer;
+  transition: background-color 0.15s, border-color 0.15s;
+
+  &:hover {
+    background-color: rgba(255, 255, 255, 0.12);
+  }
+
+  &.active {
+    background-color: rgba(255, 255, 255, 0.2);
+    border-color: rgba(255, 255, 255, 0.3);
+  }
+}
+
+.nyx-editor__bubble-sep {
+  display: inline-block;
+  width: 1px;
+  height: 1.2em;
+  background-color: rgba(255, 255, 255, 0.2);
+  margin: 0 4px;
+  flex-shrink: 0;
+}
+
+// Bubble transition
+.nyx-bubble-enter-active,
+.nyx-bubble-leave-active {
+  transition: opacity 0.1s, transform 0.1s;
+}
+
+.nyx-bubble-enter-from,
+.nyx-bubble-leave-to {
+  opacity: 0;
+  transform: translateX(-50%) translateY(calc(-100% + 4px));
 }

--- a/src/components/NyxEditor/NyxEditor.scss
+++ b/src/components/NyxEditor/NyxEditor.scss
@@ -194,8 +194,8 @@
   // ─── Source textarea ─────────────────────────────────────────────────
 
   &__source {
-    flex: 1;
     min-height: 120px;
+    overflow: hidden;
     padding: var(--nyx-pad-editor);
     font-size: var(--nyx-font-size-editor);
     font-family: var(--nyx-font-family-mono, monospace);
@@ -239,44 +239,40 @@
       ol { list-style-type: decimal; padding-left: 1.5em; margin: 0.5em 0; }
       li { margin: 0.2em 0; }
 
+      ol p, ul p {
+        margin: 0;
+      }
+
       // Task list — override list-item display so checkbox and text sit in a row
       ul[data-type="taskList"] {
         list-style: none;
         padding-left: 0;
-      }
 
-      li[data-type="taskItem"] {
-        display: flex;
-        flex-direction: row;
-        align-items: flex-start;
-        gap: 0.5em;
-        list-style: none;
-        margin: 0.2em 0;
+        li {
+          display: flex;
+          flex-direction: row;
+          align-items: flex-start;
+          gap: 0.5em;
+          list-style: none;
+          margin: 0.2em 0;
 
-        > label {
-          display: inline-flex;
-          align-items: center;
-          flex-shrink: 0;
-          padding-top: 0.2em;
-          cursor: pointer;
-
-          input[type="checkbox"] {
+          > label {
+            display: inline-flex;
+            align-items: center;
+            flex-shrink: 0;
+            padding-top: 0.2em;
             cursor: pointer;
-            margin: 0;
+
+            input[type="checkbox"] { cursor: pointer; margin: 0; }
+            > span { display: none; }
           }
 
-          // empty span tiptap renders next to the checkbox
-          > span { display: none; }
-        }
+          > div { flex: 1; min-width: 0; }
 
-        > div {
-          flex: 1;
-          min-width: 0;
-        }
-
-        &[data-checked="true"] > div {
-          opacity: 0.6;
-          text-decoration: line-through;
+          &[data-checked="true"] > div {
+            opacity: 0.6;
+            text-decoration: line-through;
+          }
         }
       }
 

--- a/src/components/NyxEditor/NyxEditor.scss
+++ b/src/components/NyxEditor/NyxEditor.scss
@@ -10,6 +10,7 @@
   --nyx-font-size-editor: var(--nyx-font-size-md);
   --nyx-border-size-editor: 1px;
 
+  position: relative;
   display: flex;
   flex-direction: column;
   width: 100%;
@@ -165,6 +166,49 @@
     }
   }
 
+  // ─── Source toggle button ────────────────────────────────────────────
+
+  &__source-toggle {
+    position: absolute;
+    top: 6px;
+    right: 8px;
+    z-index: 1;
+    padding: 0.15em 0.4em;
+    font-size: 0.75em;
+    font-family: var(--nyx-font-family-mono, monospace);
+    background: transparent;
+    border: 1px solid transparent;
+    border-radius: var(--nyx-radius-sm);
+    color: var(--nyx-c-editor-alt, #888);
+    cursor: pointer;
+    opacity: 0.5;
+    transition: opacity 0.15s, border-color 0.15s, background-color 0.15s;
+
+    &:hover, &.active {
+      opacity: 1;
+      border-color: var(--nyx-c-editor-alt, #888);
+      background-color: var(--nyx-c-editor-highlight);
+    }
+  }
+
+  // ─── Source textarea ─────────────────────────────────────────────────
+
+  &__source {
+    flex: 1;
+    min-height: 120px;
+    padding: var(--nyx-pad-editor);
+    font-size: var(--nyx-font-size-editor);
+    font-family: var(--nyx-font-family-mono, monospace);
+    background: transparent;
+    border: none;
+    outline: none;
+    color: inherit;
+    resize: none;
+    width: 100%;
+    line-height: 1.6;
+    tab-size: 2;
+  }
+
   // ─── Editor content ──────────────────────────────────────────────────
 
   &__content {
@@ -174,17 +218,56 @@
       min-height: 120px;
       padding: var(--nyx-pad-editor);
       font-size: var(--nyx-font-size-editor);
+      line-height: 1.6;
       outline: none;
       color: inherit;
 
+      // Re-apply styles stripped by the global Meyer reset
+      strong, b { font-weight: bold; }
+      em, i { font-style: italic; }
+      u { text-decoration: underline; }
+      s, del { text-decoration: line-through; }
+
       p { margin: 0 0 0.5em; }
-      h1, h2, h3, h4, h5, h6 { font-weight: bold; margin: 0.75em 0 0.25em; }
+      h1, h2, h3, h4, h5, h6 { font-weight: bold; margin: 0.75em 0 0.25em; line-height: 1.2; }
       h1 { font-size: 1.8em; }
       h2 { font-size: 1.5em; }
       h3 { font-size: 1.25em; }
 
-      ul, ol { padding-left: 1.5em; margin: 0.5em 0; }
+      // Restore list markers stripped by the reset
+      ul { list-style-type: disc; padding-left: 1.5em; margin: 0.5em 0; }
+      ol { list-style-type: decimal; padding-left: 1.5em; margin: 0.5em 0; }
       li { margin: 0.2em 0; }
+
+      // Task list
+      ul[data-type="taskList"] {
+        list-style: none;
+        padding-left: 0.25em;
+
+        li[data-type="taskItem"] {
+          display: flex;
+          align-items: flex-start;
+          gap: 0.5em;
+
+          > label {
+            flex-shrink: 0;
+            margin-top: 0.1em;
+
+            input[type="checkbox"] {
+              cursor: pointer;
+            }
+          }
+
+          > div {
+            flex: 1;
+          }
+
+          &[data-checked="true"] > div {
+            opacity: 0.6;
+            text-decoration: line-through;
+          }
+        }
+      }
 
       blockquote {
         border-left: 3px solid var(--nyx-c-editor-alt);
@@ -224,6 +307,7 @@
       }
     }
   }
+
 }
 
 // ─── Bubble menu — teleported to <body>, position: fixed ─────────────

--- a/src/components/NyxEditor/NyxEditor.spec.ts
+++ b/src/components/NyxEditor/NyxEditor.spec.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { shallowRef } from 'vue'
+import { NyxEditorMode, NyxEditorFormat, NyxTheme, NyxVariant, NyxSize } from '@/types'
+
+// Tiptap relies on browser APIs not available in jsdom; mock the integration layer
+vi.mock('@tiptap/vue-3', () => ({
+  useEditor: () => shallowRef(null),
+  EditorContent: { template: '<div class="tiptap" />' },
+}))
+
+vi.mock('@tiptap/vue-3/menus', () => ({
+  BubbleMenu: { template: '<div class="nyx-editor__bubble"><slot /></div>', props: ['editor', 'tippyOptions'] },
+}))
+
+vi.mock('@tiptap/starter-kit', () => ({ default: {} }))
+vi.mock('tiptap-markdown', () => ({ Markdown: {} }))
+
+// eslint-disable-next-line import/first
+import NyxEditor from './NyxEditor.vue'
+
+describe('NyxEditor', () => {
+  it('renders without errors', () => {
+    const wrapper = mount(NyxEditor)
+    expect(wrapper.find('.nyx-editor').exists()).toBe(true)
+  })
+
+  it('applies mode-zen class by default', () => {
+    const wrapper = mount(NyxEditor)
+    expect(wrapper.find('.nyx-editor').classes()).toContain('mode-zen')
+  })
+
+  it('applies mode-toolbar class when mode is toolbar', () => {
+    const wrapper = mount(NyxEditor, { props: { mode: NyxEditorMode.Toolbar } })
+    expect(wrapper.find('.nyx-editor').classes()).toContain('mode-toolbar')
+  })
+
+  it('renders toolbar in toolbar mode', () => {
+    const wrapper = mount(NyxEditor, { props: { mode: NyxEditorMode.Toolbar } })
+    expect(wrapper.find('.nyx-editor__toolbar').exists()).toBe(true)
+  })
+
+  it('does not render toolbar in zen mode', () => {
+    const wrapper = mount(NyxEditor, { props: { mode: NyxEditorMode.Zen } })
+    expect(wrapper.find('.nyx-editor__toolbar').exists()).toBe(false)
+  })
+
+  it('applies theme class', () => {
+    const wrapper = mount(NyxEditor, { props: { theme: NyxTheme.Primary } })
+    expect(wrapper.find('.nyx-editor').classes()).toContain('theme-primary')
+  })
+
+  it('applies variant class', () => {
+    const wrapper = mount(NyxEditor, { props: { variant: NyxVariant.Solid } })
+    expect(wrapper.find('.nyx-editor').classes()).toContain('variant-solid')
+  })
+
+  it('applies size class', () => {
+    const wrapper = mount(NyxEditor, { props: { size: NyxSize.Large } })
+    expect(wrapper.find('.nyx-editor').classes()).toContain('size-lg')
+  })
+
+  it('defaults to markdown format', () => {
+    const wrapper = mount(NyxEditor)
+    expect((wrapper.props() as { format: NyxEditorFormat }).format).toBe(NyxEditorFormat.Markdown)
+  })
+
+  it('accepts html format prop', () => {
+    const wrapper = mount(NyxEditor, { props: { format: NyxEditorFormat.Html } })
+    expect((wrapper.props() as { format: NyxEditorFormat }).format).toBe(NyxEditorFormat.Html)
+  })
+
+  it('defaults to zen mode', () => {
+    const wrapper = mount(NyxEditor)
+    expect((wrapper.props() as { mode: NyxEditorMode }).mode).toBe(NyxEditorMode.Zen)
+  })
+
+  it('has disabled prop defaulting to false', () => {
+    const wrapper = mount(NyxEditor)
+    expect((wrapper.props() as { disabled: boolean }).disabled).toBe(false)
+  })
+
+  it('renders EditorContent', () => {
+    const wrapper = mount(NyxEditor)
+    expect(wrapper.find('.nyx-editor__content').exists()).toBe(true)
+  })
+})

--- a/src/components/NyxEditor/NyxEditor.spec.ts
+++ b/src/components/NyxEditor/NyxEditor.spec.ts
@@ -9,10 +9,6 @@ vi.mock('@tiptap/vue-3', () => ({
   EditorContent: { template: '<div class="tiptap" />' },
 }))
 
-vi.mock('@tiptap/vue-3/menus', () => ({
-  BubbleMenu: { template: '<div class="nyx-editor__bubble"><slot /></div>', props: ['editor', 'tippyOptions'] },
-}))
-
 vi.mock('@tiptap/starter-kit', () => ({ default: {} }))
 vi.mock('tiptap-markdown', () => ({ Markdown: {} }))
 

--- a/src/components/NyxEditor/NyxEditor.stories.ts
+++ b/src/components/NyxEditor/NyxEditor.stories.ts
@@ -1,0 +1,115 @@
+import { defineComponent, ref } from 'vue'
+import NyxEditor from './NyxEditor.vue'
+import { NyxEditorMode, NyxEditorFormat, NyxTheme, NyxVariant, NyxSize } from '@/types'
+import type { NyxEditorProps } from './NyxEditor.types'
+
+export default {
+  title: 'Components/NyxEditor',
+  component: NyxEditor,
+  argTypes: {
+    mode: {
+      control: { type: 'select' },
+      options: Object.values(NyxEditorMode),
+    },
+    format: {
+      control: { type: 'select' },
+      options: Object.values(NyxEditorFormat),
+    },
+    theme: {
+      control: { type: 'select' },
+      options: Object.values(NyxTheme),
+    },
+    variant: {
+      control: { type: 'select' },
+      options: Object.values(NyxVariant),
+    },
+    size: {
+      control: { type: 'select' },
+      options: Object.values(NyxSize),
+    },
+  },
+}
+
+const Template = (args: NyxEditorProps) => defineComponent({
+  components: { NyxEditor },
+  setup() {
+    const content = ref('')
+    return { args, content }
+  },
+  template: `<nyx-editor v-bind="args" v-model="content" />`,
+})
+
+const TemplateWithContent = (args: NyxEditorProps, initialContent: string) => defineComponent({
+  components: { NyxEditor },
+  setup() {
+    const content = ref(initialContent)
+    return { args, content }
+  },
+  template: `<nyx-editor v-bind="args" v-model="content" />`,
+})
+
+export const Zen = Template({ mode: NyxEditorMode.Zen })
+
+export const Toolbar = Template({ mode: NyxEditorMode.Toolbar })
+
+export const ZenWithContent = TemplateWithContent(
+  { mode: NyxEditorMode.Zen },
+  '# Hello\n\nThis is a **rich text** editor in *zen* mode.\n\n- Item one\n- Item two',
+)
+
+export const ToolbarWithContent = TemplateWithContent(
+  { mode: NyxEditorMode.Toolbar },
+  '# Hello\n\nThis is a **rich text** editor in *toolbar* mode.',
+)
+
+export const HtmlFormat = TemplateWithContent(
+  { mode: NyxEditorMode.Toolbar, format: NyxEditorFormat.Html },
+  '<h1>Hello</h1><p>This editor outputs <strong>HTML</strong>.</p>',
+)
+
+export const Disabled = TemplateWithContent(
+  { mode: NyxEditorMode.Toolbar, disabled: true },
+  '# Read-only\n\nThis editor is disabled.',
+)
+
+export const Themes = () => defineComponent({
+  components: { NyxEditor },
+  setup() {
+    const themes = Object.values(NyxTheme)
+    const contents = Object.fromEntries(themes.map(t => [t, ref('')]))
+    return { themes, contents }
+  },
+  template: `
+    <div style="display: flex; flex-direction: column; gap: 1rem;">
+      <nyx-editor
+        v-for="theme in themes"
+        :key="theme"
+        :theme="theme"
+        :mode="'${NyxEditorMode.Toolbar}'"
+        :placeholder="theme"
+        v-model="contents[theme].value"
+      />
+    </div>
+  `,
+})
+
+export const Sizes = () => defineComponent({
+  components: { NyxEditor },
+  setup() {
+    const sizes = Object.values(NyxSize)
+    const contents = Object.fromEntries(sizes.map(s => [s, ref('')]))
+    return { sizes, contents }
+  },
+  template: `
+    <div style="display: flex; flex-direction: column; gap: 1rem;">
+      <nyx-editor
+        v-for="size in sizes"
+        :key="size"
+        :size="size"
+        :mode="'${NyxEditorMode.Toolbar}'"
+        :placeholder="size"
+        v-model="contents[size].value"
+      />
+    </div>
+  `,
+})

--- a/src/components/NyxEditor/NyxEditor.types.ts
+++ b/src/components/NyxEditor/NyxEditor.types.ts
@@ -1,0 +1,18 @@
+import type { NyxEditorMode, NyxEditorFormat, NyxSize, NyxVariant, NyxTheme } from '@/types'
+
+export interface NyxEditorProps {
+  mode?: NyxEditorMode
+  format?: NyxEditorFormat
+  theme?: NyxTheme
+  variant?: NyxVariant
+  size?: NyxSize
+  pixel?: boolean
+  disabled?: boolean
+  placeholder?: string
+}
+
+export interface NyxEditorEmits {
+  (event: 'change', content: string): void
+  (event: 'focus', e: FocusEvent): void
+  (event: 'blur', e: FocusEvent): void
+}

--- a/src/components/NyxEditor/NyxEditor.vue
+++ b/src/components/NyxEditor/NyxEditor.vue
@@ -48,28 +48,6 @@ const autoResizeSource = () => {
 
 watch(sourceModel, (val) => { if (val) nextTick(autoResizeSource) })
 
-// ── Keyboard shortcuts ───────────────────────────────────────────────
-const editorRef = ref<HTMLElement | null>(null)
-
-const wrapSelection = (before: string, after = before) => {
-  const el = sourceRef.value
-  if (!el) return
-  const { selectionStart: start, selectionEnd: end } = el
-  el.setRangeText(`${before}${el.value.slice(start, end)}${after}`, start, end, 'select')
-  model.value = el.value
-  nextTick(autoResizeSource)
-}
-
-const sourceShortcut = (wrap: () => void) => () => { if (sourceModel.value) wrap() }
-
-useKeyboardShortcuts({
-  'SUPER+/': () => { sourceModel.value = !sourceModel.value },
-  'SUPER+B': sourceShortcut(() => wrapSelection('**')),
-  'SUPER+I': sourceShortcut(() => wrapSelection('_')),
-  'SUPER+S': sourceShortcut(() => wrapSelection('~~')),
-  // Formatted view: Tiptap/ProseMirror handles B/I/U/S/Z natively
-}, editorRef)
-
 // ── Custom bubble menu state ─────────────────────────────────────────
 const bubbleVisible = ref(false)
 
@@ -150,7 +128,7 @@ watch(() => props.disabled, (val) => {
 </script>
 
 <template>
-  <div ref="editorRef" class="nyx-editor" :class="[...classList, `mode-${props.mode}`]">
+  <div class="nyx-editor" :class="[...classList, `mode-${props.mode}`]">
 
     <!-- Toolbar mode: persistent top bar -->
     <div

--- a/src/components/NyxEditor/NyxEditor.vue
+++ b/src/components/NyxEditor/NyxEditor.vue
@@ -226,7 +226,7 @@ watch(() => props.disabled, (val) => {
           role="toolbar"
           aria-label="Text formatting"
           :style="{ top: bubbleStyle.top, left: bubbleStyle.left }"
-          @mousedown="onBubbleMousedown"
+          @mousedown.prevent="onBubbleMousedown"
         >
           <button
             class="nyx-editor__bubble-btn"

--- a/src/components/NyxEditor/NyxEditor.vue
+++ b/src/components/NyxEditor/NyxEditor.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import './NyxEditor.scss'
-import { ref, reactive, watch } from 'vue'
+import { ref, reactive, watch, nextTick } from 'vue'
 import { useEditor, EditorContent } from '@tiptap/vue-3'
 import StarterKit from '@tiptap/starter-kit'
 import Underline from '@tiptap/extension-underline'
@@ -27,6 +27,18 @@ const model = defineModel<string>({ default: '' })
 const sourceModel = defineModel<boolean>('source', { default: false })
 
 const { classList } = useNyxProps(props)
+
+// ── Source textarea auto-resize ──────────────────────────────────────
+const sourceRef = ref<HTMLTextAreaElement | null>(null)
+
+const autoResizeSource = () => {
+  const el = sourceRef.value
+  if (!el) return
+  el.style.height = 'auto'
+  el.style.height = `${el.scrollHeight}px`
+}
+
+watch(sourceModel, (val) => { if (val) nextTick(autoResizeSource) })
 
 // ── Custom bubble menu state ─────────────────────────────────────────
 const bubbleVisible = ref(false)
@@ -227,10 +239,12 @@ watch(() => props.disabled, (val) => {
     <!-- Source view -->
     <textarea
       v-if="sourceModel"
+      ref="sourceRef"
       class="nyx-editor__source"
       v-model="model"
       :disabled="props.disabled"
       spellcheck="false"
+      @input="autoResizeSource"
     />
 
     <!-- Formatted view -->

--- a/src/components/NyxEditor/NyxEditor.vue
+++ b/src/components/NyxEditor/NyxEditor.vue
@@ -3,7 +3,7 @@ import './NyxEditor.scss'
 import { ref, watch, nextTick } from 'vue'
 import { useEditor, EditorContent } from '@tiptap/vue-3'
 import StarterKit from '@tiptap/starter-kit'
-import Underline from '@tiptap/extension-underline'
+import UnderlineExtension from '@tiptap/extension-underline'
 import TaskList from '@tiptap/extension-task-list'
 import TaskItem from '@tiptap/extension-task-item'
 import { Markdown, type MarkdownStorage } from 'tiptap-markdown'
@@ -12,6 +12,12 @@ import { NyxEditorMode, NyxEditorFormat, NyxTheme, NyxVariant, NyxSize } from '@
 import useNyxProps from '@/composables/useNyxProps'
 import useKeyboardShortcuts from '@/composables/useKeyboardShortcuts'
 import NyxEditorBubbleMenu from './NyxEditorBubbleMenu/NyxEditorBubbleMenu.vue'
+import {
+  Bold, Italic, Underline, Strikethrough, Code,
+  List, ListOrdered, ListChecks,
+  Heading1, Heading2, Heading3, Pilcrow,
+  Undo2, Redo2, FileCode,
+} from 'lucide-vue-next'
 
 const props = withDefaults(defineProps<NyxEditorProps>(), {
   mode: NyxEditorMode.Zen,
@@ -110,7 +116,7 @@ const getContent = () => {
 const editor = useEditor({
   extensions: [
     StarterKit,
-    Underline,
+    UnderlineExtension,
     TaskList,
     TaskItem.configure({ nested: true }),
     ...(props.format === NyxEditorFormat.Markdown ? [Markdown] : []),
@@ -154,99 +160,57 @@ watch(() => props.disabled, (val) => {
       aria-label="Text formatting"
       @mousedown.prevent
     >
-      <button
-        class="nyx-editor__toolbar-btn"
-        :class="{ active: editor?.isActive('bold') }"
-        @click="editor?.chain().focus().toggleBold().run()"
-        aria-label="Bold"
-      ><strong>B</strong></button>
-      <button
-        class="nyx-editor__toolbar-btn"
-        :class="{ active: editor?.isActive('italic') }"
-        @click="editor?.chain().focus().toggleItalic().run()"
-        aria-label="Italic"
-      ><em>I</em></button>
-      <button
-        class="nyx-editor__toolbar-btn"
-        :class="{ active: editor?.isActive('underline') }"
-        @click="editor?.chain().focus().toggleUnderline().run()"
-        aria-label="Underline"
-      ><u>U</u></button>
-      <button
-        class="nyx-editor__toolbar-btn"
-        :class="{ active: editor?.isActive('strike') }"
-        @click="editor?.chain().focus().toggleStrike().run()"
-        aria-label="Strikethrough"
-      ><s>S</s></button>
-      <button
-        class="nyx-editor__toolbar-btn"
-        :class="{ active: editor?.isActive('code') }"
-        @click="editor?.chain().focus().toggleCode().run()"
-        aria-label="Inline code"
-      >&lt;&gt;</button>
+      <button class="nyx-editor__toolbar-btn" :class="{ active: editor?.isActive('bold') }"
+        @click="editor?.chain().focus().toggleBold().run()" aria-label="Bold">
+        <Bold :size="15" /></button>
+      <button class="nyx-editor__toolbar-btn" :class="{ active: editor?.isActive('italic') }"
+        @click="editor?.chain().focus().toggleItalic().run()" aria-label="Italic">
+        <Italic :size="15" /></button>
+      <button class="nyx-editor__toolbar-btn" :class="{ active: editor?.isActive('underline') }"
+        @click="editor?.chain().focus().toggleUnderline().run()" aria-label="Underline">
+        <Underline :size="15" /></button>
+      <button class="nyx-editor__toolbar-btn" :class="{ active: editor?.isActive('strike') }"
+        @click="editor?.chain().focus().toggleStrike().run()" aria-label="Strikethrough">
+        <Strikethrough :size="15" /></button>
+      <button class="nyx-editor__toolbar-btn" :class="{ active: editor?.isActive('code') }"
+        @click="editor?.chain().focus().toggleCode().run()" aria-label="Inline code">
+        <Code :size="15" /></button>
 
       <span class="nyx-editor__toolbar-sep" aria-hidden="true" />
 
-      <button
-        class="nyx-editor__toolbar-btn"
-        :class="{ active: editor?.isActive('bulletList') }"
-        @click="editor?.chain().focus().toggleBulletList().run()"
-        aria-label="Bullet list"
-      >UL</button>
-      <button
-        class="nyx-editor__toolbar-btn"
-        :class="{ active: editor?.isActive('orderedList') }"
-        @click="editor?.chain().focus().toggleOrderedList().run()"
-        aria-label="Ordered list"
-      >OL</button>
-      <button
-        class="nyx-editor__toolbar-btn"
-        :class="{ active: editor?.isActive('taskList') }"
-        @click="editor?.chain().focus().toggleTaskList().run()"
-        aria-label="Task list"
-      >☐</button>
+      <button class="nyx-editor__toolbar-btn" :class="{ active: editor?.isActive('bulletList') }"
+        @click="editor?.chain().focus().toggleBulletList().run()" aria-label="Bullet list">
+        <List :size="15" /></button>
+      <button class="nyx-editor__toolbar-btn" :class="{ active: editor?.isActive('orderedList') }"
+        @click="editor?.chain().focus().toggleOrderedList().run()" aria-label="Ordered list">
+        <ListOrdered :size="15" /></button>
+      <button class="nyx-editor__toolbar-btn" :class="{ active: editor?.isActive('taskList') }"
+        @click="editor?.chain().focus().toggleTaskList().run()" aria-label="Task list">
+        <ListChecks :size="15" /></button>
 
       <span class="nyx-editor__toolbar-sep" aria-hidden="true" />
 
-      <button
-        class="nyx-editor__toolbar-btn"
-        :class="{ active: editor?.isActive('heading', { level: 1 }) }"
-        @click="editor?.chain().focus().toggleHeading({ level: 1 }).run()"
-        aria-label="Heading 1"
-      >H1</button>
-      <button
-        class="nyx-editor__toolbar-btn"
-        :class="{ active: editor?.isActive('heading', { level: 2 }) }"
-        @click="editor?.chain().focus().toggleHeading({ level: 2 }).run()"
-        aria-label="Heading 2"
-      >H2</button>
-      <button
-        class="nyx-editor__toolbar-btn"
-        :class="{ active: editor?.isActive('heading', { level: 3 }) }"
-        @click="editor?.chain().focus().toggleHeading({ level: 3 }).run()"
-        aria-label="Heading 3"
-      >H3</button>
-      <button
-        class="nyx-editor__toolbar-btn"
-        :class="{ active: editor?.isActive('paragraph') }"
-        @click="editor?.chain().focus().setParagraph().run()"
-        aria-label="Paragraph"
-      >P</button>
+      <button class="nyx-editor__toolbar-btn" :class="{ active: editor?.isActive('heading', { level: 1 }) }"
+        @click="editor?.chain().focus().toggleHeading({ level: 1 }).run()" aria-label="Heading 1">
+        <Heading1 :size="15" /></button>
+      <button class="nyx-editor__toolbar-btn" :class="{ active: editor?.isActive('heading', { level: 2 }) }"
+        @click="editor?.chain().focus().toggleHeading({ level: 2 }).run()" aria-label="Heading 2">
+        <Heading2 :size="15" /></button>
+      <button class="nyx-editor__toolbar-btn" :class="{ active: editor?.isActive('heading', { level: 3 }) }"
+        @click="editor?.chain().focus().toggleHeading({ level: 3 }).run()" aria-label="Heading 3">
+        <Heading3 :size="15" /></button>
+      <button class="nyx-editor__toolbar-btn" :class="{ active: editor?.isActive('paragraph') }"
+        @click="editor?.chain().focus().setParagraph().run()" aria-label="Paragraph">
+        <Pilcrow :size="15" /></button>
 
       <span class="nyx-editor__toolbar-sep nyx-editor__toolbar-sep--grow" aria-hidden="true" />
 
-      <button
-        class="nyx-editor__toolbar-btn"
-        :disabled="!editor?.can().undo()"
-        @click="editor?.chain().focus().undo().run()"
-        aria-label="Undo"
-      >↩</button>
-      <button
-        class="nyx-editor__toolbar-btn"
-        :disabled="!editor?.can().redo()"
-        @click="editor?.chain().focus().redo().run()"
-        aria-label="Redo"
-      >↪</button>
+      <button class="nyx-editor__toolbar-btn" :disabled="!editor?.can().undo()"
+        @click="editor?.chain().focus().undo().run()" aria-label="Undo">
+        <Undo2 :size="15" /></button>
+      <button class="nyx-editor__toolbar-btn" :disabled="!editor?.can().redo()"
+        @click="editor?.chain().focus().redo().run()" aria-label="Redo">
+        <Redo2 :size="15" /></button>
     </div>
 
     <!-- Source toggle button -->
@@ -255,7 +219,7 @@ watch(() => props.disabled, (val) => {
       :class="{ active: sourceModel }"
       @click="sourceModel = !sourceModel"
       aria-label="Toggle source"
-    >&lt;/&gt;</button>
+    ><FileCode :size="14" /></button>
 
     <!-- Source view -->
     <textarea

--- a/src/components/NyxEditor/NyxEditor.vue
+++ b/src/components/NyxEditor/NyxEditor.vue
@@ -10,6 +10,7 @@ import { Markdown, type MarkdownStorage } from 'tiptap-markdown'
 import type { NyxEditorProps, NyxEditorEmits } from './NyxEditor.types'
 import { NyxEditorMode, NyxEditorFormat, NyxTheme, NyxVariant, NyxSize } from '@/types'
 import useNyxProps from '@/composables/useNyxProps'
+import NyxEditorBubbleMenu from './NyxEditorBubbleMenu/NyxEditorBubbleMenu.vue'
 
 const props = withDefaults(defineProps<NyxEditorProps>(), {
   mode: NyxEditorMode.Zen,
@@ -250,98 +251,14 @@ watch(() => props.disabled, (val) => {
     <!-- Formatted view -->
     <EditorContent v-else :editor="editor" class="nyx-editor__content" />
 
-    <!-- Zen mode: custom bubble menu, teleported to body for correct z-index -->
-    <Teleport to="body">
-      <Transition name="nyx-bubble">
-        <div
-          v-if="props.mode === 'zen' && bubbleVisible"
-          class="nyx-editor__bubble"
-          role="toolbar"
-          aria-label="Text formatting"
-          :style="{ top: bubbleStyle.top, left: bubbleStyle.left }"
-          @mousedown.prevent="onBubbleMousedown"
-        >
-          <button
-            class="nyx-editor__bubble-btn"
-            :class="{ active: editor?.isActive('bold') }"
-            @click="editor?.chain().focus().toggleBold().run()"
-            aria-label="Bold"
-          ><strong>B</strong></button>
-          <button
-            class="nyx-editor__bubble-btn"
-            :class="{ active: editor?.isActive('italic') }"
-            @click="editor?.chain().focus().toggleItalic().run()"
-            aria-label="Italic"
-          ><em>I</em></button>
-          <button
-            class="nyx-editor__bubble-btn"
-            :class="{ active: editor?.isActive('underline') }"
-            @click="editor?.chain().focus().toggleUnderline().run()"
-            aria-label="Underline"
-          ><u>U</u></button>
-          <button
-            class="nyx-editor__bubble-btn"
-            :class="{ active: editor?.isActive('strike') }"
-            @click="editor?.chain().focus().toggleStrike().run()"
-            aria-label="Strikethrough"
-          ><s>S</s></button>
-          <button
-            class="nyx-editor__bubble-btn"
-            :class="{ active: editor?.isActive('code') }"
-            @click="editor?.chain().focus().toggleCode().run()"
-            aria-label="Inline code"
-          >&lt;&gt;</button>
-
-          <span class="nyx-editor__bubble-sep" aria-hidden="true" />
-
-          <button
-            class="nyx-editor__bubble-btn"
-            :class="{ active: editor?.isActive('bulletList') }"
-            @click="editor?.chain().focus().toggleBulletList().run()"
-            aria-label="Bullet list"
-          >UL</button>
-          <button
-            class="nyx-editor__bubble-btn"
-            :class="{ active: editor?.isActive('orderedList') }"
-            @click="editor?.chain().focus().toggleOrderedList().run()"
-            aria-label="Ordered list"
-          >OL</button>
-          <button
-            class="nyx-editor__bubble-btn"
-            :class="{ active: editor?.isActive('taskList') }"
-            @click="editor?.chain().focus().toggleTaskList().run()"
-            aria-label="Task list"
-          >☐</button>
-
-          <span class="nyx-editor__bubble-sep" aria-hidden="true" />
-
-          <button
-            class="nyx-editor__bubble-btn"
-            :class="{ active: editor?.isActive('heading', { level: 1 }) }"
-            @click="editor?.chain().focus().toggleHeading({ level: 1 }).run()"
-            aria-label="Heading 1"
-          >H1</button>
-          <button
-            class="nyx-editor__bubble-btn"
-            :class="{ active: editor?.isActive('heading', { level: 2 }) }"
-            @click="editor?.chain().focus().toggleHeading({ level: 2 }).run()"
-            aria-label="Heading 2"
-          >H2</button>
-          <button
-            class="nyx-editor__bubble-btn"
-            :class="{ active: editor?.isActive('heading', { level: 3 }) }"
-            @click="editor?.chain().focus().toggleHeading({ level: 3 }).run()"
-            aria-label="Heading 3"
-          >H3</button>
-          <button
-            class="nyx-editor__bubble-btn"
-            :class="{ active: editor?.isActive('paragraph') }"
-            @click="editor?.chain().focus().setParagraph().run()"
-            aria-label="Paragraph"
-          >P</button>
-        </div>
-      </Transition>
-    </Teleport>
+    <!-- Zen mode: custom bubble menu -->
+    <NyxEditorBubbleMenu
+      v-if="props.mode === 'zen'"
+      :editor="editor ?? null"
+      :visible="bubbleVisible"
+      :style="{ top: bubbleStyle.top, left: bubbleStyle.left }"
+      @mousedown="onBubbleMousedown"
+    />
 
   </div>
 </template>

--- a/src/components/NyxEditor/NyxEditor.vue
+++ b/src/components/NyxEditor/NyxEditor.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import './NyxEditor.scss'
-import { ref, reactive, watch, nextTick } from 'vue'
+import { ref, watch, nextTick } from 'vue'
 import { useEditor, EditorContent } from '@tiptap/vue-3'
 import StarterKit from '@tiptap/starter-kit'
 import Underline from '@tiptap/extension-underline'
@@ -43,7 +43,6 @@ watch(sourceModel, (val) => { if (val) nextTick(autoResizeSource) })
 
 // ── Custom bubble menu state ─────────────────────────────────────────
 const bubbleVisible = ref(false)
-const bubbleStyle = reactive({ top: '0px', left: '0px' })
 
 // Prevent hiding the bubble while a bubble button is being clicked
 let suppressNextHide = false
@@ -68,8 +67,6 @@ const updateBubble = () => {
     bubbleVisible.value = false
     return
   }
-  bubbleStyle.top = `${rect.top + window.scrollY - 8}px`
-  bubbleStyle.left = `${rect.left + window.scrollX + rect.width / 2}px`
   bubbleVisible.value = true
 }
 
@@ -256,7 +253,6 @@ watch(() => props.disabled, (val) => {
       v-if="props.mode === 'zen'"
       :editor="editor ?? null"
       :visible="bubbleVisible"
-      :style="{ top: bubbleStyle.top, left: bubbleStyle.left }"
       @mousedown="onBubbleMousedown"
     />
 

--- a/src/components/NyxEditor/NyxEditor.vue
+++ b/src/components/NyxEditor/NyxEditor.vue
@@ -1,0 +1,214 @@
+<script setup lang="ts">
+import './NyxEditor.scss'
+import { watch } from 'vue'
+import { useEditor, EditorContent } from '@tiptap/vue-3'
+import { BubbleMenu } from '@tiptap/vue-3/menus'
+import StarterKit from '@tiptap/starter-kit'
+import { Markdown, type MarkdownStorage } from 'tiptap-markdown'
+import type { NyxEditorProps, NyxEditorEmits } from './NyxEditor.types'
+import { NyxEditorMode, NyxEditorFormat, NyxTheme, NyxVariant, NyxSize } from '@/types'
+import useNyxProps from '@/composables/useNyxProps'
+
+const props = withDefaults(defineProps<NyxEditorProps>(), {
+  mode: NyxEditorMode.Zen,
+  format: NyxEditorFormat.Markdown,
+  theme: NyxTheme.Default,
+  variant: NyxVariant.Outline,
+  size: NyxSize.Medium,
+  disabled: false,
+  placeholder: '',
+})
+
+const emit = defineEmits<NyxEditorEmits>()
+
+const model = defineModel<string>({ default: '' })
+
+const { classList } = useNyxProps(props)
+
+const getContent = () => {
+  if (!editor.value) return ''
+  return props.format === NyxEditorFormat.Markdown
+    ? (editor.value.storage as unknown as { markdown: MarkdownStorage }).markdown.getMarkdown()
+    : editor.value.getHTML()
+}
+
+const editor = useEditor({
+  extensions: [
+    StarterKit,
+    ...(props.format === NyxEditorFormat.Markdown ? [Markdown] : []),
+  ],
+  content: model.value,
+  editable: !props.disabled,
+  onUpdate: () => {
+    const content = getContent()
+    model.value = content
+    emit('change', content)
+  },
+  onFocus: ({ event }) => emit('focus', event as FocusEvent),
+  onBlur: ({ event }) => emit('blur', event as FocusEvent),
+})
+
+watch(() => model.value, (value) => {
+  if (!editor.value) return
+  const current = getContent()
+  if (value !== current) {
+    editor.value.commands.setContent(value, { emitUpdate: false })
+  }
+})
+
+watch(() => props.disabled, (val) => {
+  editor.value?.setEditable(!val)
+})
+</script>
+
+<template>
+  <div class="nyx-editor" :class="[...classList, `mode-${props.mode}`]">
+    <!-- Toolbar mode: persistent top bar -->
+    <div v-if="props.mode === NyxEditorMode.Toolbar" class="nyx-editor__toolbar" role="toolbar" aria-label="Text formatting">
+      <button
+        class="nyx-editor__toolbar-btn"
+        :class="{ active: editor?.isActive('bold') }"
+        @click="editor?.chain().focus().toggleBold().run()"
+        aria-label="Bold"
+      ><strong>B</strong></button>
+      <button
+        class="nyx-editor__toolbar-btn"
+        :class="{ active: editor?.isActive('italic') }"
+        @click="editor?.chain().focus().toggleItalic().run()"
+        aria-label="Italic"
+      ><em>I</em></button>
+      <button
+        class="nyx-editor__toolbar-btn"
+        :class="{ active: editor?.isActive('strike') }"
+        @click="editor?.chain().focus().toggleStrike().run()"
+        aria-label="Strikethrough"
+      ><s>S</s></button>
+      <button
+        class="nyx-editor__toolbar-btn"
+        :class="{ active: editor?.isActive('code') }"
+        @click="editor?.chain().focus().toggleCode().run()"
+        aria-label="Inline code"
+      >&lt;&gt;</button>
+
+      <span class="nyx-editor__toolbar-sep" aria-hidden="true" />
+
+      <button
+        class="nyx-editor__toolbar-btn"
+        :class="{ active: editor?.isActive('heading', { level: 1 }) }"
+        @click="editor?.chain().focus().toggleHeading({ level: 1 }).run()"
+        aria-label="Heading 1"
+      >H1</button>
+      <button
+        class="nyx-editor__toolbar-btn"
+        :class="{ active: editor?.isActive('heading', { level: 2 }) }"
+        @click="editor?.chain().focus().toggleHeading({ level: 2 }).run()"
+        aria-label="Heading 2"
+      >H2</button>
+      <button
+        class="nyx-editor__toolbar-btn"
+        :class="{ active: editor?.isActive('heading', { level: 3 }) }"
+        @click="editor?.chain().focus().toggleHeading({ level: 3 }).run()"
+        aria-label="Heading 3"
+      >H3</button>
+
+      <span class="nyx-editor__toolbar-sep" aria-hidden="true" />
+
+      <button
+        class="nyx-editor__toolbar-btn"
+        :class="{ active: editor?.isActive('bulletList') }"
+        @click="editor?.chain().focus().toggleBulletList().run()"
+        aria-label="Bullet list"
+      >• List</button>
+      <button
+        class="nyx-editor__toolbar-btn"
+        :class="{ active: editor?.isActive('orderedList') }"
+        @click="editor?.chain().focus().toggleOrderedList().run()"
+        aria-label="Ordered list"
+      >1. List</button>
+      <button
+        class="nyx-editor__toolbar-btn"
+        :class="{ active: editor?.isActive('blockquote') }"
+        @click="editor?.chain().focus().toggleBlockquote().run()"
+        aria-label="Blockquote"
+      >"</button>
+      <button
+        class="nyx-editor__toolbar-btn"
+        :class="{ active: editor?.isActive('codeBlock') }"
+        @click="editor?.chain().focus().toggleCodeBlock().run()"
+        aria-label="Code block"
+      >{ }</button>
+
+      <span class="nyx-editor__toolbar-sep nyx-editor__toolbar-sep--grow" aria-hidden="true" />
+
+      <button
+        class="nyx-editor__toolbar-btn"
+        :disabled="!editor?.can().undo()"
+        @click="editor?.chain().focus().undo().run()"
+        aria-label="Undo"
+      >↩</button>
+      <button
+        class="nyx-editor__toolbar-btn"
+        :disabled="!editor?.can().redo()"
+        @click="editor?.chain().focus().redo().run()"
+        aria-label="Redo"
+      >↪</button>
+    </div>
+
+    <!-- Zen mode: bubble menu appears on text selection -->
+    <BubbleMenu
+      v-if="editor && props.mode === NyxEditorMode.Zen"
+      :editor="editor"
+      :tippy-options="{ duration: 100, placement: 'top' }"
+    >
+      <div class="nyx-editor__bubble" role="toolbar" aria-label="Text formatting">
+        <button
+          class="nyx-editor__bubble-btn"
+          :class="{ active: editor.isActive('bold') }"
+          @click="editor.chain().focus().toggleBold().run()"
+          aria-label="Bold"
+        ><strong>B</strong></button>
+        <button
+          class="nyx-editor__bubble-btn"
+          :class="{ active: editor.isActive('italic') }"
+          @click="editor.chain().focus().toggleItalic().run()"
+          aria-label="Italic"
+        ><em>I</em></button>
+        <button
+          class="nyx-editor__bubble-btn"
+          :class="{ active: editor.isActive('strike') }"
+          @click="editor.chain().focus().toggleStrike().run()"
+          aria-label="Strikethrough"
+        ><s>S</s></button>
+        <button
+          class="nyx-editor__bubble-btn"
+          :class="{ active: editor.isActive('code') }"
+          @click="editor.chain().focus().toggleCode().run()"
+          aria-label="Inline code"
+        >&lt;&gt;</button>
+
+        <span class="nyx-editor__bubble-sep" aria-hidden="true" />
+
+        <button
+          class="nyx-editor__bubble-btn"
+          :class="{ active: editor.isActive('heading', { level: 1 }) }"
+          @click="editor.chain().focus().toggleHeading({ level: 1 }).run()"
+          aria-label="Heading 1"
+        >H1</button>
+        <button
+          class="nyx-editor__bubble-btn"
+          :class="{ active: editor.isActive('heading', { level: 2 }) }"
+          @click="editor.chain().focus().toggleHeading({ level: 2 }).run()"
+          aria-label="Heading 2"
+        >H2</button>
+        <button
+          class="nyx-editor__bubble-btn"
+          :class="{ active: editor.isActive('heading', { level: 3 }) }"
+          @click="editor.chain().focus().toggleHeading({ level: 3 }).run()"
+          aria-label="Heading 3"
+        >H3</button>
+      </div>
+    </BubbleMenu>
+
+    <EditorContent :editor="editor" class="nyx-editor__content" />
+  </div>
+</template>

--- a/src/components/NyxEditor/NyxEditor.vue
+++ b/src/components/NyxEditor/NyxEditor.vue
@@ -10,6 +10,7 @@ import { Markdown, type MarkdownStorage } from 'tiptap-markdown'
 import type { NyxEditorProps, NyxEditorEmits } from './NyxEditor.types'
 import { NyxEditorMode, NyxEditorFormat, NyxTheme, NyxVariant, NyxSize } from '@/types'
 import useNyxProps from '@/composables/useNyxProps'
+import useKeyboardShortcuts from '@/composables/useKeyboardShortcuts'
 import NyxEditorBubbleMenu from './NyxEditorBubbleMenu/NyxEditorBubbleMenu.vue'
 
 const props = withDefaults(defineProps<NyxEditorProps>(), {
@@ -40,6 +41,32 @@ const autoResizeSource = () => {
 }
 
 watch(sourceModel, (val) => { if (val) nextTick(autoResizeSource) })
+
+// ── Keyboard shortcuts ───────────────────────────────────────────────
+const editorRef = ref<HTMLElement | null>(null)
+
+const wrapSelection = (before: string, after = before) => {
+  const el = sourceRef.value
+  if (!el) return
+  const { selectionStart: start, selectionEnd: end } = el
+  el.setRangeText(`${before}${el.value.slice(start, end)}${after}`, start, end, 'select')
+  model.value = el.value
+  nextTick(autoResizeSource)
+}
+
+const sourceShortcut = (wrap: () => void) => () => { if (sourceModel.value) wrap() }
+
+useKeyboardShortcuts({
+  'CTRL+/':  () => { sourceModel.value = !sourceModel.value },
+  'META+/':  () => { sourceModel.value = !sourceModel.value },
+  'CTRL+B':  sourceShortcut(() => wrapSelection('**')),
+  'META+B':  sourceShortcut(() => wrapSelection('**')),
+  'CTRL+I':  sourceShortcut(() => wrapSelection('_')),
+  'META+I':  sourceShortcut(() => wrapSelection('_')),
+  'CTRL+S':  sourceShortcut(() => wrapSelection('~~')),
+  'META+S':  sourceShortcut(() => wrapSelection('~~')),
+  // Formatted view: Tiptap/ProseMirror handles B/I/U/S/Z natively
+}, editorRef)
 
 // ── Custom bubble menu state ─────────────────────────────────────────
 const bubbleVisible = ref(false)
@@ -121,7 +148,7 @@ watch(() => props.disabled, (val) => {
 </script>
 
 <template>
-  <div class="nyx-editor" :class="[...classList, `mode-${props.mode}`]">
+  <div ref="editorRef" class="nyx-editor" :class="[...classList, `mode-${props.mode}`]">
 
     <!-- Toolbar mode: persistent top bar -->
     <div

--- a/src/components/NyxEditor/NyxEditor.vue
+++ b/src/components/NyxEditor/NyxEditor.vue
@@ -57,14 +57,10 @@ const wrapSelection = (before: string, after = before) => {
 const sourceShortcut = (wrap: () => void) => () => { if (sourceModel.value) wrap() }
 
 useKeyboardShortcuts({
-  'CTRL+/':  () => { sourceModel.value = !sourceModel.value },
-  'META+/':  () => { sourceModel.value = !sourceModel.value },
-  'CTRL+B':  sourceShortcut(() => wrapSelection('**')),
-  'META+B':  sourceShortcut(() => wrapSelection('**')),
-  'CTRL+I':  sourceShortcut(() => wrapSelection('_')),
-  'META+I':  sourceShortcut(() => wrapSelection('_')),
-  'CTRL+S':  sourceShortcut(() => wrapSelection('~~')),
-  'META+S':  sourceShortcut(() => wrapSelection('~~')),
+  'SUPER+/': () => { sourceModel.value = !sourceModel.value },
+  'SUPER+B': sourceShortcut(() => wrapSelection('**')),
+  'SUPER+I': sourceShortcut(() => wrapSelection('_')),
+  'SUPER+S': sourceShortcut(() => wrapSelection('~~')),
   // Formatted view: Tiptap/ProseMirror handles B/I/U/S/Z natively
 }, editorRef)
 

--- a/src/components/NyxEditor/NyxEditor.vue
+++ b/src/components/NyxEditor/NyxEditor.vue
@@ -24,6 +24,7 @@ const props = withDefaults(defineProps<NyxEditorProps>(), {
 const emit = defineEmits<NyxEditorEmits>()
 
 const model = defineModel<string>({ default: '' })
+const sourceModel = defineModel<boolean>('source', { default: false })
 
 const { classList } = useNyxProps(props)
 
@@ -215,7 +216,25 @@ watch(() => props.disabled, (val) => {
       >↪</button>
     </div>
 
-    <EditorContent :editor="editor" class="nyx-editor__content" />
+    <!-- Source toggle button -->
+    <button
+      class="nyx-editor__source-toggle"
+      :class="{ active: sourceModel }"
+      @click="sourceModel = !sourceModel"
+      aria-label="Toggle source"
+    >&lt;/&gt;</button>
+
+    <!-- Source view -->
+    <textarea
+      v-if="sourceModel"
+      class="nyx-editor__source"
+      v-model="model"
+      :disabled="props.disabled"
+      spellcheck="false"
+    />
+
+    <!-- Formatted view -->
+    <EditorContent v-else :editor="editor" class="nyx-editor__content" />
 
     <!-- Zen mode: custom bubble menu, teleported to body for correct z-index -->
     <Teleport to="body">

--- a/src/components/NyxEditor/NyxEditor.vue
+++ b/src/components/NyxEditor/NyxEditor.vue
@@ -10,7 +10,6 @@ import { Markdown, type MarkdownStorage } from 'tiptap-markdown'
 import type { NyxEditorProps, NyxEditorEmits } from './NyxEditor.types'
 import { NyxEditorMode, NyxEditorFormat, NyxTheme, NyxVariant, NyxSize } from '@/types'
 import useNyxProps from '@/composables/useNyxProps'
-import useKeyboardShortcuts from '@/composables/useKeyboardShortcuts'
 import NyxEditorBubbleMenu from './NyxEditorBubbleMenu/NyxEditorBubbleMenu.vue'
 import {
   Bold, Italic, Underline, Strikethrough, Code,

--- a/src/components/NyxEditor/NyxEditor.vue
+++ b/src/components/NyxEditor/NyxEditor.vue
@@ -1,9 +1,11 @@
 <script setup lang="ts">
 import './NyxEditor.scss'
-import { watch } from 'vue'
+import { ref, reactive, watch } from 'vue'
 import { useEditor, EditorContent } from '@tiptap/vue-3'
-import { BubbleMenu } from '@tiptap/vue-3/menus'
 import StarterKit from '@tiptap/starter-kit'
+import Underline from '@tiptap/extension-underline'
+import TaskList from '@tiptap/extension-task-list'
+import TaskItem from '@tiptap/extension-task-item'
 import { Markdown, type MarkdownStorage } from 'tiptap-markdown'
 import type { NyxEditorProps, NyxEditorEmits } from './NyxEditor.types'
 import { NyxEditorMode, NyxEditorFormat, NyxTheme, NyxVariant, NyxSize } from '@/types'
@@ -25,6 +27,45 @@ const model = defineModel<string>({ default: '' })
 
 const { classList } = useNyxProps(props)
 
+// ── Custom bubble menu state ─────────────────────────────────────────
+const bubbleVisible = ref(false)
+const bubbleStyle = reactive({ top: '0px', left: '0px' })
+
+// Prevent hiding the bubble while a bubble button is being clicked
+let suppressNextHide = false
+
+const updateBubble = () => {
+  if (suppressNextHide) return
+  if (!editor.value || props.mode !== NyxEditorMode.Zen) {
+    bubbleVisible.value = false
+    return
+  }
+  if (editor.value.state.selection.empty) {
+    bubbleVisible.value = false
+    return
+  }
+  const sel = window.getSelection()
+  if (!sel || sel.rangeCount === 0) {
+    bubbleVisible.value = false
+    return
+  }
+  const rect = sel.getRangeAt(0).getBoundingClientRect()
+  if (!rect.width && !rect.height) {
+    bubbleVisible.value = false
+    return
+  }
+  bubbleStyle.top = `${rect.top + window.scrollY - 8}px`
+  bubbleStyle.left = `${rect.left + window.scrollX + rect.width / 2}px`
+  bubbleVisible.value = true
+}
+
+const onBubbleMousedown = () => {
+  suppressNextHide = true
+  // Allow the click handler to fire, then restore normal behaviour
+  requestAnimationFrame(() => { suppressNextHide = false })
+}
+
+// ── Content helpers ─────────────────────────────────────────────────
 const getContent = () => {
   if (!editor.value) return ''
   return props.format === NyxEditorFormat.Markdown
@@ -35,6 +76,9 @@ const getContent = () => {
 const editor = useEditor({
   extensions: [
     StarterKit,
+    Underline,
+    TaskList,
+    TaskItem.configure({ nested: true }),
     ...(props.format === NyxEditorFormat.Markdown ? [Markdown] : []),
   ],
   content: model.value,
@@ -44,8 +88,12 @@ const editor = useEditor({
     model.value = content
     emit('change', content)
   },
+  onSelectionUpdate: updateBubble,
   onFocus: ({ event }) => emit('focus', event as FocusEvent),
-  onBlur: ({ event }) => emit('blur', event as FocusEvent),
+  onBlur: ({ event }) => {
+    bubbleVisible.value = false
+    emit('blur', event as FocusEvent)
+  },
 })
 
 watch(() => model.value, (value) => {
@@ -63,8 +111,15 @@ watch(() => props.disabled, (val) => {
 
 <template>
   <div class="nyx-editor" :class="[...classList, `mode-${props.mode}`]">
+
     <!-- Toolbar mode: persistent top bar -->
-    <div v-if="props.mode === NyxEditorMode.Toolbar" class="nyx-editor__toolbar" role="toolbar" aria-label="Text formatting">
+    <div
+      v-if="props.mode === 'toolbar'"
+      class="nyx-editor__toolbar"
+      role="toolbar"
+      aria-label="Text formatting"
+      @mousedown.prevent
+    >
       <button
         class="nyx-editor__toolbar-btn"
         :class="{ active: editor?.isActive('bold') }"
@@ -79,6 +134,12 @@ watch(() => props.disabled, (val) => {
       ><em>I</em></button>
       <button
         class="nyx-editor__toolbar-btn"
+        :class="{ active: editor?.isActive('underline') }"
+        @click="editor?.chain().focus().toggleUnderline().run()"
+        aria-label="Underline"
+      ><u>U</u></button>
+      <button
+        class="nyx-editor__toolbar-btn"
         :class="{ active: editor?.isActive('strike') }"
         @click="editor?.chain().focus().toggleStrike().run()"
         aria-label="Strikethrough"
@@ -89,6 +150,27 @@ watch(() => props.disabled, (val) => {
         @click="editor?.chain().focus().toggleCode().run()"
         aria-label="Inline code"
       >&lt;&gt;</button>
+
+      <span class="nyx-editor__toolbar-sep" aria-hidden="true" />
+
+      <button
+        class="nyx-editor__toolbar-btn"
+        :class="{ active: editor?.isActive('bulletList') }"
+        @click="editor?.chain().focus().toggleBulletList().run()"
+        aria-label="Bullet list"
+      >UL</button>
+      <button
+        class="nyx-editor__toolbar-btn"
+        :class="{ active: editor?.isActive('orderedList') }"
+        @click="editor?.chain().focus().toggleOrderedList().run()"
+        aria-label="Ordered list"
+      >OL</button>
+      <button
+        class="nyx-editor__toolbar-btn"
+        :class="{ active: editor?.isActive('taskList') }"
+        @click="editor?.chain().focus().toggleTaskList().run()"
+        aria-label="Task list"
+      >☐</button>
 
       <span class="nyx-editor__toolbar-sep" aria-hidden="true" />
 
@@ -110,33 +192,12 @@ watch(() => props.disabled, (val) => {
         @click="editor?.chain().focus().toggleHeading({ level: 3 }).run()"
         aria-label="Heading 3"
       >H3</button>
-
-      <span class="nyx-editor__toolbar-sep" aria-hidden="true" />
-
       <button
         class="nyx-editor__toolbar-btn"
-        :class="{ active: editor?.isActive('bulletList') }"
-        @click="editor?.chain().focus().toggleBulletList().run()"
-        aria-label="Bullet list"
-      >• List</button>
-      <button
-        class="nyx-editor__toolbar-btn"
-        :class="{ active: editor?.isActive('orderedList') }"
-        @click="editor?.chain().focus().toggleOrderedList().run()"
-        aria-label="Ordered list"
-      >1. List</button>
-      <button
-        class="nyx-editor__toolbar-btn"
-        :class="{ active: editor?.isActive('blockquote') }"
-        @click="editor?.chain().focus().toggleBlockquote().run()"
-        aria-label="Blockquote"
-      >"</button>
-      <button
-        class="nyx-editor__toolbar-btn"
-        :class="{ active: editor?.isActive('codeBlock') }"
-        @click="editor?.chain().focus().toggleCodeBlock().run()"
-        aria-label="Code block"
-      >{ }</button>
+        :class="{ active: editor?.isActive('paragraph') }"
+        @click="editor?.chain().focus().setParagraph().run()"
+        aria-label="Paragraph"
+      >P</button>
 
       <span class="nyx-editor__toolbar-sep nyx-editor__toolbar-sep--grow" aria-hidden="true" />
 
@@ -154,61 +215,100 @@ watch(() => props.disabled, (val) => {
       >↪</button>
     </div>
 
-    <!-- Zen mode: bubble menu appears on text selection -->
-    <BubbleMenu
-      v-if="editor && props.mode === NyxEditorMode.Zen"
-      :editor="editor"
-      :tippy-options="{ duration: 100, placement: 'top' }"
-    >
-      <div class="nyx-editor__bubble" role="toolbar" aria-label="Text formatting">
-        <button
-          class="nyx-editor__bubble-btn"
-          :class="{ active: editor.isActive('bold') }"
-          @click="editor.chain().focus().toggleBold().run()"
-          aria-label="Bold"
-        ><strong>B</strong></button>
-        <button
-          class="nyx-editor__bubble-btn"
-          :class="{ active: editor.isActive('italic') }"
-          @click="editor.chain().focus().toggleItalic().run()"
-          aria-label="Italic"
-        ><em>I</em></button>
-        <button
-          class="nyx-editor__bubble-btn"
-          :class="{ active: editor.isActive('strike') }"
-          @click="editor.chain().focus().toggleStrike().run()"
-          aria-label="Strikethrough"
-        ><s>S</s></button>
-        <button
-          class="nyx-editor__bubble-btn"
-          :class="{ active: editor.isActive('code') }"
-          @click="editor.chain().focus().toggleCode().run()"
-          aria-label="Inline code"
-        >&lt;&gt;</button>
-
-        <span class="nyx-editor__bubble-sep" aria-hidden="true" />
-
-        <button
-          class="nyx-editor__bubble-btn"
-          :class="{ active: editor.isActive('heading', { level: 1 }) }"
-          @click="editor.chain().focus().toggleHeading({ level: 1 }).run()"
-          aria-label="Heading 1"
-        >H1</button>
-        <button
-          class="nyx-editor__bubble-btn"
-          :class="{ active: editor.isActive('heading', { level: 2 }) }"
-          @click="editor.chain().focus().toggleHeading({ level: 2 }).run()"
-          aria-label="Heading 2"
-        >H2</button>
-        <button
-          class="nyx-editor__bubble-btn"
-          :class="{ active: editor.isActive('heading', { level: 3 }) }"
-          @click="editor.chain().focus().toggleHeading({ level: 3 }).run()"
-          aria-label="Heading 3"
-        >H3</button>
-      </div>
-    </BubbleMenu>
-
     <EditorContent :editor="editor" class="nyx-editor__content" />
+
+    <!-- Zen mode: custom bubble menu, teleported to body for correct z-index -->
+    <Teleport to="body">
+      <Transition name="nyx-bubble">
+        <div
+          v-if="props.mode === 'zen' && bubbleVisible"
+          class="nyx-editor__bubble"
+          role="toolbar"
+          aria-label="Text formatting"
+          :style="{ top: bubbleStyle.top, left: bubbleStyle.left }"
+          @mousedown="onBubbleMousedown"
+        >
+          <button
+            class="nyx-editor__bubble-btn"
+            :class="{ active: editor?.isActive('bold') }"
+            @click="editor?.chain().focus().toggleBold().run()"
+            aria-label="Bold"
+          ><strong>B</strong></button>
+          <button
+            class="nyx-editor__bubble-btn"
+            :class="{ active: editor?.isActive('italic') }"
+            @click="editor?.chain().focus().toggleItalic().run()"
+            aria-label="Italic"
+          ><em>I</em></button>
+          <button
+            class="nyx-editor__bubble-btn"
+            :class="{ active: editor?.isActive('underline') }"
+            @click="editor?.chain().focus().toggleUnderline().run()"
+            aria-label="Underline"
+          ><u>U</u></button>
+          <button
+            class="nyx-editor__bubble-btn"
+            :class="{ active: editor?.isActive('strike') }"
+            @click="editor?.chain().focus().toggleStrike().run()"
+            aria-label="Strikethrough"
+          ><s>S</s></button>
+          <button
+            class="nyx-editor__bubble-btn"
+            :class="{ active: editor?.isActive('code') }"
+            @click="editor?.chain().focus().toggleCode().run()"
+            aria-label="Inline code"
+          >&lt;&gt;</button>
+
+          <span class="nyx-editor__bubble-sep" aria-hidden="true" />
+
+          <button
+            class="nyx-editor__bubble-btn"
+            :class="{ active: editor?.isActive('bulletList') }"
+            @click="editor?.chain().focus().toggleBulletList().run()"
+            aria-label="Bullet list"
+          >UL</button>
+          <button
+            class="nyx-editor__bubble-btn"
+            :class="{ active: editor?.isActive('orderedList') }"
+            @click="editor?.chain().focus().toggleOrderedList().run()"
+            aria-label="Ordered list"
+          >OL</button>
+          <button
+            class="nyx-editor__bubble-btn"
+            :class="{ active: editor?.isActive('taskList') }"
+            @click="editor?.chain().focus().toggleTaskList().run()"
+            aria-label="Task list"
+          >☐</button>
+
+          <span class="nyx-editor__bubble-sep" aria-hidden="true" />
+
+          <button
+            class="nyx-editor__bubble-btn"
+            :class="{ active: editor?.isActive('heading', { level: 1 }) }"
+            @click="editor?.chain().focus().toggleHeading({ level: 1 }).run()"
+            aria-label="Heading 1"
+          >H1</button>
+          <button
+            class="nyx-editor__bubble-btn"
+            :class="{ active: editor?.isActive('heading', { level: 2 }) }"
+            @click="editor?.chain().focus().toggleHeading({ level: 2 }).run()"
+            aria-label="Heading 2"
+          >H2</button>
+          <button
+            class="nyx-editor__bubble-btn"
+            :class="{ active: editor?.isActive('heading', { level: 3 }) }"
+            @click="editor?.chain().focus().toggleHeading({ level: 3 }).run()"
+            aria-label="Heading 3"
+          >H3</button>
+          <button
+            class="nyx-editor__bubble-btn"
+            :class="{ active: editor?.isActive('paragraph') }"
+            @click="editor?.chain().focus().setParagraph().run()"
+            aria-label="Paragraph"
+          >P</button>
+        </div>
+      </Transition>
+    </Teleport>
+
   </div>
 </template>

--- a/src/components/NyxEditor/NyxEditorBubbleMenu/NyxEditorBubbleMenu.vue
+++ b/src/components/NyxEditor/NyxEditorBubbleMenu/NyxEditorBubbleMenu.vue
@@ -3,6 +3,11 @@ import { ref, watch, nextTick } from 'vue'
 import type { Editor } from '@tiptap/vue-3'
 import { NyxPosition } from '@/types'
 import useSelectionPosition from '@/composables/useSelectionPosition'
+import {
+  Bold, Italic, Underline, Strikethrough, Code,
+  List, ListOrdered, ListChecks,
+  Heading1, Heading2, Heading3, Pilcrow,
+} from 'lucide-vue-next'
 
 const props = defineProps<{
   editor: Editor | null
@@ -37,84 +42,60 @@ watch(() => props.visible, (val) => {
         :style="cssVariables"
         @mousedown.prevent="emit('mousedown')"
       >
-        <button
-          class="nyx-editor__bubble-btn"
-          :class="{ active: editor?.isActive('bold') }"
-          @click="editor?.chain().focus().toggleBold().run()"
-          aria-label="Bold"
-        ><strong>B</strong></button>
-        <button
-          class="nyx-editor__bubble-btn"
-          :class="{ active: editor?.isActive('italic') }"
-          @click="editor?.chain().focus().toggleItalic().run()"
-          aria-label="Italic"
-        ><em>I</em></button>
-        <button
-          class="nyx-editor__bubble-btn"
-          :class="{ active: editor?.isActive('underline') }"
-          @click="editor?.chain().focus().toggleUnderline().run()"
-          aria-label="Underline"
-        ><u>U</u></button>
-        <button
-          class="nyx-editor__bubble-btn"
-          :class="{ active: editor?.isActive('strike') }"
-          @click="editor?.chain().focus().toggleStrike().run()"
-          aria-label="Strikethrough"
-        ><s>S</s></button>
-        <button
-          class="nyx-editor__bubble-btn"
-          :class="{ active: editor?.isActive('code') }"
-          @click="editor?.chain().focus().toggleCode().run()"
-          aria-label="Inline code"
-        >&lt;&gt;</button>
+        <button class="nyx-editor__bubble-btn" :class="{ active: editor?.isActive('bold') }"
+          @click="editor?.chain().focus().toggleBold().run()" aria-label="Bold">
+          <Bold :size="14" />
+        </button>
+        <button class="nyx-editor__bubble-btn" :class="{ active: editor?.isActive('italic') }"
+          @click="editor?.chain().focus().toggleItalic().run()" aria-label="Italic">
+          <Italic :size="14" />
+        </button>
+        <button class="nyx-editor__bubble-btn" :class="{ active: editor?.isActive('underline') }"
+          @click="editor?.chain().focus().toggleUnderline().run()" aria-label="Underline">
+          <Underline :size="14" />
+        </button>
+        <button class="nyx-editor__bubble-btn" :class="{ active: editor?.isActive('strike') }"
+          @click="editor?.chain().focus().toggleStrike().run()" aria-label="Strikethrough">
+          <Strikethrough :size="14" />
+        </button>
+        <button class="nyx-editor__bubble-btn" :class="{ active: editor?.isActive('code') }"
+          @click="editor?.chain().focus().toggleCode().run()" aria-label="Inline code">
+          <Code :size="14" />
+        </button>
 
         <span class="nyx-editor__bubble-sep" aria-hidden="true" />
 
-        <button
-          class="nyx-editor__bubble-btn"
-          :class="{ active: editor?.isActive('bulletList') }"
-          @click="editor?.chain().focus().toggleBulletList().run()"
-          aria-label="Bullet list"
-        >UL</button>
-        <button
-          class="nyx-editor__bubble-btn"
-          :class="{ active: editor?.isActive('orderedList') }"
-          @click="editor?.chain().focus().toggleOrderedList().run()"
-          aria-label="Ordered list"
-        >OL</button>
-        <button
-          class="nyx-editor__bubble-btn"
-          :class="{ active: editor?.isActive('taskList') }"
-          @click="editor?.chain().focus().toggleTaskList().run()"
-          aria-label="Task list"
-        >☐</button>
+        <button class="nyx-editor__bubble-btn" :class="{ active: editor?.isActive('bulletList') }"
+          @click="editor?.chain().focus().toggleBulletList().run()" aria-label="Bullet list">
+          <List :size="14" />
+        </button>
+        <button class="nyx-editor__bubble-btn" :class="{ active: editor?.isActive('orderedList') }"
+          @click="editor?.chain().focus().toggleOrderedList().run()" aria-label="Ordered list">
+          <ListOrdered :size="14" />
+        </button>
+        <button class="nyx-editor__bubble-btn" :class="{ active: editor?.isActive('taskList') }"
+          @click="editor?.chain().focus().toggleTaskList().run()" aria-label="Task list">
+          <ListChecks :size="14" />
+        </button>
 
         <span class="nyx-editor__bubble-sep" aria-hidden="true" />
 
-        <button
-          class="nyx-editor__bubble-btn"
-          :class="{ active: editor?.isActive('heading', { level: 1 }) }"
-          @click="editor?.chain().focus().toggleHeading({ level: 1 }).run()"
-          aria-label="Heading 1"
-        >H1</button>
-        <button
-          class="nyx-editor__bubble-btn"
-          :class="{ active: editor?.isActive('heading', { level: 2 }) }"
-          @click="editor?.chain().focus().toggleHeading({ level: 2 }).run()"
-          aria-label="Heading 2"
-        >H2</button>
-        <button
-          class="nyx-editor__bubble-btn"
-          :class="{ active: editor?.isActive('heading', { level: 3 }) }"
-          @click="editor?.chain().focus().toggleHeading({ level: 3 }).run()"
-          aria-label="Heading 3"
-        >H3</button>
-        <button
-          class="nyx-editor__bubble-btn"
-          :class="{ active: editor?.isActive('paragraph') }"
-          @click="editor?.chain().focus().setParagraph().run()"
-          aria-label="Paragraph"
-        >P</button>
+        <button class="nyx-editor__bubble-btn" :class="{ active: editor?.isActive('heading', { level: 1 }) }"
+          @click="editor?.chain().focus().toggleHeading({ level: 1 }).run()" aria-label="Heading 1">
+          <Heading1 :size="14" />
+        </button>
+        <button class="nyx-editor__bubble-btn" :class="{ active: editor?.isActive('heading', { level: 2 }) }"
+          @click="editor?.chain().focus().toggleHeading({ level: 2 }).run()" aria-label="Heading 2">
+          <Heading2 :size="14" />
+        </button>
+        <button class="nyx-editor__bubble-btn" :class="{ active: editor?.isActive('heading', { level: 3 }) }"
+          @click="editor?.chain().focus().toggleHeading({ level: 3 }).run()" aria-label="Heading 3">
+          <Heading3 :size="14" />
+        </button>
+        <button class="nyx-editor__bubble-btn" :class="{ active: editor?.isActive('paragraph') }"
+          @click="editor?.chain().focus().setParagraph().run()" aria-label="Paragraph">
+          <Pilcrow :size="14" />
+        </button>
       </div>
     </Transition>
   </Teleport>

--- a/src/components/NyxEditor/NyxEditorBubbleMenu/NyxEditorBubbleMenu.vue
+++ b/src/components/NyxEditor/NyxEditorBubbleMenu/NyxEditorBubbleMenu.vue
@@ -1,0 +1,108 @@
+<script setup lang="ts">
+import type { Editor } from '@tiptap/vue-3'
+import type { CSSProperties } from 'vue'
+
+defineProps<{
+  editor: Editor | null
+  visible: boolean
+  style: CSSProperties
+}>()
+
+const emit = defineEmits<{
+  mousedown: []
+}>()
+</script>
+
+<template>
+  <Teleport to="body">
+    <Transition name="nyx-bubble">
+      <div
+        v-if="visible"
+        class="nyx-editor__bubble"
+        role="toolbar"
+        aria-label="Text formatting"
+        :style="style"
+        @mousedown.prevent="emit('mousedown')"
+      >
+        <button
+          class="nyx-editor__bubble-btn"
+          :class="{ active: editor?.isActive('bold') }"
+          @click="editor?.chain().focus().toggleBold().run()"
+          aria-label="Bold"
+        ><strong>B</strong></button>
+        <button
+          class="nyx-editor__bubble-btn"
+          :class="{ active: editor?.isActive('italic') }"
+          @click="editor?.chain().focus().toggleItalic().run()"
+          aria-label="Italic"
+        ><em>I</em></button>
+        <button
+          class="nyx-editor__bubble-btn"
+          :class="{ active: editor?.isActive('underline') }"
+          @click="editor?.chain().focus().toggleUnderline().run()"
+          aria-label="Underline"
+        ><u>U</u></button>
+        <button
+          class="nyx-editor__bubble-btn"
+          :class="{ active: editor?.isActive('strike') }"
+          @click="editor?.chain().focus().toggleStrike().run()"
+          aria-label="Strikethrough"
+        ><s>S</s></button>
+        <button
+          class="nyx-editor__bubble-btn"
+          :class="{ active: editor?.isActive('code') }"
+          @click="editor?.chain().focus().toggleCode().run()"
+          aria-label="Inline code"
+        >&lt;&gt;</button>
+
+        <span class="nyx-editor__bubble-sep" aria-hidden="true" />
+
+        <button
+          class="nyx-editor__bubble-btn"
+          :class="{ active: editor?.isActive('bulletList') }"
+          @click="editor?.chain().focus().toggleBulletList().run()"
+          aria-label="Bullet list"
+        >UL</button>
+        <button
+          class="nyx-editor__bubble-btn"
+          :class="{ active: editor?.isActive('orderedList') }"
+          @click="editor?.chain().focus().toggleOrderedList().run()"
+          aria-label="Ordered list"
+        >OL</button>
+        <button
+          class="nyx-editor__bubble-btn"
+          :class="{ active: editor?.isActive('taskList') }"
+          @click="editor?.chain().focus().toggleTaskList().run()"
+          aria-label="Task list"
+        >☐</button>
+
+        <span class="nyx-editor__bubble-sep" aria-hidden="true" />
+
+        <button
+          class="nyx-editor__bubble-btn"
+          :class="{ active: editor?.isActive('heading', { level: 1 }) }"
+          @click="editor?.chain().focus().toggleHeading({ level: 1 }).run()"
+          aria-label="Heading 1"
+        >H1</button>
+        <button
+          class="nyx-editor__bubble-btn"
+          :class="{ active: editor?.isActive('heading', { level: 2 }) }"
+          @click="editor?.chain().focus().toggleHeading({ level: 2 }).run()"
+          aria-label="Heading 2"
+        >H2</button>
+        <button
+          class="nyx-editor__bubble-btn"
+          :class="{ active: editor?.isActive('heading', { level: 3 }) }"
+          @click="editor?.chain().focus().toggleHeading({ level: 3 }).run()"
+          aria-label="Heading 3"
+        >H3</button>
+        <button
+          class="nyx-editor__bubble-btn"
+          :class="{ active: editor?.isActive('paragraph') }"
+          @click="editor?.chain().focus().setParagraph().run()"
+          aria-label="Paragraph"
+        >P</button>
+      </div>
+    </Transition>
+  </Teleport>
+</template>

--- a/src/components/NyxEditor/NyxEditorBubbleMenu/NyxEditorBubbleMenu.vue
+++ b/src/components/NyxEditor/NyxEditorBubbleMenu/NyxEditorBubbleMenu.vue
@@ -1,16 +1,28 @@
 <script setup lang="ts">
+import { ref, watch, nextTick } from 'vue'
 import type { Editor } from '@tiptap/vue-3'
-import type { CSSProperties } from 'vue'
+import { NyxPosition } from '@/types'
+import useSelectionPosition from '@/composables/useSelectionPosition'
 
-defineProps<{
+const props = defineProps<{
   editor: Editor | null
   visible: boolean
-  style: CSSProperties
 }>()
 
 const emit = defineEmits<{
   mousedown: []
 }>()
+
+const bubbleRef = ref<HTMLElement | null>(null)
+
+const { cssVariables, updateCssVariables } = useSelectionPosition(bubbleRef, {
+  position: ref(NyxPosition.Top),
+  offsetY: -8,
+})
+
+watch(() => props.visible, (val) => {
+  if (val) nextTick(updateCssVariables)
+})
 </script>
 
 <template>
@@ -18,10 +30,11 @@ const emit = defineEmits<{
     <Transition name="nyx-bubble">
       <div
         v-if="visible"
+        ref="bubbleRef"
         class="nyx-editor__bubble"
         role="toolbar"
         aria-label="Text formatting"
-        :style="style"
+        :style="cssVariables"
         @mousedown.prevent="emit('mousedown')"
       >
         <button

--- a/src/components/NyxEditor/index.ts
+++ b/src/components/NyxEditor/index.ts
@@ -1,0 +1,1 @@
+export { default as NyxEditor } from './NyxEditor.vue'

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,3 +1,4 @@
+import NyxEditor from './NyxEditor/NyxEditor.vue'
 import NyxAvatar from './NyxAvatar/NyxAvatar.vue'
 import NyxBadge from './NyxBadge/NyxBadge.vue'
 import NyxBreadcrumbs from './NyxBreadcrumbs/NyxBreadcrumbs.vue'
@@ -23,6 +24,7 @@ import NyxTooltip from './NyxTooltip/NyxTooltip.vue'
 import NyxTree from './NyxTree/index'
 
 export {
+  NyxEditor,
   NyxAvatar,
   NyxBadge,
   NyxBreadcrumbs,

--- a/src/composables/useKeyboardShortcuts.ts
+++ b/src/composables/useKeyboardShortcuts.ts
@@ -16,10 +16,26 @@ const keySort = (a: string, b: string) => {
   return 0
 }
 
+const expandShortcuts = (
+  shortcuts: Record<string, (event: KeyboardEvent) => void>
+): Record<string, (event: KeyboardEvent) => void> => {
+  const expanded: Record<string, (event: KeyboardEvent) => void> = {}
+  for (const [combo, handler] of Object.entries(shortcuts)) {
+    if (combo.includes('SUPER')) {
+      expanded[combo.replace('SUPER', 'CTRL')] = handler
+      expanded[combo.replace('SUPER', 'META')] = handler
+    } else {
+      expanded[combo] = handler
+    }
+  }
+  return expanded
+}
+
 const useKeyboardShortcuts = (
   shortcuts: Record<string, (event: KeyboardEvent) => void>,
   target?: Ref<HTMLElement | null>
 ) => {
+  const expanded = expandShortcuts(shortcuts)
   const keyHistory: Set<string> = new Set()
 
   const getTarget = () => target?.value ?? window
@@ -29,9 +45,9 @@ const useKeyboardShortcuts = (
     keyHistory.add(key)
     const combination = Array.from(keyHistory).sort(keySort).join('+')
 
-    if (shortcuts[combination]) {
+    if (expanded[combination]) {
       event.preventDefault()
-      shortcuts[combination](event)
+      expanded[combination](event)
     }
   }
 

--- a/src/composables/useKeyboardShortcuts.ts
+++ b/src/composables/useKeyboardShortcuts.ts
@@ -1,5 +1,4 @@
-import type { KeyDict } from '@/types'
-import { onMounted, onUnmounted } from 'vue'
+import { onMounted, onUnmounted, type Ref } from 'vue'
 
 const getNormalizedKeyName = (key: string) => {
   if (key === ' ') return 'SPACE'
@@ -17,8 +16,13 @@ const keySort = (a: string, b: string) => {
   return 0
 }
 
-const useKeyboardShortcuts = (shortcuts: Record<string, (event: KeyboardEvent) => void>) => {
+const useKeyboardShortcuts = (
+  shortcuts: Record<string, (event: KeyboardEvent) => void>,
+  target?: Ref<HTMLElement | null>
+) => {
   const keyHistory: Set<string> = new Set()
+
+  const getTarget = () => target?.value ?? window
 
   const keydownHandler = (event: KeyboardEvent) => {
     const key = getNormalizedKeyName(event.key)
@@ -36,13 +40,13 @@ const useKeyboardShortcuts = (shortcuts: Record<string, (event: KeyboardEvent) =
   }
 
   onMounted(() => {
-    window.addEventListener('keydown', keydownHandler)
-    window.addEventListener('keyup', keyupHandler)
+    getTarget().addEventListener('keydown', keydownHandler as EventListener)
+    getTarget().addEventListener('keyup', keyupHandler as EventListener)
   })
 
   onUnmounted(() => {
-    window.removeEventListener('keydown', keydownHandler)
-    window.removeEventListener('keyup', keyupHandler)
+    getTarget().removeEventListener('keydown', keydownHandler as EventListener)
+    getTarget().removeEventListener('keyup', keyupHandler as EventListener)
   })
 }
 

--- a/src/composables/useSelectionPosition.ts
+++ b/src/composables/useSelectionPosition.ts
@@ -1,0 +1,17 @@
+import { type DefineComponent, type Ref } from 'vue'
+import useTeleportPositionBase, { type TeleportPositionOptions } from './useTeleportPositionBase'
+
+const useSelectionPosition = (
+  elAbsolute: Ref<HTMLElement | DefineComponent | null>,
+  options?: TeleportPositionOptions
+) => {
+  const getAnchorRect = (): DOMRect | null => {
+    const sel = window.getSelection()
+    if (!sel || sel.rangeCount === 0) return null
+    return sel.getRangeAt(0).getBoundingClientRect()
+  }
+
+  return useTeleportPositionBase(getAnchorRect, elAbsolute, options)
+}
+
+export default useSelectionPosition

--- a/src/composables/useTeleportPosition.ts
+++ b/src/composables/useTeleportPosition.ts
@@ -1,164 +1,24 @@
-import { computed, type DefineComponent, onBeforeUnmount, onMounted, type Ref, ref, watch } from 'vue'
-import { type CssVariablesDict, NyxPosition, NyxSize } from '@/types'
-import { clamp } from '@/utils'
-
-interface TeleportPositionOptions {
-  position?: Ref<NyxPosition>
-  isEqualWidth?: boolean
-  isUpdateAllowed?: Ref<boolean>
-  gap?: Ref<NyxSize>
-  offsetX?: number
-  offsetY?: number
-}
+import { type DefineComponent, type Ref, watch } from 'vue'
+import useTeleportPositionBase, { type TeleportPositionOptions } from './useTeleportPositionBase'
 
 const useTeleportPosition = (
   elRelative: Ref<HTMLElement | DefineComponent | null>,
   elAbsolute: Ref<HTMLElement | DefineComponent | null>,
   options?: TeleportPositionOptions
 ) => {
-  const position = options?.position ?? ref(NyxPosition.Bottom)
-  const isEqualWidth = !!options?.isEqualWidth
-  const isUpdateAllowed = computed(() => options?.isUpdateAllowed?.value !== false)
-  const offsetX = options?.offsetX ?? 0
-  const offsetY = options?.offsetY ?? 0
-
-  // Compute gap as a pixel value
-  const gap = computed(() => {
-    if (!options?.gap?.value) return 0
-    if (typeof window === 'undefined') return 0
-    const gapValue = window
-      .getComputedStyle(document.body)
-      .getPropertyValue(`--nyx-gap-${ options.gap.value }`) ?? '0'
-    if (gapValue.endsWith('rem')) {
-      return parseFloat(gapValue) * 16 // Convert rem to pixels
-    }
-    return parseFloat(gapValue) // If it's 0 or other units, keep it as is
-  })
-
-  const cssVariables = ref<CssVariablesDict>({
-    '--top': '0px',
-    '--left': '0px',
-    '--width': 'auto'
-  })
-
-  // Reactive computed position to expose externally
-  const computedPosition = ref<NyxPosition>(position.value)
-
-  const updateCssVariables = () => {
-    if (typeof window === 'undefined') return
-    if (!elRelative.value || !elAbsolute.value || !isUpdateAllowed.value) return
-
-    const elRelativeRect = ('getBoundingClientRect' in elRelative.value )
+  const getAnchorRect = (): DOMRect | null => {
+    if (!elRelative.value) return null
+    return ('getBoundingClientRect' in elRelative.value)
       ? elRelative.value.getBoundingClientRect()
       : (elRelative.value as DefineComponent).$el.getBoundingClientRect()
-    const elAbsoluteRect = ('getBoundingClientRect' in elAbsolute.value)
-      ? elAbsolute.value.getBoundingClientRect()
-      : (elAbsolute.value as DefineComponent).$el.getBoundingClientRect()
-
-    const { top, bottom, left, right, width: relWidth, height: relHeight } = elRelativeRect
-    const { width: absWidth, height: absHeight } = elAbsoluteRect
-
-    const computedWidth = isEqualWidth ? relWidth : absWidth
-    let computedTop = bottom
-    let computedLeft = left
-
-    // Determine if there's enough space for the absolute element
-    const hasSpaceBelow = bottom + absHeight <= window.innerHeight
-    const hasSpaceAbove = top - absHeight >= 0
-    const hasSpaceLeft = left - absWidth >= 0
-    const hasSpaceRight = right + absWidth <= window.innerWidth
-
-    // Mirror position if there's not enough space
-    const getMirroredPosition = (pos: NyxPosition) => {
-      switch (pos) {
-        case NyxPosition.BottomLeft:
-          return hasSpaceBelow ? pos : NyxPosition.TopLeft
-        case NyxPosition.BottomRight:
-          return hasSpaceBelow ? pos : NyxPosition.TopRight
-        case NyxPosition.Bottom:
-          return hasSpaceBelow ? pos : NyxPosition.Top
-        case NyxPosition.TopLeft:
-          return hasSpaceAbove ? pos : NyxPosition.BottomLeft
-        case NyxPosition.TopRight:
-          return hasSpaceAbove ? pos : NyxPosition.BottomRight
-        case NyxPosition.Top:
-          return hasSpaceAbove ? pos : NyxPosition.Bottom
-        case NyxPosition.Left:
-          return hasSpaceLeft ? pos : NyxPosition.Right
-        case NyxPosition.Right:
-          return hasSpaceRight ? pos : NyxPosition.Left
-        default:
-          return pos
-      }
-    }
-
-    computedPosition.value = getMirroredPosition(position.value)
-
-    // Apply final positioning and factor in gap
-    switch (computedPosition.value) {
-      case NyxPosition.BottomLeft:
-        computedTop = bottom + gap.value + offsetY
-        computedLeft = left + offsetX
-        break
-      case NyxPosition.BottomRight:
-        computedTop = bottom + gap.value + offsetY
-        computedLeft = right - computedWidth + offsetX
-        break
-      case NyxPosition.Bottom:
-        computedTop = bottom + gap.value + offsetY
-        computedLeft = left + (relWidth - computedWidth) / 2 + offsetX
-        break
-      case NyxPosition.TopLeft:
-        computedTop = top - absHeight - gap.value + offsetY
-        computedLeft = left + offsetX
-        break
-      case NyxPosition.TopRight:
-        computedTop = top - absHeight - gap.value + offsetY
-        computedLeft = right - computedWidth + offsetX
-        break
-      case NyxPosition.Top:
-        computedTop = top - absHeight - gap.value + offsetY
-        computedLeft = left + (relWidth - computedWidth) / 2 + offsetX
-        break
-      case NyxPosition.Left:
-        computedTop = top + (relHeight - absHeight) / 2 + offsetY
-        computedLeft = left - absWidth - gap.value + offsetX
-        break
-      case NyxPosition.Right:
-        computedTop = top + (relHeight - absHeight) / 2 + offsetY
-        computedLeft = right + gap.value + offsetX
-        break
-    }
-
-    // Ensure element stays within viewport bounds
-    computedTop = clamp(computedTop, 0, window.innerHeight - absHeight)
-    computedLeft = clamp(computedLeft, 0, window.innerWidth - computedWidth)
-
-    cssVariables.value = {
-      ...cssVariables.value,
-      '--top': `${computedTop}px`,
-      '--left': `${computedLeft}px`,
-      '--width': isEqualWidth ? `${relWidth}px` : 'auto'
-    }
   }
 
-  watch([isUpdateAllowed, elRelative, elAbsolute, position], updateCssVariables, { immediate: true })
+  const result = useTeleportPositionBase(getAnchorRect, elAbsolute, options)
 
-  onMounted(() => {
-    window.addEventListener('resize', updateCssVariables)
-    window.addEventListener('scroll', updateCssVariables, true)
-  })
+  // Re-position when the anchor element itself changes
+  watch(elRelative, result.updateCssVariables)
 
-  onBeforeUnmount(() => {
-    window.removeEventListener('resize', updateCssVariables)
-    window.removeEventListener('scroll', updateCssVariables, true)
-  })
-
-  return {
-    cssVariables,
-    updateCssVariables,
-    computedPosition
-  }
+  return result
 }
 
 export default useTeleportPosition

--- a/src/composables/useTeleportPositionBase.ts
+++ b/src/composables/useTeleportPositionBase.ts
@@ -1,0 +1,121 @@
+import { computed, type DefineComponent, onBeforeUnmount, onMounted, type Ref, ref, watch } from 'vue'
+import { type CssVariablesDict, NyxPosition, NyxSize } from '@/types'
+import { clamp } from '@/utils'
+
+export interface TeleportPositionOptions {
+  position?: Ref<NyxPosition>
+  isEqualWidth?: boolean
+  isUpdateAllowed?: Ref<boolean>
+  gap?: Ref<NyxSize>
+  offsetX?: number
+  offsetY?: number
+}
+
+const useTeleportPositionBase = (
+  getAnchorRect: () => DOMRect | null,
+  elAbsolute: Ref<HTMLElement | DefineComponent | null>,
+  options?: TeleportPositionOptions
+) => {
+  const position = options?.position ?? ref(NyxPosition.Bottom)
+  const isEqualWidth = !!options?.isEqualWidth
+  const isUpdateAllowed = computed(() => options?.isUpdateAllowed?.value !== false)
+  const offsetX = options?.offsetX ?? 0
+  const offsetY = options?.offsetY ?? 0
+
+  const gap = computed(() => {
+    if (!options?.gap?.value) return 0
+    if (typeof window === 'undefined') return 0
+    const gapValue = window
+      .getComputedStyle(document.body)
+      .getPropertyValue(`--nyx-gap-${options.gap.value}`) ?? '0'
+    return gapValue.endsWith('rem') ? parseFloat(gapValue) * 16 : parseFloat(gapValue)
+  })
+
+  const cssVariables = ref<CssVariablesDict>({ '--top': '0px', '--left': '0px', '--width': 'auto' })
+  const computedPosition = ref<NyxPosition>(position.value)
+
+  const updateCssVariables = () => {
+    if (typeof window === 'undefined') return
+    if (!elAbsolute.value || !isUpdateAllowed.value) return
+
+    const anchorRect = getAnchorRect()
+    if (!anchorRect) return
+
+    const elAbsoluteRect = ('getBoundingClientRect' in elAbsolute.value)
+      ? elAbsolute.value.getBoundingClientRect()
+      : (elAbsolute.value as DefineComponent).$el.getBoundingClientRect()
+
+    const { top, bottom, left, right, width: relWidth, height: relHeight } = anchorRect
+    const { width: absWidth, height: absHeight } = elAbsoluteRect
+
+    const computedWidth = isEqualWidth ? relWidth : absWidth
+    let computedTop = bottom
+    let computedLeft = left
+
+    const hasSpaceBelow = bottom + absHeight <= window.innerHeight
+    const hasSpaceAbove = top - absHeight >= 0
+    const hasSpaceLeft = left - absWidth >= 0
+    const hasSpaceRight = right + absWidth <= window.innerWidth
+
+    const getMirroredPosition = (pos: NyxPosition): NyxPosition => {
+      switch (pos) {
+        case NyxPosition.BottomLeft:  return hasSpaceBelow ? pos : NyxPosition.TopLeft
+        case NyxPosition.BottomRight: return hasSpaceBelow ? pos : NyxPosition.TopRight
+        case NyxPosition.Bottom:      return hasSpaceBelow ? pos : NyxPosition.Top
+        case NyxPosition.TopLeft:     return hasSpaceAbove ? pos : NyxPosition.BottomLeft
+        case NyxPosition.TopRight:    return hasSpaceAbove ? pos : NyxPosition.BottomRight
+        case NyxPosition.Top:         return hasSpaceAbove ? pos : NyxPosition.Bottom
+        case NyxPosition.Left:        return hasSpaceLeft  ? pos : NyxPosition.Right
+        case NyxPosition.Right:       return hasSpaceRight ? pos : NyxPosition.Left
+        default:                      return pos
+      }
+    }
+
+    computedPosition.value = getMirroredPosition(position.value)
+
+    switch (computedPosition.value) {
+      case NyxPosition.BottomLeft:
+        computedTop  = bottom + gap.value + offsetY; computedLeft = left + offsetX; break
+      case NyxPosition.BottomRight:
+        computedTop  = bottom + gap.value + offsetY; computedLeft = right - computedWidth + offsetX; break
+      case NyxPosition.Bottom:
+        computedTop  = bottom + gap.value + offsetY; computedLeft = left + (relWidth - computedWidth) / 2 + offsetX; break
+      case NyxPosition.TopLeft:
+        computedTop  = top - absHeight - gap.value + offsetY; computedLeft = left + offsetX; break
+      case NyxPosition.TopRight:
+        computedTop  = top - absHeight - gap.value + offsetY; computedLeft = right - computedWidth + offsetX; break
+      case NyxPosition.Top:
+        computedTop  = top - absHeight - gap.value + offsetY; computedLeft = left + (relWidth - computedWidth) / 2 + offsetX; break
+      case NyxPosition.Left:
+        computedTop  = top + (relHeight - absHeight) / 2 + offsetY; computedLeft = left - absWidth - gap.value + offsetX; break
+      case NyxPosition.Right:
+        computedTop  = top + (relHeight - absHeight) / 2 + offsetY; computedLeft = right + gap.value + offsetX; break
+    }
+
+    computedTop  = clamp(computedTop,  0, window.innerHeight - absHeight)
+    computedLeft = clamp(computedLeft, 0, window.innerWidth  - computedWidth)
+
+    cssVariables.value = {
+      ...cssVariables.value,
+      '--top':   `${computedTop}px`,
+      '--left':  `${computedLeft}px`,
+      '--width': isEqualWidth ? `${relWidth}px` : 'auto',
+    }
+  }
+
+  watch([isUpdateAllowed, elAbsolute, position], updateCssVariables, { immediate: true })
+
+  onMounted(() => {
+    window.addEventListener('resize', updateCssVariables)
+    window.addEventListener('scroll', updateCssVariables, true)
+  })
+
+  onBeforeUnmount(() => {
+    window.removeEventListener('resize', updateCssVariables)
+    window.removeEventListener('scroll', updateCssVariables, true)
+  })
+
+  return { cssVariables, updateCssVariables, computedPosition }
+}
+
+export default useTeleportPositionBase

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -59,3 +59,13 @@ export enum NyxProgressVariant {
   Line = 'line',
   Dots = 'dots'
 }
+
+export enum NyxEditorMode {
+  Zen = 'zen',
+  Toolbar = 'toolbar'
+}
+
+export enum NyxEditorFormat {
+  Markdown = 'markdown',
+  Html = 'html'
+}


### PR DESCRIPTION
## Summary

- Adds `NyxEditor`, a Tiptap-based WYSIWYG editor with two UI modes and two output formats
- **zen mode** — distraction-free surface; a `BubbleMenu` floats on text selection (B / I / S / code / H1–H3)
- **toolbar mode** — persistent top bar with full formatting controls, styled after Google Docs / Word (bold, italic, strike, code, headings, lists, blockquote, code block, undo/redo)
- `format` prop controls output: `markdown` (via `tiptap-markdown`) or `html`
- v-model binds to the serialized content string
- New enums `NyxEditorMode` and `NyxEditorFormat` added to `src/types/common.ts`
- Follows all project conventions: `useNyxProps`, theme/size/variant props, `.types.ts`, `.stories.ts`, `.spec.ts`, spec doc in `docs/specs/components/`

## New dependencies

| Package | Reason |
|---|---|
| `@tiptap/vue-3` | Vue 3 wrapper for Tiptap/ProseMirror |
| `@tiptap/starter-kit` | Bundled common extensions (bold, italic, headings, lists, etc.) |
| `tiptap-markdown` | Markdown serialization/deserialization |