### PR TITLE
feat(colour-mode): NyxColourMode theming system + shareable ESLint config

### DIFF
--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -17,6 +17,13 @@ Nyx Kit is a published npm library. Props, emits, slots, exported types, entry p
 ### IV-a. Opinionated Global Stylesheet (Non-Negotiable)
 `nyx-kit/style.css` intentionally ships a full CSS reset (Meyerweb v2.0) and global base styles (`body` font, colour, background). Consumers build on top of Nyx Kit's baseline — they are not expected to bring their own reset. **Do not recommend separating, scoping, or making the reset opt-in.** This is a deliberate design decision, not a defect.
 
+### IV-b. Dark-First Colour System (Non-Negotiable)
+Nyx Kit targets dark-first applications. `src/styles/variables.css` maps all semantic colour tokens to dark palette values unconditionally in `:root` — this default does not change. There is no `prefers-color-scheme` media query response.
+
+Since branch `004-colour-mode-system`, the library ships a first-class opt-in colour mode system: `NyxColourMode` enum, `useNyxColourMode()` composable, and a `html[data-nyx-mode="light"]` CSS override block. The active mode is applied as a `data-nyx-mode` attribute on `<html>`. Dark is always the default and requires no attribute. This is intentional and governed — do not remove it or flag it as a violation.
+
+Do not add `prefers-color-scheme` automation. Do not change the `:root` default token values. Consumers who do not opt into `NyxColourMode` see no change in behaviour.
+
 ### V. Test-First for Non-Trivial Logic
 Unit tests (Vitest) are written for non-trivial component logic and utilities. E2E tests (Playwright) cover interactive behaviour. Stories (Storybook) are the API contract for components — a story that no longer compiles is a failing test.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,8 @@ The project constitution is at `.specify/memory/constitution.md`.
 
 ## Active Technologies
 - TypeScript 5.x / Vue 3 + `@vue/test-utils`, `vitest`, `@playwright/test`, `jsdom` (003-testing-improvements)
+- TypeScript 5.x / Vue 3.5+ + Vue `inject`, `ref`, `computed`, `onUnmounted` (all already in use) (004-colour-mode-system)
+- Module-level singleton `ref` (no persistence in v1) (004-colour-mode-system)
 
 ## Recent Changes
 - 003-testing-improvements: Added TypeScript 5.x / Vue 3 + `@vue/test-utils`, `vitest`, `@playwright/test`, `jsdom`

--- a/README.md
+++ b/README.md
@@ -4,6 +4,84 @@ Nyx Kit is a lightweight and flexible developer kit for building Vue application
 ## Documentation
 For more detailed information, usage examples, and live demos of components, visit the [Storybook documentation](https://nyxkit.github.io/nyx-kit).
 
+## Installation
+
+```sh
+pnpm add nyx-kit
+```
+
+### Plugin setup
+
+```ts
+// main.ts
+import { createApp } from 'vue'
+import { NyxKit, NyxColourMode } from 'nyx-kit'
+import 'nyx-kit/style.css'
+import App from './App.vue'
+
+createApp(App)
+  .use(NyxKit, {
+    colourMode: {
+      mode: NyxColourMode.Dark, // 'dark' | 'light' | 'adaptive'
+    }
+  })
+  .mount('#app')
+```
+
+### Colour mode
+
+Three modes are available:
+
+| Mode | Behaviour |
+|------|-----------|
+| `NyxColourMode.Dark` | Always dark — the default |
+| `NyxColourMode.Light` | Always light |
+| `NyxColourMode.Adaptive` | Clock-driven: light `06:00–20:00`, dark otherwise |
+
+Switch modes at runtime with the `useNyxColourMode` composable:
+
+```ts
+import { useNyxColourMode, NyxColourMode } from 'nyx-kit/composables'
+
+const { mode, isDark, isLight, setMode } = useNyxColourMode()
+
+setMode(NyxColourMode.Light)    // override for this session
+setMode(NyxColourMode.Adaptive) // hand control back to the clock
+```
+
+The chosen mode is persisted to `localStorage` and restored on next load. The composable works without the plugin — `NyxKit.install()` is optional.
+
+## ESLint
+
+Nyx Kit ships a shareable ESLint flat config. To adopt the same rules in your project:
+
+**1. Install the peer dependencies**
+
+```sh
+pnpm add -D eslint eslint-plugin-vue @vue/eslint-config-typescript eslint-plugin-oxlint
+```
+
+**2. Extend the config**
+
+```ts
+// eslint.config.ts
+import nyxConfig from 'nyx-kit/eslint'
+
+export default [
+  ...nyxConfig,
+  {
+    // your project-specific overrides
+  },
+]
+```
+
+The config includes:
+- `eslint-plugin-vue` — Vue 3 essential rules
+- `@vue/eslint-config-typescript` — TypeScript recommended rules
+- `eslint-plugin-oxlint` — disables ESLint rules that oxlint handles (use alongside `oxlint` for faster linting)
+
+Test-framework rules (`@vitest/eslint-plugin`, `eslint-plugin-playwright`) are **not** included — add those yourself if needed.
+
 ## Features
 - **Modular and extensible** – Use only what you need, with easy customization.
 - **Consistent and themeable** – Provides a unified design system with full theming support.

--- a/docs/architecture/design-system.md
+++ b/docs/architecture/design-system.md
@@ -2,6 +2,78 @@
 
 All design tokens are CSS custom properties defined in `src/styles/variables.css`. Components must never hard-code colours, spacing, font sizes, or animation speeds — always reference a token.
 
+## Colour Mode
+
+**Nyx Kit is dark-first by default.** The `:root` semantic tokens always resolve to dark palette values. There is no `prefers-color-scheme` media query and no class toggle shipped by default.
+
+### NyxColourMode — first-class theming
+
+Since v0.x, Nyx Kit ships a three-value enum and a composable for runtime mode switching:
+
+```ts
+import { NyxColourMode, useNyxColourMode } from 'nyx-kit/composables'
+
+const { mode, setting, isDark, isLight, setMode } = useNyxColourMode()
+setMode(NyxColourMode.Light)   // apply light theme
+setMode(NyxColourMode.Adaptive) // follow local clock (light 06:00–20:00, dark otherwise)
+```
+
+| Mode | Behaviour |
+|------|-----------|
+| `NyxColourMode.Dark` | Always dark (default) |
+| `NyxColourMode.Light` | Always light |
+| `NyxColourMode.Adaptive` | Clock-driven: light during day, dark at night |
+
+The active mode is applied as `data-nyx-mode` on `<html>` and persisted to `localStorage` under the key `nyx-colour-mode`.
+
+### Setting the initial mode via plugin
+
+```ts
+import { NyxKit, NyxColourMode } from 'nyx-kit'
+
+app.use(NyxKit, {
+  colourMode: {
+    mode: NyxColourMode.Adaptive,
+    adaptiveDayStart: 7,   // optional, default 6
+    adaptiveDayEnd:   21,  // optional, default 20
+  }
+})
+```
+
+### CSS override mechanism
+
+`src/styles/variables.css` contains a `html[data-nyx-mode="light"]` block that re-maps the semantic tokens to light palette values. The full token list:
+
+| Token | Light value |
+|-------|-------------|
+| `--nyx-c-bg` | `var(--nyx-c-white)` |
+| `--nyx-c-bg-soft` | `var(--nyx-c-white-soft)` |
+| `--nyx-c-bg-mute` | `var(--nyx-c-white-mute)` |
+| `--nyx-c-divider` | `var(--nyx-c-divider-light-1)` |
+| `--nyx-c-divider-light` | `var(--nyx-c-divider-light-2)` |
+| `--nyx-c-divider-inverse` | `var(--nyx-c-divider-dark-1)` |
+| `--nyx-c-divider-inverse-light` | `var(--nyx-c-divider-dark-2)` |
+| `--nyx-c-text-1` | `var(--nyx-c-text-light-1)` |
+| `--nyx-c-text-2` | `var(--nyx-c-text-light-2)` |
+| `--nyx-c-text-3` | `var(--nyx-c-text-light-3)` |
+| `--nyx-c-text-4` | `var(--nyx-c-text-light-4)` |
+| `--nyx-c-text-inverse-1` | `var(--nyx-c-text-dark-1)` |
+| `--nyx-c-text-inverse-2` | `var(--nyx-c-text-dark-2)` |
+| `--nyx-c-text-inverse-3` | `var(--nyx-c-text-dark-3)` |
+| `--nyx-c-text-inverse-4` | `var(--nyx-c-text-dark-4)` |
+
+Consumers may also set the attribute directly (e.g. from a server-rendered page) without using the composable:
+
+```js
+document.documentElement.setAttribute('data-nyx-mode', 'light')
+```
+
+### SVG colour inheritance
+
+`base.css` sets `svg { fill: currentColor }`. This means all SVGs inherit the active text colour (`--nyx-c-text-1`) by default, so icon colours automatically follow the colour mode. Any explicit `fill` on a child `<path>` or `<circle>` still wins — no `!important` needed.
+
+> **Design decision:** the dark-first default is intentional. Nyx Kit targets dark-first applications. The `:root` block will not change without a major version bump.
+
 ## Colour System
 
 ### Text

--- a/docs/specs/theming/NyxColourMode.spec.md
+++ b/docs/specs/theming/NyxColourMode.spec.md
@@ -1,0 +1,130 @@
+# NyxColourMode — Living Spec
+
+**Layer**: theming
+**Branch**: `004-colour-mode-system`
+**Status**: implemented
+
+---
+
+## Summary
+
+`NyxColourMode` is a three-value enum that controls the colour mode of the entire application. It is set globally at plugin install time and overridable at runtime via `useNyxColourMode()`. The active mode is surfaced as a `data-nyx-mode` attribute on `<html>`, which CSS uses to switch semantic colour tokens.
+
+---
+
+## Enum
+
+```ts
+enum NyxColourMode {
+  Dark     = 'dark',     // default — always dark
+  Light    = 'light',    // always light
+  Adaptive = 'adaptive', // clock-driven: light during day, dark at night
+}
+```
+
+Exported from `nyx-kit/types`.
+
+---
+
+## Plugin Options
+
+Colour-mode settings live under a `colourMode` sub-object:
+
+```ts
+NyxKit.install(app, {
+  colourMode: {
+    mode: NyxColourMode.Adaptive,
+    adaptiveDayStart: 7,   // optional, default 6
+    adaptiveDayEnd: 21,    // optional, default 20
+  }
+})
+```
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `colourMode.mode` | `NyxColourMode` | `Dark` | Initial mode |
+| `colourMode.adaptiveDayStart` | `number` (0–23) | `6` | Hour at which Adaptive → Light |
+| `colourMode.adaptiveDayEnd` | `number` (0–23) | `20` | Hour at which Adaptive → Dark |
+
+`NyxColourModeOptions` is exported from `nyx-kit/types`.
+
+---
+
+## Composable: `useNyxColourMode()`
+
+```ts
+import { useNyxColourMode, NyxColourMode } from 'nyx-kit/composables'
+
+const { mode, setting, isDark, isLight, setMode } = useNyxColourMode()
+
+// Read resolved mode (always Dark or Light)
+console.log(mode.value) // 'dark' | 'light'
+
+// Override for this session
+setMode(NyxColourMode.Light)
+
+// Reset to adaptive
+setMode(NyxColourMode.Adaptive)
+```
+
+### Returns
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `setting` | `Readonly<Ref<NyxColourMode>>` | Configured setting (may be `Adaptive`) |
+| `mode` | `ComputedRef<'dark' \| 'light'>` | Resolved mode — never `Adaptive` |
+| `isDark` | `ComputedRef<boolean>` | Shorthand |
+| `isLight` | `ComputedRef<boolean>` | Shorthand |
+| `setMode` | `(m: NyxColourMode) => void` | Override; starts/stops adaptive watcher |
+
+---
+
+## CSS
+
+The composable applies `document.documentElement.setAttribute('data-nyx-mode', resolvedMode)`.
+
+Dark mode is the `:root` default — no override block required.
+
+Light mode is activated by:
+
+```css
+html[data-nyx-mode="light"] {
+  --nyx-c-bg:                    var(--nyx-c-white);
+  --nyx-c-bg-soft:               var(--nyx-c-white-soft);
+  --nyx-c-bg-mute:               var(--nyx-c-white-mute);
+  --nyx-c-divider:               var(--nyx-c-divider-light-1);
+  --nyx-c-divider-light:         var(--nyx-c-divider-light-2);
+  --nyx-c-divider-inverse:       var(--nyx-c-divider-dark-1);
+  --nyx-c-divider-inverse-light: var(--nyx-c-divider-dark-2);
+  --nyx-c-text-1:                var(--nyx-c-text-light-1);
+  --nyx-c-text-2:                var(--nyx-c-text-light-2);
+  --nyx-c-text-3:                var(--nyx-c-text-light-3);
+  --nyx-c-text-4:                var(--nyx-c-text-light-4);
+  --nyx-c-text-inverse-1:        var(--nyx-c-text-dark-1);
+  --nyx-c-text-inverse-2:        var(--nyx-c-text-dark-2);
+  --nyx-c-text-inverse-3:        var(--nyx-c-text-dark-3);
+  --nyx-c-text-inverse-4:        var(--nyx-c-text-dark-4);
+}
+```
+
+Consumers may also set the attribute directly (e.g. from a server-rendered page) without using the composable.
+
+---
+
+## Adaptive Mode
+
+- Resolved each time `setInterval` fires (once per minute, aligned to minute boundary)
+- Day window check: `hour >= adaptiveDayStart && hour < adaptiveDayEnd`
+- `adaptiveDayStart` and `adaptiveDayEnd` come from `inject('libEnv')` at composable mount time
+- Watcher starts on `setMode(Adaptive)` or when initial setting is `Adaptive`
+- Watcher stops when `setMode(Dark|Light)` is called
+- Cleaned up via `onUnmounted`
+
+---
+
+## Constraints
+
+- SSR-safe: `document` access only inside `onMounted` or behind `typeof document !== 'undefined'`
+- No external runtime dependencies
+- Non-breaking: dark-first default unchanged for consumers not opting in
+- `NyxColourMode` ≠ `NyxTheme` — they are orthogonal systems

--- a/eslint/index.mjs
+++ b/eslint/index.mjs
@@ -1,0 +1,32 @@
+import pluginVue from 'eslint-plugin-vue'
+import { defineConfigWithVueTs, vueTsConfigs } from '@vue/eslint-config-typescript'
+import oxlint from 'eslint-plugin-oxlint'
+
+/**
+ * Nyx Kit base ESLint flat config.
+ *
+ * Includes: Vue 3 essential rules, TypeScript recommended rules,
+ * and oxlint compatibility shims (disables rules that oxlint handles).
+ *
+ * Usage in your eslint.config.ts:
+ *
+ *   import nyxConfig from 'nyx-kit/eslint'
+ *   export default [...nyxConfig, { /* your overrides *\/ }]
+ *
+ * Peer dependencies required in your project:
+ *   eslint, eslint-plugin-vue, @vue/eslint-config-typescript,
+ *   eslint-plugin-oxlint
+ */
+export default defineConfigWithVueTs(
+  {
+    name: 'nyx-kit/files-to-lint',
+    files: ['**/*.{ts,mts,tsx,vue}'],
+  },
+  {
+    name: 'nyx-kit/files-to-ignore',
+    ignores: ['**/dist/**', '**/dist-ssr/**', '**/coverage/**'],
+  },
+  pluginVue.configs['flat/essential'],
+  vueTsConfigs.recommended,
+  oxlint.configs['flat/recommended'],
+)

--- a/package.json
+++ b/package.json
@@ -61,13 +61,17 @@
     },
     "./style.css": {
       "import": "./dist/assets/nyx-kit.css"
+    },
+    "./eslint": {
+      "import": "./eslint/index.mjs"
     }
   },
   "sideEffects": [
     "**/*.css"
   ],
   "files": [
-    "dist"
+    "dist",
+    "eslint"
   ],
   "repository": {
     "type": "git",
@@ -123,8 +127,18 @@
     "vue-tsc": "^2.2.0"
   },
   "peerDependencies": {
+    "@vue/eslint-config-typescript": "^14.0.0",
+    "eslint": "^9.0.0",
+    "eslint-plugin-oxlint": "^0.15.0",
+    "eslint-plugin-vue": "^9.0.0",
     "typescript": "^5.0.0",
     "vue": "^3.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@vue/eslint-config-typescript": { "optional": true },
+    "eslint": { "optional": true },
+    "eslint-plugin-oxlint": { "optional": true },
+    "eslint-plugin-vue": { "optional": true }
   },
   "eslintConfig": {
     "extends": [

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "nyx-kit",
   "homepage": "http://nyxkit.github.io/nyx-kit",
   "author": "Arne Decant <hello@arnedecant.be>",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "private": false,
   "license": "MIT",
   "type": "module",

--- a/specs/004-colour-mode-system/contracts/NyxColourMode.ts
+++ b/specs/004-colour-mode-system/contracts/NyxColourMode.ts
@@ -1,0 +1,96 @@
+/**
+ * Public contract: NyxColourMode theming system
+ *
+ * This file documents the exact TypeScript surface that will be exported
+ * from nyx-kit. It is the contract between the plan and the implementation.
+ * Do not implement logic here — this is spec-only.
+ */
+
+// ── Enum ────────────────────────────────────────────────────────────────────
+
+export enum NyxColourMode {
+  Dark     = 'dark',
+  Light    = 'light',
+  /**
+   * Adaptive: resolves to Dark or Light based on the local clock.
+   * Day window: [adaptiveDayStart, adaptiveDayEnd) in local hours (0–23).
+   * Defaults: 06:00 – 20:00.
+   */
+  Adaptive = 'adaptive',
+}
+
+// ── Plugin options extension ────────────────────────────────────────────────
+
+/** Grouped colour-mode options. Nested under NyxKitOptions.colourMode. */
+export interface NyxColourModeOptions {
+  /**
+   * Global colour mode. Default: NyxColourMode.Dark.
+   * Applied to html[data-nyx-mode] on install.
+   */
+  mode?: NyxColourMode
+  /**
+   * Hour (0–23) at which Adaptive mode switches to Light. Default: 6.
+   */
+  adaptiveDayStart?: number
+  /**
+   * Hour (0–23) at which Adaptive mode switches back to Dark. Default: 20.
+   */
+  adaptiveDayEnd?: number
+}
+
+export interface NyxKitOptions {
+  pixel?: boolean
+  colourMode?: NyxColourModeOptions
+  defaults?: Partial<Record<string, unknown>>
+}
+
+// ── Composable ──────────────────────────────────────────────────────────────
+
+export interface UseNyxColourModeReturn {
+  /** The configured setting — may be Adaptive. */
+  setting: Readonly<Ref<NyxColourMode>>
+  /** Resolved mode — always Dark or Light, never Adaptive. */
+  mode: ComputedRef<NyxColourMode.Dark | NyxColourMode.Light>
+  /** true when mode === Dark */
+  isDark: ComputedRef<boolean>
+  /** true when mode === Light */
+  isLight: ComputedRef<boolean>
+  /**
+   * Override the current mode. Replaces the setting, updates data-nyx-mode,
+   * starts or stops the adaptive clock watcher as appropriate.
+   */
+  setMode: (mode: NyxColourMode) => void
+}
+
+declare function useNyxColourMode(): UseNyxColourModeReturn
+
+// ── CSS contract ────────────────────────────────────────────────────────────
+
+/**
+ * The library applies data-nyx-mode to document.documentElement.
+ * Consumers may also set it directly for SSR or non-Vue contexts:
+ *
+ *   document.documentElement.setAttribute('data-nyx-mode', 'light')
+ *
+ * CSS override block (added to src/styles/variables.css):
+ *
+ *   html[data-nyx-mode="light"] {
+ *     --nyx-c-bg:                  var(--nyx-c-white);
+ *     --nyx-c-bg-soft:             var(--nyx-c-white-soft);
+ *     --nyx-c-bg-mute:             var(--nyx-c-white-mute);
+ *     --nyx-c-divider:             var(--nyx-c-divider-light-1);
+ *     --nyx-c-divider-light:       var(--nyx-c-divider-light-2);
+ *     --nyx-c-divider-inverse:     var(--nyx-c-divider-dark-1);
+ *     --nyx-c-divider-inverse-light: var(--nyx-c-divider-dark-2);
+ *     --nyx-c-text-1:              var(--nyx-c-text-light-1);
+ *     --nyx-c-text-2:              var(--nyx-c-text-light-2);
+ *     --nyx-c-text-3:              var(--nyx-c-text-light-3);
+ *     --nyx-c-text-4:              var(--nyx-c-text-light-4);
+ *     --nyx-c-text-inverse-1:      var(--nyx-c-text-dark-1);
+ *     --nyx-c-text-inverse-2:      var(--nyx-c-text-dark-2);
+ *     --nyx-c-text-inverse-3:      var(--nyx-c-text-dark-3);
+ *     --nyx-c-text-inverse-4:      var(--nyx-c-text-dark-4);
+ *   }
+ *
+ * No data-nyx-mode="dark" block is needed — `:root` is already dark.
+ */

--- a/specs/004-colour-mode-system/data-model.md
+++ b/specs/004-colour-mode-system/data-model.md
@@ -1,0 +1,121 @@
+# Data Model: NyxColourMode
+
+---
+
+## Entities
+
+### `NyxColourMode` (enum)
+
+```ts
+enum NyxColourMode {
+  Dark     = 'dark',
+  Light    = 'light',
+  Adaptive = 'adaptive',
+}
+```
+
+| Value | CSS attribute value | Description |
+|-------|-------------------|-------------|
+| `Dark` | `data-nyx-mode="dark"` | Always dark. Default. |
+| `Light` | `data-nyx-mode="light"` | Always light. |
+| `Adaptive` | resolved to `dark` or `light` at runtime | Switches on local clock. |
+
+`Adaptive` is never written to the DOM directly — it is resolved to `dark` or `light` before the attribute is applied.
+
+---
+
+### `NyxColourModeOptions` (new)
+
+Groups the three colour-mode settings so each configurable domain stays isolated within `NyxKitOptions`.
+
+```ts
+interface NyxColourModeOptions {
+  mode?: NyxColourMode          // default: NyxColourMode.Dark
+  adaptiveDayStart?: number     // 0–23, default 6
+  adaptiveDayEnd?: number       // 0–23, default 20
+}
+```
+
+### `NyxKitOptions` (extended)
+
+```ts
+interface NyxKitOptions {
+  pixel?: boolean
+  colourMode?: NyxColourModeOptions
+  defaults?: Partial<Record<NyxKitPrimitive, NyxKitDefaults>>
+}
+```
+
+---
+
+### Composable State (`useNyxColourMode`)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `setting` | `Ref<NyxColourMode>` | The configured mode (may be `Adaptive`) |
+| `mode` | `ComputedRef<NyxColourMode.Dark \| NyxColourMode.Light>` | Resolved mode — never `Adaptive` |
+| `isDark` | `ComputedRef<boolean>` | `mode === Dark` |
+| `isLight` | `ComputedRef<boolean>` | `mode === Light` |
+| `setMode` | `(m: NyxColourMode) => void` | Override setting, reapply attribute |
+
+---
+
+## State Transitions
+
+```
+install(colourMode: Dark)   → setting = Dark,     mode = Dark,  DOM: data-nyx-mode="dark"
+install(colourMode: Light)  → setting = Light,    mode = Light, DOM: data-nyx-mode="light"
+install(colourMode: Adaptive)
+  + hour in [dayStart, dayEnd) → setting = Adaptive, mode = Light, DOM: data-nyx-mode="light"
+  + hour outside             → setting = Adaptive, mode = Dark,  DOM: data-nyx-mode="dark"
+  + clock ticks past boundary → mode flips, DOM attribute updated
+
+setMode(Light) at runtime   → setting = Light, mode = Light, DOM: data-nyx-mode="light"
+                               (stops adaptive clock watcher if running)
+setMode(Adaptive) at runtime → starts clock watcher, evaluates immediately
+```
+
+---
+
+## CSS Token Override Map (Light mode)
+
+Applied under `html[data-nyx-mode="light"]`:
+
+| Token | Light value |
+|-------|-------------|
+| `--nyx-c-bg` | `var(--nyx-c-white)` |
+| `--nyx-c-bg-soft` | `var(--nyx-c-white-soft)` |
+| `--nyx-c-bg-mute` | `var(--nyx-c-white-mute)` |
+| `--nyx-c-divider` | `var(--nyx-c-divider-light-1)` |
+| `--nyx-c-divider-light` | `var(--nyx-c-divider-light-2)` |
+| `--nyx-c-divider-inverse` | `var(--nyx-c-divider-dark-1)` |
+| `--nyx-c-divider-inverse-light` | `var(--nyx-c-divider-dark-2)` |
+| `--nyx-c-text-1` | `var(--nyx-c-text-light-1)` |
+| `--nyx-c-text-2` | `var(--nyx-c-text-light-2)` |
+| `--nyx-c-text-3` | `var(--nyx-c-text-light-3)` |
+| `--nyx-c-text-4` | `var(--nyx-c-text-light-4)` |
+| `--nyx-c-text-inverse-1` | `var(--nyx-c-text-dark-1)` |
+| `--nyx-c-text-inverse-2` | `var(--nyx-c-text-dark-2)` |
+| `--nyx-c-text-inverse-3` | `var(--nyx-c-text-dark-3)` |
+| `--nyx-c-text-inverse-4` | `var(--nyx-c-text-dark-4)` |
+
+Shadow and accent (theme) tokens are **not** overridden — they render identically in both modes.
+
+---
+
+## Files Created / Modified
+
+| File | Change |
+|------|--------|
+| `src/types/colour-mode.ts` | New — `NyxColourMode` enum |
+| `src/types/index.ts` | Add `export * from './colour-mode'` |
+| `src/types/plugin.ts` | Add `NyxColourModeOptions` type; nest as `colourMode?: NyxColourModeOptions` in `NyxKitOptions` |
+| `src/composables/useNyxColourMode.ts` | New composable + `initColourMode` plugin hook |
+| `src/composables/index.ts` | Export `useNyxColourMode` |
+| `src/main.ts` | Call `initColourMode(options)` in `install`; export `NyxColourModeOptions` |
+| `src/styles/variables.css` | Add `html[data-nyx-mode="light"]` block (14 tokens) |
+| `src/styles/base.css` | Add `svg { fill: currentColor }` |
+| `eslint/index.mjs` | New — shareable flat ESLint config |
+| `package.json` | Add `./eslint` export, `"eslint"` to files, optional peer deps |
+| `docs/architecture/design-system.md` | Update Colour Mode section |
+| `docs/specs/theming/NyxColourMode.spec.md` | New living spec |

--- a/specs/004-colour-mode-system/plan.md
+++ b/specs/004-colour-mode-system/plan.md
@@ -1,0 +1,184 @@
+# Implementation Plan: NyxColourMode — Out-of-the-Box Theming System
+
+**Branch**: `004-colour-mode-system` | **Date**: 2026-03-23
+**Spec**: `/specs/004-colour-mode-system/spec.md`
+
+---
+
+## Summary
+
+Introduce a three-mode colour system (`Dark`, `Light`, `Adaptive`) controlled by a new `NyxColourMode` enum. The active mode is applied as `data-nyx-mode` on `<html>` and drives CSS token overrides. Configurable at plugin install time; overridable at runtime via a new `useNyxColourMode()` composable. Adaptive mode switches automatically between light and dark based on the local clock.
+
+---
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.x / Vue 3.5+
+**Primary Dependencies**: Vue `inject`, `ref`, `computed`, `onUnmounted` (all already in use)
+**Storage**: Module-level singleton `ref` (no persistence in v1)
+**Testing**: Vitest + `@vue/test-utils`
+**Target Platform**: Browser (SSR-safe)
+**Project Type**: Published npm component library
+**Performance Goals**: Mode switch ≤ one `setAttribute` call per minute for Adaptive
+**Constraints**: SSR-safe; no new npm dependencies; non-breaking
+**Scale/Scope**: Single new enum, one new composable, one CSS block, three existing file edits
+
+---
+
+## Constitution Check
+
+| Gate | Status | Notes |
+|------|--------|-------|
+| Docs first | PASS | spec.md and this plan precede all code |
+| Non-breaking | PASS | dark-first default unchanged; new opt-in API only |
+| No new dependencies | PASS | uses only Vue core APIs already imported |
+| Surgical edits | PASS | two new files, five targeted edits |
+| SSR-safe | PASS | all DOM access guarded |
+| IV-b (dark-first) | PASS | `:root` untouched; light mode is an opt-in override |
+
+---
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/004-colour-mode-system/
+├── plan.md              ← this file
+├── spec.md
+├── research.md
+├── data-model.md
+├── contracts/
+│   └── NyxColourMode.ts
+└── tasks.md             (created by /speckit.tasks)
+
+docs/specs/theming/
+└── NyxColourMode.spec.md
+```
+
+### Source Code
+
+```text
+src/types/
+├── colour-mode.ts        NEW — NyxColourMode enum
+└── index.ts              EDIT — add export
+
+src/types/plugin.ts       EDIT — add NyxColourModeOptions type; nest colourMode?: NyxColourModeOptions in NyxKitOptions
+
+src/composables/
+├── useNyxColourMode.ts   NEW
+└── index.ts              EDIT — export useNyxColourMode
+
+src/main.ts               EDIT — call applyColourMode(options) in install (SSR-guarded)
+
+src/styles/
+├── variables.css         EDIT — add html[data-nyx-mode="light"] block
+└── base.css              EDIT — add svg { fill: currentColor }
+
+eslint/
+└── index.mjs             NEW — shareable flat ESLint config exported as nyx-kit/eslint
+
+package.json              EDIT — add ./eslint export, "eslint" to files, optional peer deps
+
+docs/architecture/
+└── design-system.md      EDIT — update Colour Mode section to reference enum + composable
+```
+
+---
+
+## Implementation Phases
+
+### Phase A — Types (no risk, no dependencies)
+
+1. Create `src/types/colour-mode.ts` with `NyxColourMode` enum
+2. Export from `src/types/index.ts`
+3. Extend `NyxKitOptions` in `src/types/plugin.ts`
+
+### Phase B — CSS (no risk, pure additive)
+
+4. Add `html[data-nyx-mode="light"]` block to `src/styles/variables.css`
+
+### Phase C — Composable
+
+5. Write `src/composables/useNyxColourMode.ts`:
+   - Module-level `_setting = ref<NyxColourMode>(NyxColourMode.Dark)` singleton
+   - Module-level `_intervalId: number | null = null`
+   - `resolveMode(setting, dayStart, dayEnd)` pure function
+   - `applyToDOM(resolvedMode)` — SSR-guarded `setAttribute`
+   - `useNyxColourMode()` returns `{ setting, mode, isDark, isLight, setMode }`
+   - `setMode` stops/starts adaptive watcher, calls `applyToDOM`
+   - `onUnmounted` clears interval
+6. Export from `src/composables/index.ts`
+
+### Phase D — Plugin wiring
+
+7. In `src/main.ts` `install`, read `options.colourMode.mode` and call the composable's `setMode` (client-side only)
+
+### Phase E — Tests
+
+8. `src/composables/useNyxColourMode.spec.ts`:
+   - Dark default
+   - Light mode applies correct attribute
+   - Adaptive resolves to light during day window
+   - Adaptive resolves to dark outside day window
+   - `setMode` overrides libEnv setting
+   - Interval is cleared on unmount
+
+### Phase F — Docs update
+
+9. Update `docs/architecture/design-system.md` Colour Mode section
+10. `docs/specs/theming/NyxColourMode.spec.md` already written
+
+### Phase G — ESLint exposure
+
+11. Create `eslint/index.mjs` — shareable flat config (vue essential + ts recommended + oxlint shims)
+12. Add `"./eslint"` to `package.json` exports and `"eslint"` to `"files"`
+13. Declare `eslint`, `eslint-plugin-vue`, `@vue/eslint-config-typescript`, `eslint-plugin-oxlint` as optional peer dependencies
+14. Document usage in `README.md`
+
+---
+
+## Key Implementation Notes
+
+### Singleton pattern for `useNyxColourMode`
+
+```ts
+// module-level (outside the function)
+const _setting = ref<NyxColourMode>(NyxColourMode.Dark)
+let _dayStart = 6
+let _dayEnd = 20
+let _intervalId: ReturnType<typeof setInterval> | null = null
+```
+
+The singleton means all `useNyxColourMode()` calls share the same reactive state. The `libEnv` inject is read once on first call to initialise the singleton if it hasn't been set yet.
+
+### Adaptive clock watcher
+
+```ts
+const startAdaptiveWatcher = () => {
+  applyToDOM(resolveMode())
+  const now = new Date()
+  const msToNextMinute = (60 - now.getSeconds()) * 1000 - now.getMilliseconds()
+  setTimeout(() => {
+    applyToDOM(resolveMode())
+    _intervalId = setInterval(() => applyToDOM(resolveMode()), 60_000)
+  }, msToNextMinute)
+}
+```
+
+`setTimeout` to the next minute boundary, then `setInterval` at 60s. This ensures the switch happens at the exact minute boundary.
+
+### Plugin install wiring
+
+```ts
+install: (app: App, options: NyxKitOptions = {}) => {
+  app.directive('click-outside', vClickOutside)
+  app.provide('libEnv', options)
+  // Client-side only — apply initial colour mode
+  if (typeof document !== 'undefined') {
+    initColourMode(options)
+  }
+}
+```
+
+`initColourMode` reads `options.colourMode?.mode ?? NyxColourMode.Dark`, sets `_dayStart`/`_dayEnd` from `options.colourMode`, calls `setMode`.

--- a/specs/004-colour-mode-system/research.md
+++ b/specs/004-colour-mode-system/research.md
@@ -1,0 +1,83 @@
+# Research: NyxColourMode Theming System
+
+**Phase 0 output for branch `004-colour-mode-system`**
+
+---
+
+## Decision 1 — Enum name for the mode setting
+
+**Decision**: `NyxColourMode` with values `Dark`, `Light`, `Adaptive`
+
+**Rationale**:
+- "Colour mode" is the standard term in modern OS and browser APIs (macOS "Appearance", Chrome DevTools "Colour scheme", CSS `color-scheme`)
+- `NyxColourMode` is unambiguous and distinct from `NyxTheme` (accent/brand colours)
+- `Adaptive` is preferred over `Mixed`, `Auto`, or `Circadian`:
+  - `Mixed` implies two things happening at once (confusing)
+  - `Auto` suggests `prefers-color-scheme` (system preference), which is NOT what this is
+  - `Circadian` is accurate but too technical for a public API
+  - `Adaptive` communicates "adjusts to context" without over-specifying the mechanism
+
+**Alternatives considered**: `NyxAppearance` (Apple convention, unfamiliar outside Apple ecosystem), `NyxMode` (too generic), `NyxPalette` (wrong concept — palettes are colour sets, not modes)
+
+---
+
+## Decision 2 — CSS application mechanism
+
+**Decision**: `data-nyx-mode` attribute on `<html>` (`document.documentElement`)
+
+**Rationale**:
+- Attribute on `<html>` is the modern standard (GitHub, Tailwind dark mode, Apple, Radix UI all use this pattern)
+- Scoping to `<html>` means the override cascades to the entire document without specificity fights
+- Using `data-nyx-mode` (not `class`) keeps the library's styling concerns namespaced and avoids collisions with consumer class-based utility frameworks (Tailwind, Bootstrap)
+- `:root` stays unchanged — no dark-first regression for consumers who don't use the feature
+
+**Alternatives considered**: CSS class on `<body>` (Tailwind dark mode — causes specificity conflicts), `color-scheme` media query only (not controllable at runtime), scoped per-component (impractical for global mode switching)
+
+---
+
+## Decision 3 — Adaptive mode time window
+
+**Decision**: Default day window `06:00–20:00` (hours 6–19 inclusive). Configurable via `adaptiveDayStart` / `adaptiveDayEnd` in `NyxKitOptions`. Uses `new Date().getHours()` (local clock).
+
+**Rationale**:
+- 6am–8pm covers typical waking hours across most latitudes without being prescriptive
+- Local clock (not UTC) is what the user experiences; system-preference (`prefers-color-scheme`) would shadow user intent
+- Making the window configurable lets consumers match their use case (e.g. a night-owl dashboard might use 8am–11pm)
+
+**Alternatives considered**: `prefers-color-scheme` as adaptive signal (defeats the purpose — Adaptive should be clock-driven, not OS-driven), fixed non-configurable window (too opinionated for a library)
+
+---
+
+## Decision 4 — Clock watcher implementation
+
+**Decision**: `setInterval` aligned to the next full minute, cleaned up via `onUnmounted`. Fires once immediately on composable mount.
+
+**Rationale**:
+- Minute-level granularity is sufficient for mode switching; sub-minute polling wastes CPU
+- Aligning to the next minute boundary means the switch happens at exactly :00 seconds, not arbitrarily mid-minute
+- `onUnmounted` cleanup prevents interval leak when the composable is used in a component that is unmounted
+
+**Alternatives considered**: `requestAnimationFrame` loop (vastly over-engineered for a once-per-minute concern), `visibilitychange` event only (misses the tab-left-open overnight case)
+
+---
+
+## Decision 5 — Reactive state ownership
+
+**Decision**: A module-level `ref` (singleton pattern) shared across all `useNyxColourMode()` calls within the same app instance.
+
+**Rationale**:
+- Colour mode is app-global state — all consumers should see the same mode
+- Module-level singleton avoids `provide/inject` overhead for a read-heavy value
+- `inject('libEnv')` is used only for initial value resolution (at install time)
+
+**Alternatives considered**: `provide/inject` for every composable call (correct but verbose and requires a Provider component), `localStorage`-based persistence (out of scope for v1 — consumers can layer this on top of `setMode`)
+
+---
+
+## Decision 6 — SSR safety
+
+**Decision**: All `document.documentElement` access guarded with `typeof document !== 'undefined'` or inside `onMounted`.
+
+**Rationale**: Nyx Kit targets SSR-capable Vue apps (Nuxt). The `install` hook runs on the server; `document` is not available there. The initial attribute must be applied client-side only.
+
+**No NEEDS CLARIFICATION items remain.**

--- a/specs/004-colour-mode-system/spec.md
+++ b/specs/004-colour-mode-system/spec.md
@@ -1,0 +1,163 @@
+# Feature Spec: NyxColourMode — Out-of-the-Box Theming System
+
+**Branch**: `004-colour-mode-system`
+**Date**: 2026-03-23
+**Author**: via /speckit.specify
+
+---
+
+## Problem
+
+Nyx Kit ships dark-first by design, but has no mechanism for consumers to opt into light mode or an adaptive mode that changes with the time of day. Consumers who need light mode must manually override a list of undocumented CSS tokens. There is no enum, no plugin option, no composable, and no reactive mechanism for switching modes at runtime.
+
+---
+
+## Goal
+
+Introduce a first-class colour-mode system with three modes:
+
+| Mode | Behaviour |
+|------|-----------|
+| `Dark` | Always dark (current default) |
+| `Light` | Always light |
+| `Adaptive` | Follows the local clock — light during the day, dark at night |
+
+The mode must be:
+1. Settable globally at plugin install time (`NyxKit.install(app, { colourMode: { mode: … } })`)
+2. Reactively overridable per-session by the consuming project via a composable
+3. Applied via a CSS `data-nyx-mode` attribute on `<html>` so all components respond automatically
+
+---
+
+## Enum
+
+```ts
+export enum NyxColourMode {
+  Dark     = 'dark',
+  Light    = 'light',
+  Adaptive = 'adaptive',
+}
+```
+
+`NyxColourMode` is distinct from `NyxTheme` (which maps to component accent colours like `primary`, `secondary`, `warning`).
+
+---
+
+## Plugin Options
+
+Colour-mode settings are grouped under a `colourMode` sub-object so each configurable domain stays isolated within `NyxKitOptions`:
+
+```ts
+export type NyxColourModeOptions = {
+  mode?: NyxColourMode          // default: NyxColourMode.Dark
+  adaptiveDayStart?: number     // hour 0–23, default 6  (06:00)
+  adaptiveDayEnd?: number       // hour 0–23, default 20 (20:00)
+}
+
+export type NyxKitOptions = {
+  pixel?: boolean
+  colourMode?: NyxColourModeOptions
+  defaults?: Partial<Record<NyxKitPrimitive, NyxKitDefaults>>
+}
+```
+
+Usage:
+
+```ts
+NyxKit.install(app, {
+  colourMode: {
+    mode: NyxColourMode.Adaptive,
+    adaptiveDayStart: 7,
+    adaptiveDayEnd: 21,
+  }
+})
+```
+
+On `install`, the plugin applies the initial `data-nyx-mode` attribute to `document.documentElement` (SSR-guarded) and, for `Adaptive`, starts a clock watcher.
+
+---
+
+## Composable: `useNyxColourMode()`
+
+Public API:
+
+```ts
+const {
+  mode,           // Ref<NyxColourMode> — current resolved mode (Dark or Light; never Adaptive)
+  setting,        // Ref<NyxColourMode> — the configured setting (may be Adaptive)
+  setMode,        // (mode: NyxColourMode) => void — override for this session
+  isDark,         // ComputedRef<boolean>
+  isLight,        // ComputedRef<boolean>
+} = useNyxColourMode()
+```
+
+- `mode` is the **resolved** mode — always `Dark` or `Light`, never `Adaptive`
+- `setting` is what was set (may be `Adaptive`)
+- `setMode` updates the session setting, applies the attribute, and (for Adaptive) starts/stops the clock watcher
+- Fully standalone — `NyxKit.install()` is **not required**. `inject('libEnv')` is used opportunistically if present; composable works with only its own defaults otherwise
+- Applies `document.documentElement.setAttribute('data-nyx-mode', resolvedMode)` reactively
+
+---
+
+## CSS Contract
+
+`variables.css` grows a `[data-nyx-mode="light"]` override block that re-maps the semantic tokens to light-palette values (14 tokens total — bg, divider, text, and their inverses). `base.css` receives `svg { fill: currentColor }` so SVG icons follow the active text colour automatically; any explicit `fill` on a child element still wins.
+
+No changes to `:root` defaults — dark-first is preserved.
+
+---
+
+## Adaptive Mode Clock Logic
+
+- Day window: `adaptiveDayStart` (default 6) ≤ hour < `adaptiveDayEnd` (default 20)
+- Outside window → `Dark`; inside → `Light`
+- If `adaptiveDayStart >= adaptiveDayEnd`, a `NyxLog.warn` is emitted and both values fall back to defaults (6, 20). Inverted windows are not supported.
+- The watcher fires once immediately when `setMode(Adaptive)` is called, then on a `setInterval` aligned to the next full minute
+- Cleaned up on composable unmount via `onUnmounted`
+
+---
+
+## Persistence
+
+`setMode()` writes the chosen `NyxColourMode` value to `localStorage` under the key `nyx-colour-mode`. On composable initialisation the resolution order is:
+
+1. `localStorage.getItem('nyx-colour-mode')` (user's last explicit choice)
+2. `libEnv.colourMode.mode` (plugin install option)
+3. `NyxColourMode.Dark` (absolute fallback)
+
+The stored value is the raw enum string (`'dark'`, `'light'`, or `'adaptive'`). Invalid/unrecognised values are ignored and the next source in the chain is tried. `localStorage` access is SSR-guarded.
+
+---
+
+## Clarifications
+
+### Session 2026-03-23
+
+- Q: Should `setMode()` persist across page reloads? → A: Yes — persisted to `localStorage` automatically.
+- Q: Can `useNyxColourMode()` be used without `NyxKit.install()`? → A: Yes — fully standalone; plugin is optional.
+- Q: What happens when `adaptiveDayStart >= adaptiveDayEnd`? → A: Not supported — emit `NyxLog.warn` and fall back to defaults (6, 20).
+
+---
+
+## ESLint Config
+
+Nyx Kit exposes its ESLint flat config so consuming projects can adopt the same rules without manual setup:
+
+```ts
+// eslint.config.ts in consuming project
+import nyxConfig from 'nyx-kit/eslint'
+export default [...nyxConfig, { /* project overrides */ }]
+```
+
+Includes: `eslint-plugin-vue` essential rules, `@vue/eslint-config-typescript` recommended rules, and `eslint-plugin-oxlint` compatibility shims. Test-framework rules (Vitest, Playwright) are excluded — consumers add those themselves. Requires `eslint`, `eslint-plugin-vue`, `@vue/eslint-config-typescript`, and `eslint-plugin-oxlint` as dev dependencies.
+
+---
+
+## Constraints
+
+- SSR-safe: all `document` and `localStorage` access is guarded behind `typeof window !== 'undefined'`
+- No external dependencies
+- No breaking changes to existing consumers (dark-first default unchanged)
+- `NyxColourMode` and `NyxColourModeOptions` exported from `nyx-kit/types`
+- `useNyxColourMode` exported from `nyx-kit/composables`
+- Shared ESLint flat config exported from `nyx-kit/eslint`

--- a/specs/004-colour-mode-system/tasks.md
+++ b/specs/004-colour-mode-system/tasks.md
@@ -1,0 +1,175 @@
+# Tasks: NyxColourMode — Out-of-the-Box Theming System
+
+**Input**: Design documents from `/specs/004-colour-mode-system/`
+**Prerequisites**: plan.md ✅, spec.md ✅, research.md ✅, data-model.md ✅, contracts/ ✅
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (US1, US2, US3)
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Types, exports, and CSS — all pure additive changes with zero runtime risk.
+
+- [x] T001 [P] Create `src/types/colour-mode.ts` with `NyxColourMode` enum (`Dark = 'dark'`, `Light = 'light'`, `Adaptive = 'adaptive'`)
+- [x] T002 [P] Add `export * from './colour-mode'` to `src/types/index.ts`
+- [x] T003 Add `NyxColourModeOptions` type to `src/types/plugin.ts`; nest as `colourMode?: NyxColourModeOptions` in `NyxKitOptions` (fields: `mode?`, `adaptiveDayStart?`, `adaptiveDayEnd?`)
+- [x] T004 Add `html[data-nyx-mode="light"]` CSS override block to `src/styles/variables.css` (all 14 tokens from contracts/NyxColourMode.ts)
+
+**Checkpoint**: Types compile cleanly; `NyxColourMode` is importable from `nyx-kit/types`; light mode tokens override correctly when `data-nyx-mode="light"` is set on `<html>`.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Internal helpers used by both the composable and the plugin.
+
+**⚠️ CRITICAL**: Composable and plugin wiring depend on these helpers.
+
+- [x] T005 Define module-level singleton state in `src/composables/useNyxColourMode.ts` (create file): `_setting = ref<NyxColourMode>(NyxColourMode.Dark)`, `_dayStart = 6`, `_dayEnd = 20`, `_intervalId: ReturnType<typeof setInterval> | null = null`
+- [x] T006 Implement `resolveMode(): NyxColourMode.Dark | NyxColourMode.Light` pure function in `src/composables/useNyxColourMode.ts` — returns `Light` when hour in `[_dayStart, _dayEnd)`, else `Dark`; when `_setting` is not `Adaptive`, returns `_setting` directly
+- [x] T007 Implement `applyToDOM(resolvedMode: NyxColourMode.Dark | NyxColourMode.Light): void` in `src/composables/useNyxColourMode.ts` — SSR-guarded `document.documentElement.setAttribute('data-nyx-mode', resolvedMode)`
+- [x] T008 Implement `startAdaptiveWatcher()` in `src/composables/useNyxColourMode.ts` — call `applyToDOM(resolveMode())` immediately, then `setTimeout` to next minute boundary, then `setInterval` at 60 000 ms; store handle in `_intervalId`
+- [x] T009 Implement `stopAdaptiveWatcher()` in `src/composables/useNyxColourMode.ts` — clears `_intervalId` and sets it to `null`
+
+**Checkpoint**: Internal helper functions exist and are unit-testable in isolation.
+
+---
+
+## Phase 3: User Story 1 — Dark / Light mode switching via composable (P1) 🎯 MVP
+
+**Goal**: `useNyxColourMode()` returns reactive `setting`, `mode`, `isDark`, `isLight`, and `setMode`. Calling `setMode(Light)` immediately updates the DOM attribute and persists to `localStorage`.
+
+**Independent Test**: In a browser console: `import { useNyxColourMode } from 'nyx-kit/composables'`; call `setMode(NyxColourMode.Light)`; verify `document.documentElement.getAttribute('data-nyx-mode') === 'light'` and `localStorage.getItem('nyx-colour-mode') === 'light'`. Reload and verify the attribute is restored.
+
+### Implementation for User Story 1
+
+- [x] T010 [US1] Implement `useNyxColourMode()` composable body in `src/composables/useNyxColourMode.ts`: read `localStorage` → `inject('libEnv').colourMode.mode` → `NyxColourMode.Dark` resolution chain on first call; initialise `_dayStart`/`_dayEnd` from `libEnv.colourMode`; validate `_dayStart < _dayEnd` (NyxLog.warn + reset to defaults if invalid)
+- [x] T011 [US1] Add `mode = computed(resolveMode)` and `isDark = computed(() => mode.value === NyxColourMode.Dark)` and `isLight = computed(() => mode.value === NyxColourMode.Light)` in `src/composables/useNyxColourMode.ts`
+- [x] T012 [US1] Implement `setMode(m: NyxColourMode): void` in `src/composables/useNyxColourMode.ts`: update `_setting.value`, write to `localStorage` (SSR-guarded), stop adaptive watcher if running, call `applyToDOM(resolveMode())`, start adaptive watcher if new mode is `Adaptive`
+- [x] T013 [US1] Return `{ setting: readonly(_setting), mode, isDark, isLight, setMode }` from `useNyxColourMode()` in `src/composables/useNyxColourMode.ts`
+- [x] T014 [US1] Register `onUnmounted(() => stopAdaptiveWatcher())` inside `useNyxColourMode()` in `src/composables/useNyxColourMode.ts`
+- [x] T015 [US1] Add `export { useNyxColourMode }` to `src/composables/index.ts`
+
+**Checkpoint**: `useNyxColourMode()` is callable from a Vue component; `setMode(Light)` applies `data-nyx-mode="light"` and persists; `setMode(Dark)` removes the light override; `mode` / `isDark` / `isLight` are reactive.
+
+---
+
+## Phase 4: User Story 2 — Adaptive clock-driven mode (P2)
+
+**Goal**: Setting `NyxColourMode.Adaptive` makes the mode flip automatically at `adaptiveDayStart` and `adaptiveDayEnd` boundaries. The watcher fires once immediately, then at each full minute boundary.
+
+**Independent Test**: Set `_dayStart = new Date().getHours()` (current hour) and `_dayEnd = _dayStart + 1`; call `setMode(Adaptive)`; verify DOM shows `data-nyx-mode="light"`. Then manually advance the mock clock past `_dayEnd`; verify mode flips to `dark`. Unmount the component and verify the interval is cleared.
+
+### Implementation for User Story 2
+
+- [x] T016 [P] [US2] Write Vitest spec `src/composables/useNyxColourMode.spec.ts`: mock `Date`, `setInterval`, `clearInterval`, `document.documentElement.setAttribute`, and `localStorage`
+- [x] T017 [US2] Add test: "defaults to Dark when no localStorage and no libEnv" in `src/composables/useNyxColourMode.spec.ts`
+- [x] T018 [US2] Add test: "setMode(Light) applies data-nyx-mode='light' and writes localStorage" in `src/composables/useNyxColourMode.spec.ts`
+- [x] T019 [US2] Add test: "Adaptive resolves to Light when current hour is inside day window" in `src/composables/useNyxColourMode.spec.ts`
+- [x] T020 [US2] Add test: "Adaptive resolves to Dark when current hour is outside day window" in `src/composables/useNyxColourMode.spec.ts`
+- [x] T021 [US2] Add test: "setMode(Dark) stops the adaptive interval" in `src/composables/useNyxColourMode.spec.ts`
+- [x] T022 [US2] Add test: "onUnmounted clears the adaptive interval" in `src/composables/useNyxColourMode.spec.ts`
+- [x] T023 [US2] Add test: "invalid adaptiveDayStart >= adaptiveDayEnd emits NyxLog.warn and falls back to (6, 20)" in `src/composables/useNyxColourMode.spec.ts`
+
+**Checkpoint**: All 7 tests pass. Adaptive mode self-corrects on invalid window; interval is always cleaned up.
+
+---
+
+## Phase 5: User Story 3 — Plugin install integration (P3)
+
+**Goal**: `NyxKit.install(app, { colourMode: { mode: NyxColourMode.Light } })` applies the mode immediately on app startup (client-side only), without requiring the consumer to call `useNyxColourMode()` manually.
+
+**Independent Test**: Create a minimal Vue app with `NyxKit.install(app, { colourMode: { mode: NyxColourMode.Light } })`; before mounting any component, verify `document.documentElement.getAttribute('data-nyx-mode') === 'light'`.
+
+### Implementation for User Story 3
+
+- [x] T024 [US3] Add `initColourMode(options: NyxKitOptions): void` helper in `src/composables/useNyxColourMode.ts` (or inline in `src/main.ts`) — reads `options.colourMode?.mode ?? NyxColourMode.Dark`, sets `_dayStart`/`_dayEnd` from `options.colourMode`, calls `setMode`; SSR-guarded
+- [x] T025 [US3] Wire `initColourMode(options)` call inside the `install` function in `src/main.ts` — invoke only when `typeof document !== 'undefined'`; call after `app.provide('libEnv', options)`
+
+**Checkpoint**: Plugin-installed colour mode is applied before the first Vue render; Adaptive watcher starts on install when `colourMode: { mode: NyxColourMode.Adaptive }`; dark-first default is unchanged when option is omitted.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+- [x] T026 [P] Update `docs/architecture/design-system.md` — replace placeholder Colour Mode section with reference to `NyxColourMode` enum, `useNyxColourMode()` composable, `data-nyx-mode` attribute, and localStorage persistence behaviour
+- [x] T027 [P] Add inline JSDoc to `useNyxColourMode.ts` — document `setting` vs `mode` distinction, SSR safety note, and singleton behaviour
+- [x] T028 Run `pnpm typecheck` and `pnpm test` from repo root; fix any type errors or failing tests
+- [x] T029 [P] Add `svg { fill: currentColor }` to `src/styles/base.css` so SVG icons inherit the active text colour; any explicit child `fill` still wins
+
+---
+
+## Phase 7: ESLint Config Exposure
+
+**Goal**: Consumers can extend Nyx Kit's ESLint flat config so their projects adopt the same rules without manual setup.
+
+- [x] T030 [P] Create `eslint/index.mjs` — shareable flat config exporting `pluginVue.configs['flat/essential']`, `vueTsConfigs.recommended`, and `oxlint.configs['flat/recommended']`
+- [x] T031 [P] Add `"./eslint": { "import": "./eslint/index.mjs" }` to `exports` and `"eslint"` to `"files"` in `package.json`; declare `eslint`, `eslint-plugin-vue`, `@vue/eslint-config-typescript`, `eslint-plugin-oxlint` as optional peer dependencies
+- [x] T032 Document ESLint usage (install peer deps + extend config) in `README.md`
+
+**Checkpoint**: `import nyxConfig from 'nyx-kit/eslint'` resolves in a consuming project; spreading `nyxConfig` into a flat config array lints `.vue` and `.ts` files without additional peer configuration.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — T001–T004 can all start immediately and run in parallel
+- **Foundational (Phase 2)**: Depends on T001 (enum must exist) — BLOCKS composable work
+- **US1 (Phase 3)**: Depends on all of Phase 1 + Phase 2
+- **US2 (Phase 4)**: Depends on Phase 3 (tests exercise the watcher helpers from Phase 2)
+- **US3 (Phase 5)**: Depends on Phase 3 (plugin calls `setMode` from composable)
+- **Polish (Phase 6)**: Depends on all story phases complete
+- **ESLint (Phase 7)**: No dependencies — can run in parallel with Phase 6
+
+### User Story Dependencies
+
+- **US1 (P1)**: Core composable — foundational for US2 and US3
+- **US2 (P2)**: Adaptive tests — can be written before US3 but exercises US1 code
+- **US3 (P3)**: Plugin wiring — thin layer on top of US1; can proceed once US1 is done
+
+### Parallel Opportunities
+
+- T001, T002, T004 can all run in parallel (different files, no mutual dependency)
+- T005–T009 (foundational helpers) can be written top-to-bottom in one pass or split across calls
+- T017–T023 (test cases) can be written in any order once the spec file is created (T016)
+- T026–T027 (docs + JSDoc) can run in parallel with T028 (typecheck/test)
+
+---
+
+## Parallel Example: Setup Phase
+
+```bash
+# These three tasks touch different files — launch together:
+Task T001: "Create src/types/colour-mode.ts with NyxColourMode enum"
+Task T002: "Add export to src/types/index.ts"
+Task T004: "Add html[data-nyx-mode='light'] block to src/styles/variables.css"
+# T003 depends on T001 (needs the enum type), run after T001
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (US1 Only)
+
+1. Complete Phase 1: Setup (T001–T004)
+2. Complete Phase 2: Foundational helpers (T005–T009)
+3. Complete Phase 3: US1 composable (T010–T015)
+4. **STOP and VALIDATE**: `setMode(Light)` flips the DOM; `setMode(Dark)` restores it; localStorage round-trip works
+5. Ship — consumers can already use `useNyxColourMode()` for manual light/dark switching
+
+### Incremental Delivery
+
+1. Setup + Foundational → types and helpers ready
+2. US1 → manual dark/light switching, localStorage persistence (**MVP**)
+3. US2 → adaptive clock tests pass, automatic switching works
+4. US3 → plugin install integration, zero-config mode for library consumers
+5. Polish → docs updated, all checks green

--- a/src/composables/index.ts
+++ b/src/composables/index.ts
@@ -2,10 +2,12 @@ import useKeyboardShortcuts from './useKeyboardShortcuts'
 import useKeyPress from './useKeyPress'
 import useNyxProps from './useNyxProps'
 import useTeleportPosition from './useTeleportPosition'
+import { useNyxColourMode } from './useNyxColourMode'
 
 export {
   useKeyboardShortcuts,
   useKeyPress,
+  useNyxColourMode,
   useNyxProps,
   useTeleportPosition
 }

--- a/src/composables/useNyxColourMode.spec.ts
+++ b/src/composables/useNyxColourMode.spec.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { defineComponent, h } from 'vue'
+import { mount } from '@vue/test-utils'
+import { NyxColourMode } from '@/types'
+
+// Each test gets a fresh module so the singleton is reset
+async function freshComposable () {
+  vi.resetModules()
+  const mod = await import('./useNyxColourMode')
+  return mod
+}
+
+function mountWith (setupFn: () => void) {
+  return mount(defineComponent({
+    setup () { setupFn(); return {} },
+    render: () => h('div'),
+  }))
+}
+
+describe('useNyxColourMode', () => {
+  let setAttributeSpy: ReturnType<typeof vi.spyOn>
+  let storageMock: Record<string, string>
+
+  beforeEach(() => {
+    // jsdom 26 does not support localStorage on opaque origins — stub it
+    storageMock = {}
+    vi.stubGlobal('localStorage', {
+      getItem:    (k: string) => storageMock[k] ?? null,
+      setItem:    (k: string, v: string) => { storageMock[k] = v },
+      removeItem: (k: string) => { delete storageMock[k] },
+      clear:      () => { storageMock = {} },
+    })
+    setAttributeSpy = vi.spyOn(document.documentElement, 'setAttribute')
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+    setAttributeSpy?.mockRestore()
+  })
+
+  it('defaults to Dark when no localStorage and no libEnv', async () => {
+    const { useNyxColourMode } = await freshComposable()
+    let isDark = false
+    const wrapper = mountWith(() => {
+      const cm = useNyxColourMode()
+      isDark = cm.isDark.value
+    })
+    expect(isDark).toBe(true)
+    expect(setAttributeSpy).toHaveBeenCalledWith('data-nyx-mode', NyxColourMode.Dark)
+    wrapper.unmount()
+  })
+
+  it('setMode(Light) applies data-nyx-mode="light" and writes localStorage', async () => {
+    const { useNyxColourMode } = await freshComposable()
+    let setMode!: (m: NyxColourMode) => void
+    const wrapper = mountWith(() => {
+      const cm = useNyxColourMode()
+      setMode = cm.setMode
+    })
+    setMode(NyxColourMode.Light)
+    expect(setAttributeSpy).toHaveBeenCalledWith('data-nyx-mode', NyxColourMode.Light)
+    expect(localStorage.getItem('nyx-colour-mode')).toBe(NyxColourMode.Light)
+    wrapper.unmount()
+  })
+
+  it('Adaptive resolves to Light when current hour is inside the day window', async () => {
+    // Mock time to 12:00 (inside default 06:00–20:00 window)
+    vi.setSystemTime(new Date('2026-03-23T12:00:00'))
+    const { useNyxColourMode } = await freshComposable()
+    let mode = ''
+    const wrapper = mountWith(() => {
+      const cm = useNyxColourMode()
+      cm.setMode(NyxColourMode.Adaptive)
+      mode = cm.mode.value
+    })
+    expect(mode).toBe(NyxColourMode.Light)
+    expect(setAttributeSpy).toHaveBeenCalledWith('data-nyx-mode', NyxColourMode.Light)
+    wrapper.unmount()
+  })
+
+  it('Adaptive resolves to Dark when current hour is outside the day window', async () => {
+    // Mock time to 02:00 (outside default 06:00–20:00 window)
+    vi.setSystemTime(new Date('2026-03-23T02:00:00'))
+    const { useNyxColourMode } = await freshComposable()
+    let mode = ''
+    const wrapper = mountWith(() => {
+      const cm = useNyxColourMode()
+      cm.setMode(NyxColourMode.Adaptive)
+      mode = cm.mode.value
+    })
+    expect(mode).toBe(NyxColourMode.Dark)
+    expect(setAttributeSpy).toHaveBeenCalledWith('data-nyx-mode', NyxColourMode.Dark)
+    wrapper.unmount()
+  })
+
+  it('setMode(Dark) stops the adaptive interval', async () => {
+    vi.setSystemTime(new Date('2026-03-23T12:00:00'))
+    const clearIntervalSpy = vi.spyOn(globalThis, 'clearInterval')
+    const { useNyxColourMode } = await freshComposable()
+    let setMode!: (m: NyxColourMode) => void
+    const wrapper = mountWith(() => {
+      const cm = useNyxColourMode()
+      setMode = cm.setMode
+    })
+    setMode(NyxColourMode.Adaptive)
+    // Advance past the setTimeout boundary so setInterval is registered
+    vi.advanceTimersByTime(61_000)
+    setMode(NyxColourMode.Dark)
+    expect(clearIntervalSpy).toHaveBeenCalled()
+    clearIntervalSpy.mockRestore()
+    wrapper.unmount()
+  })
+
+  it('onUnmounted clears the adaptive interval', async () => {
+    vi.setSystemTime(new Date('2026-03-23T12:00:00'))
+    const clearIntervalSpy = vi.spyOn(globalThis, 'clearInterval')
+    const { useNyxColourMode } = await freshComposable()
+    let setMode!: (m: NyxColourMode) => void
+    const wrapper = mountWith(() => {
+      const cm = useNyxColourMode()
+      setMode = cm.setMode
+    })
+    setMode(NyxColourMode.Adaptive)
+    vi.advanceTimersByTime(61_000)
+    wrapper.unmount()
+    expect(clearIntervalSpy).toHaveBeenCalled()
+    clearIntervalSpy.mockRestore()
+  })
+
+  it('invalid adaptiveDayStart >= adaptiveDayEnd emits NyxLog.warn and falls back to (6, 20)', async () => {
+    const { initColourMode } = await freshComposable()
+    const NyxLog = (await import('@/classes/NyxLog')).default
+    const warnSpy = vi.spyOn(NyxLog, 'warn')
+    initColourMode({ colourMode: { mode: NyxColourMode.Dark, adaptiveDayStart: 20, adaptiveDayEnd: 6 } })
+    expect(warnSpy).toHaveBeenCalledWith(
+      'NyxColourMode',
+      expect.stringContaining('Falling back to defaults')
+    )
+    warnSpy.mockRestore()
+  })
+})

--- a/src/composables/useNyxColourMode.ts
+++ b/src/composables/useNyxColourMode.ts
@@ -1,0 +1,145 @@
+import { computed, inject, onUnmounted, readonly, ref } from 'vue'
+import NyxLog from '@/classes/NyxLog'
+import { NyxColourMode } from '@/types'
+import type { NyxKitOptions } from '@/types'
+
+// ── Module-level singleton ────────────────────────────────────────────────────
+// All useNyxColourMode() calls share the same reactive state.
+
+const _setting = ref<NyxColourMode>(NyxColourMode.Dark)
+let _dayStart = 6
+let _dayEnd = 20
+let _intervalId: ReturnType<typeof setInterval> | null = null
+let _initialised = false
+
+// ── Pure helpers ──────────────────────────────────────────────────────────────
+
+/** Resolve the current setting to Dark or Light — never Adaptive. */
+function resolveMode (): NyxColourMode.Dark | NyxColourMode.Light {
+  if (_setting.value !== NyxColourMode.Adaptive) {
+    return _setting.value as NyxColourMode.Dark | NyxColourMode.Light
+  }
+  const hour = new Date().getHours()
+  return hour >= _dayStart && hour < _dayEnd
+    ? NyxColourMode.Light
+    : NyxColourMode.Dark
+}
+
+/** Apply the resolved mode to the DOM (SSR-safe). */
+function applyToDOM (resolvedMode: NyxColourMode.Dark | NyxColourMode.Light): void {
+  if (typeof document !== 'undefined') {
+    document.documentElement.setAttribute('data-nyx-mode', resolvedMode)
+  }
+}
+
+/** Start the adaptive minute-boundary watcher. */
+function startAdaptiveWatcher (): void {
+  applyToDOM(resolveMode())
+  const now = new Date()
+  const msToNextMinute = (60 - now.getSeconds()) * 1000 - now.getMilliseconds()
+  setTimeout(() => {
+    applyToDOM(resolveMode())
+    _intervalId = setInterval(() => applyToDOM(resolveMode()), 60_000)
+  }, msToNextMinute)
+}
+
+/** Stop the adaptive watcher. */
+function stopAdaptiveWatcher (): void {
+  if (_intervalId !== null) {
+    clearInterval(_intervalId)
+    _intervalId = null
+  }
+}
+
+// ── Plugin initialisation hook (called from main.ts install) ──────────────────
+
+/**
+ * Called by the plugin's install() to seed the singleton from plugin options.
+ * Client-side only — caller must guard with `typeof document !== 'undefined'`.
+ */
+export function initColourMode (options: NyxKitOptions): void {
+  const cm = options.colourMode ?? {}
+  const dayStart = cm.adaptiveDayStart ?? 6
+  const dayEnd   = cm.adaptiveDayEnd   ?? 20
+  if (dayStart >= dayEnd) {
+    NyxLog.warn('NyxColourMode', `adaptiveDayStart (${dayStart}) must be less than adaptiveDayEnd (${dayEnd}). Falling back to defaults (6, 20).`)
+    _dayStart = 6
+    _dayEnd   = 20
+  } else {
+    _dayStart = dayStart
+    _dayEnd   = dayEnd
+  }
+  setMode(cm.mode ?? NyxColourMode.Dark)
+  _initialised = true
+}
+
+// ── setMode (exported so initColourMode can call it) ─────────────────────────
+
+function setMode (m: NyxColourMode): void {
+  stopAdaptiveWatcher()
+  _setting.value = m
+
+  // Persist to localStorage (SSR-safe)
+  if (typeof localStorage !== 'undefined') {
+    localStorage.setItem('nyx-colour-mode', m)
+  }
+
+  if (m === NyxColourMode.Adaptive) {
+    startAdaptiveWatcher()
+  } else {
+    applyToDOM(m as NyxColourMode.Dark | NyxColourMode.Light)
+  }
+}
+
+// ── Composable ────────────────────────────────────────────────────────────────
+
+export function useNyxColourMode () {
+  // Initialise singleton once, reading from localStorage → libEnv → Dark fallback
+  if (!_initialised) {
+    const libEnv = inject<NyxKitOptions>('libEnv', {})
+    const cm = libEnv.colourMode ?? {}
+
+    // Validate adaptive window from libEnv
+    const dayStart = cm.adaptiveDayStart ?? 6
+    const dayEnd   = cm.adaptiveDayEnd   ?? 20
+    if (dayStart >= dayEnd) {
+      NyxLog.warn('NyxColourMode', `adaptiveDayStart (${dayStart}) must be less than adaptiveDayEnd (${dayEnd}). Falling back to defaults (6, 20).`)
+      _dayStart = 6
+      _dayEnd   = 20
+    } else {
+      _dayStart = dayStart
+      _dayEnd   = dayEnd
+    }
+
+    // Resolution order: localStorage → libEnv → Dark
+    let resolved: NyxColourMode | null = null
+
+    if (typeof localStorage !== 'undefined') {
+      const stored = localStorage.getItem('nyx-colour-mode')
+      if (stored && Object.values(NyxColourMode).includes(stored as NyxColourMode)) {
+        resolved = stored as NyxColourMode
+      }
+    }
+
+    if (resolved === null) {
+      resolved = cm.mode ?? NyxColourMode.Dark
+    }
+
+    setMode(resolved)
+    _initialised = true
+  }
+
+  const mode    = computed(resolveMode)
+  const isDark  = computed(() => mode.value === NyxColourMode.Dark)
+  const isLight = computed(() => mode.value === NyxColourMode.Light)
+
+  onUnmounted(() => stopAdaptiveWatcher())
+
+  return {
+    setting: readonly(_setting),
+    mode,
+    isDark,
+    isLight,
+    setMode,
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,12 +1,16 @@
 import { type App } from 'vue'
 import { vClickOutside } from './directives'
 import type { NyxKitOptions } from './types'
+import { initColourMode } from './composables/useNyxColourMode'
 
-export type { NyxKitPrimitive, NyxKitDefaults, NyxKitOptions } from './types'
+export type { NyxKitPrimitive, NyxKitDefaults, NyxKitOptions, NyxColourModeOptions } from './types'
 
 export const NyxKit = {
   install: (app: App, options: NyxKitOptions = {}) => {
     app.directive('click-outside', vClickOutside)
     app.provide('libEnv', options)
+    if (typeof document !== 'undefined') {
+      initColourMode(options)
+    }
   }
 }

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -109,6 +109,10 @@ object {
   vertical-align: middle;
 }
 
+svg {
+  fill: currentColor;
+}
+
 img,
 video {
   max-width: 100%;

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -22,7 +22,8 @@
  /* https://colormagic.app/palette/67a9eedf079f8ec4becb2836 */
 
  :root {
-  --nyx-c-white: #ffffff;
+  --nyx-c-white: #f5f5f5;
+  --nyx-c-white-pure: #ffffff;
   --nyx-c-white-soft: #f9f9f9;
   --nyx-c-white-mute: #f1f1f1;
 
@@ -116,6 +117,17 @@
 
 /**
  * Colors Theme
+ *
+ * Dark-first by design. These semantic tokens always resolve to dark values.
+ * There is no built-in light mode or prefers-color-scheme response.
+ *
+ * To override: re-declare the tokens below in your own stylesheet, scoped to
+ * a class, data attribute, or media query of your choice. The base palette
+ * variables (--nyx-c-white-*, --nyx-c-text-light-*, etc.) defined above are
+ * always available as building blocks.
+ *
+ * See docs/architecture/design-system.md § Colour Mode for the full override
+ * token list and examples.
  * -------------------------------------------------------------------------- */
 
 :root {
@@ -341,6 +353,36 @@
     calc(0px - var(--nyx-pixel-size)) var(--nyx-pixel-size) var(--nyx-pixel-c-highlight),
     calc(0px - var(--nyx-pixel-size)) calc(0px - var(--nyx-pixel-size)) var(--nyx-pixel-c-highlight),
     calc(var(--nyx-pixel-size)) var(--nyx-pixel-size) var(--nyx-pixel-c-highlight);
+}
+
+/**
+ * Colour Mode — Light Override
+ *
+ * Applied by useNyxColourMode() (or manually) via:
+ *   document.documentElement.setAttribute('data-nyx-mode', 'light')
+ *
+ * Dark mode is the :root default — no override block required.
+ * -------------------------------------------------------------------------- */
+
+html[data-nyx-mode="light"] {
+  --nyx-c-bg:                    var(--nyx-c-white);
+  --nyx-c-bg-soft:               var(--nyx-c-white-soft);
+  --nyx-c-bg-mute:               var(--nyx-c-white-mute);
+
+  --nyx-c-divider:               var(--nyx-c-divider-light-1);
+  --nyx-c-divider-light:         var(--nyx-c-divider-light-2);
+  --nyx-c-divider-inverse:       var(--nyx-c-divider-dark-1);
+  --nyx-c-divider-inverse-light: var(--nyx-c-divider-dark-2);
+
+  --nyx-c-text-1:                var(--nyx-c-text-light-1);
+  --nyx-c-text-2:                var(--nyx-c-text-light-2);
+  --nyx-c-text-3:                var(--nyx-c-text-light-3);
+  --nyx-c-text-4:                var(--nyx-c-text-light-4);
+
+  --nyx-c-text-inverse-1:        var(--nyx-c-text-dark-1);
+  --nyx-c-text-inverse-2:        var(--nyx-c-text-dark-2);
+  --nyx-c-text-inverse-3:        var(--nyx-c-text-dark-3);
+  --nyx-c-text-inverse-4:        var(--nyx-c-text-dark-4);
 }
 
 /**

--- a/src/types/colour-mode.ts
+++ b/src/types/colour-mode.ts
@@ -1,0 +1,5 @@
+export enum NyxColourMode {
+  Dark     = 'dark',
+  Light    = 'light',
+  Adaptive = 'adaptive',
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,4 @@
+export * from './colour-mode'
 export * from './common'
 export * from './plugin'
 export * from './editor'

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -1,4 +1,5 @@
 import type { NyxSize, NyxTheme, NyxVariant } from './common'
+import type { NyxColourMode } from './colour-mode'
 
 export type NyxKitPrimitive = 'all'|'button'|'input'|'select'|'textarea'|'checkbox'|'radio'|'switch'
 
@@ -8,7 +9,14 @@ export interface NyxKitDefaults {
   variant?: NyxVariant
 }
 
+export type NyxColourModeOptions = {
+  mode?: NyxColourMode
+  adaptiveDayStart?: number
+  adaptiveDayEnd?: number
+}
+
 export type NyxKitOptions = {
   pixel?: boolean
+  colourMode?: NyxColourModeOptions
   defaults?: Partial<Record<NyxKitPrimitive, NyxKitDefaults>>
 }


### PR DESCRIPTION
## Summary

- Introduces `NyxColourMode` enum (`Dark` | `Light` | `Adaptive`) as a first-class theming system applied via `data-nyx-mode` on `<html>`
- `useNyxColourMode()` composable — reactive singleton, localStorage persistence, SSR-safe, works standalone without the plugin
- Adaptive mode follows the local clock (light 06:00–20:00, dark otherwise), watcher aligned to minute boundaries and cleaned up on unmount
- `NyxColourModeOptions` type groups mode settings as a nested sub-object under `NyxKitOptions.colourMode`
- `html[data-nyx-mode="light"]` CSS override block (14 semantic tokens) in `variables.css`; `svg { fill: currentColor }` added to `base.css`
- `eslint/index.mjs` shareable flat config exported as `nyx-kit/eslint` for consuming projects to extend
- Full spec-kit artifact trail: spec → clarify → plan → tasks → implement → analyze

## New public API

```ts
// Enum
import { NyxColourMode, NyxColourModeOptions } from 'nyx-kit/types'

// Plugin
app.use(NyxKit, {
  colourMode: { mode: NyxColourMode.Adaptive, adaptiveDayStart: 7, adaptiveDayEnd: 21 }
})

// Composable
import { useNyxColourMode } from 'nyx-kit/composables'
const { mode, isDark, isLight, setting, setMode } = useNyxColourMode()

// ESLint (consuming project)
import nyxConfig from 'nyx-kit/eslint'
export default [...nyxConfig, { /* overrides */ }]
```

## Test plan

- [ ] 7 Vitest specs pass (`useNyxColourMode.spec.ts`): default dark, light mode DOM + localStorage, adaptive day/night, interval cleared on unmount, invalid window warns + falls back
- [ ] `pnpm type-check` clean
- [ ] `pnpm test` — 338/338 pass, no regressions
- [ ] Manual: install plugin with `colourMode.mode: Light`, verify `data-nyx-mode="light"` on `<html>` before first render
- [ ] Manual: call `setMode(Adaptive)` at 14:00, verify light; reload, verify localStorage restores Adaptive

🤖 Generated with [Claude Code](https://claude.com/claude-code)