### PR TITLE
feat(NyxGrid): add grid and masonry layout component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ node_modules
 dist
 dist-ssr
 coverage
+.env*
 *.local
 
 /cypress/videos/
@@ -28,6 +29,7 @@ coverage
 *.sw?
 
 *.tsbuildinfo
+*.tmp
 
 test-results/
 playwright-report/

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,14 @@
+node_modules/
+src/
+docs/
+specs/
+e2e/
+.storybook/
+.opencode/
+.claude/
+coverage/
+test-results/
+playwright-report/
+storybook-static/
+*.log
+.env*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -345,4 +345,4 @@ When you notice that something in the codebase or stories is out of sync, record
 
 | Noticed | Location | Description | Status |
 |---|---|---|---|
-| — | — | No known divergences. | — |
+| 2026-03-26 | `README.md` vs `specs/006-add-nyx-grid/spec.md` | Planned feature naming diverged (`NyxLayout` in README, `NyxGrid` in spec). | Fixed |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,8 @@ The project constitution is at `.specify/memory/constitution.md`.
 - Module-level singleton `ref` (no persistence in v1) (004-colour-mode-system)
 - TypeScript 5.7 / Vue 3.5 + Vue 3 (ref, computed, defineProps, defineEmits, defineModel), SCSS (005-nyx-tree)
 - N/A — all state is local/instance-level (005-nyx-tree)
+- TypeScript 5.7 / Vue 3.5 + Vue 3 (`computed`, `ref`, `useSlots`, `watch`, `nextTick`, lifecycle hooks), SCSS (006-add-nyx-grid)
+- N/A - layout state is ephemeral DOM measurement only (006-add-nyx-grid)
 
 ## Recent Changes
 - 003-testing-improvements: Added TypeScript 5.x / Vue 3 + `@vue/test-utils`, `vitest`, `@playwright/test`, `jsdom`

--- a/README.md
+++ b/README.md
@@ -109,7 +109,6 @@ Test-framework rules (`@vitest/eslint-plugin`, `eslint-plugin-playwright`) are *
 ### New Core Components
 - `NyxDropdown`: A menu for selecting one option from a list.
 - `NyxAccordion`: A collapsible container for displaying content in an expandable/collapsible format.
-- `NyxLayout`: A responsive layout system. Default is "grid".
 - `NyxToast`: A temporary notification popup.
 - `NyxSkeleton`: A placeholder loading animation for components.
 - `NyxRadioGroup`: A set of radio buttons for multiple-choice selection.

--- a/docs/specs/components/NyxGrid.spec.md
+++ b/docs/specs/components/NyxGrid.spec.md
@@ -1,0 +1,80 @@
+# NyxGrid
+
+> A structural layout primitive for arranging arbitrary slotted content in either a standard grid or masonry-style layout, with optional header and footer regions.
+
+## Purpose and scope
+
+`NyxGrid` gives consumers a reusable shell for grouped content layouts such as dashboards, galleries, and card collections. It combines a semantic section wrapper, optional header and footer regions, token-driven item spacing, and switchable layout behavior.
+
+**Use when:**
+- You need a reusable content section with optional header and footer wrappers
+- You want to lay out arbitrary child components in equal-width columns
+- You need a masonry-style arrangement for variable-height content without introducing a separate layout component
+
+**Do not use when:**
+- You need full application-shell layout (`sidebar`, `main`, `aside`, split panes)
+- You need item-level spanning, drag-and-drop, or virtualization
+- You need a data-driven collection component with built-in filtering, sorting, or pagination
+
+## Internal architecture
+
+- `NyxGrid` renders a semantic root `<section>`
+- Header resolution follows the standard slot-first rule: `header` slot first, then `title` fallback
+- Footer is slot-only and omitted entirely when absent
+- The default slot is normalized into internal item wrappers so the component can measure each top-level child and animate reflow
+- A shared layout engine computes positions for both `grid` and `masonry` modes
+- Reflow animation is transform-based and driven by item position deltas rather than external animation libraries
+
+## Props
+
+| Prop | Type | Default | Description |
+|---|---|---|---|
+| `title` | `string` | — | Plain-text header fallback rendered only when no `header` slot is provided |
+| `mode` | `NyxGridMode` | `NyxGridMode.Grid` | Chooses standard row/column placement or masonry compaction |
+| `columns` | `number` | `3` | Positive integer column count used by both modes; invalid values fall back to `3` |
+| `gap` | `NyxSize \| number` | `NyxSize.Medium` | Shared spacing between items; size tokens are scaled up by 1.5x and numeric values are treated as rem units, including `0` for no gap |
+
+## Emits
+
+None.
+
+## Slots
+
+| Slot | Scope | Purpose |
+|---|---|---|
+| `default` | — | Content items to lay out inside the content region |
+| `header` | — | Custom header content; takes precedence over `title` |
+| `footer` | — | Optional footer content rendered after the content region |
+
+## Keyboard behaviour
+
+No component-specific keyboard handling. `NyxGrid` preserves the native keyboard behavior of the slotted child content.
+
+## Accessibility
+
+- Root element is a semantic `<section>`
+- Optional header and footer use semantic `<header>` and `<footer>` elements
+- The component does not override the semantics of slotted children with list or grid ARIA roles
+- Visual item movement must preserve DOM order so assistive technologies continue to read content in source order
+- Motion should respect reduced-motion preferences by minimizing or disabling transform animation where appropriate
+
+## CSS classes
+
+| Class | Applied to | Notes |
+|---|---|---|
+| `.nyx-grid` | root `<section>` | |
+| `.nyx-grid--grid` | root | Applied in standard grid mode |
+| `.nyx-grid--masonry` | root | Applied in masonry mode |
+| `.nyx-grid__header` | optional header wrapper | |
+| `.nyx-grid__title` | fallback title element | |
+| `.nyx-grid__content` | layout stage container | |
+| `.nyx-grid__item` | internal wrapper per top-level child | Enables layout transforms |
+| `.nyx-grid__footer` | optional footer wrapper | |
+
+## Known limitations
+
+- Responsive column presets are out of scope for v1; consumers pass a single column count
+- Item spanning (`grid-column`, `grid-row`) is not supported in v1
+- Virtualization is not supported
+- Reorder animation quality depends on stable keys on top-level slot children
+- Masonry mode preserves DOM order but may not match browser-native masonry implementations exactly

--- a/docs/specs/components/NyxGrid.spec.md
+++ b/docs/specs/components/NyxGrid.spec.md
@@ -22,7 +22,7 @@
 - Header resolution follows the standard slot-first rule: `header` slot first, then `title` fallback
 - Footer is slot-only and omitted entirely when absent
 - The default slot is normalized into internal item wrappers so the component can measure each top-level child and animate reflow
-- A shared layout engine computes positions for both `grid` and `masonry` modes
+- A shared layout engine computes positions for both `grid` and `masonry` modes and applies masonry placement through CSS custom properties rather than broad inline style rules
 - Reflow animation is transform-based and driven by item position deltas rather than external animation libraries
 
 ## Props

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -17,7 +17,7 @@ export default defineConfigWithVueTs(
 
   {
     name: 'app/files-to-ignore',
-    ignores: ['**/dist/**', '**/dist-ssr/**', '**/coverage/**'],
+    ignores: ['**/dist/**', '**/dist-ssr/**', '**/coverage/**', '**/storybook-static/**', '**/playwright-report/**', '**/test-results/**'],
   },
 
   pluginVue.configs['flat/essential'],

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "nyx-kit",
   "homepage": "http://nyxkit.github.io/nyx-kit",
   "author": "Arne Decant <hello@arnedecant.be>",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "private": false,
   "license": "MIT",
   "type": "module",

--- a/specs/006-add-nyx-grid/checklists/requirements.md
+++ b/specs/006-add-nyx-grid/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: NyxGrid Layout Component
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning  
+**Created**: 2026-03-26  
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Validation pass 1: all checklist items pass.
+- Validation pass 2: spec updated to include `columns`; checklist still passes.
+- Naming direction is intentionally captured as an assumption: keep `NyxGrid` for this feature and treat broader layout naming as out of scope unless the feature expands beyond grid and masonry.

--- a/specs/006-add-nyx-grid/contracts/component-api.md
+++ b/specs/006-add-nyx-grid/contracts/component-api.md
@@ -1,0 +1,65 @@
+# Component API Contract: NyxGrid
+
+**Branch**: `006-add-nyx-grid` | **Date**: 2026-03-26
+
+This document defines the public-facing API contract for `NyxGrid` as a published npm library component. Changes to any item below are breaking changes and must be flagged explicitly.
+
+---
+
+## NyxGrid
+
+### Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `title` | `string` | - | Plain-text header fallback when no `header` slot is provided |
+| `mode` | `NyxGridMode` | `NyxGridMode.Grid` | Chooses standard grid placement or masonry compaction |
+| `columns` | `number` | `3` | Positive integer column count used by both grid and masonry; invalid values fall back to `3` |
+| `gap` | `NyxSize \| number` | `NyxSize.Medium` | Shared spacing between items; token values are scaled 1.5x and numbers are treated as rem units |
+
+### Emits
+
+None.
+
+### Slots
+
+| Slot | Scope | Purpose |
+|------|-------|---------|
+| `default` | - | Consumer-provided content items to lay out |
+| `header` | - | Custom header content; takes precedence over `title` |
+| `footer` | - | Optional footer content rendered after the layout stage |
+
+### Structural semantics
+
+| Region | Element | Render rule |
+|--------|---------|-------------|
+| Root | `<section>` | Always rendered |
+| Header | `<header>` | Only when `header` slot exists or `title` is provided |
+| Content | `<div>` | Always rendered |
+| Footer | `<footer>` | Only when `footer` slot exists |
+
+### CSS classes
+
+| Class | Applied to | Notes |
+|-------|-----------|-------|
+| `.nyx-grid` | root `<section>` | |
+| `.nyx-grid__header` | optional header wrapper | |
+| `.nyx-grid__title` | fallback title element | |
+| `.nyx-grid__content` | content stage container | |
+| `.nyx-grid__item` | internal item wrapper around each top-level slotted child | |
+| `.nyx-grid__footer` | optional footer wrapper | |
+| `.nyx-grid--grid` | root when `mode='grid'` | |
+| `.nyx-grid--masonry` | root when `mode='masonry'` | |
+
+### Behavior notes
+
+| Behavior | Contract |
+|----------|----------|
+| Invalid `mode` | Falls back to standard grid behavior |
+| Invalid `columns` | Falls back to `3` |
+| `columns` in masonry | Uses the same column count control as standard grid |
+| Numeric `gap` | Treated as a rem value, including `0` for no gap |
+| Token `gap` | Uses the selected size token scaled up by 1.5x |
+| Empty default slot | Renders an empty content region without placeholder UI |
+| Reorder animation | Supported for keyed top-level slot children |
+| Content semantics | Determined by the consumer's slotted children, not by `NyxGrid` |

--- a/specs/006-add-nyx-grid/data-model.md
+++ b/specs/006-add-nyx-grid/data-model.md
@@ -1,0 +1,142 @@
+# Data Model: NyxGrid
+
+**Branch**: `006-add-nyx-grid` | **Date**: 2026-03-26
+
+---
+
+## Entities
+
+### NyxGridProps
+
+```ts
+interface NyxGridProps {
+  title?: string
+  mode?: 'grid' | 'masonry'
+  columns?: number
+  gap?: NyxSize
+}
+```
+
+- `title` renders only when the `header` slot is absent
+- `mode` defaults to `'grid'`
+- `columns` defaults to `3` after sanitization
+- `gap` defaults to `NyxSize.Medium`
+
+---
+
+### NyxGridMode
+
+```ts
+enum NyxGridMode {
+  Grid = 'grid',
+  Masonry = 'masonry',
+}
+```
+
+- `grid` places items row-by-row into equal-width tracks
+- `masonry` places each next item into the shortest current column
+
+---
+
+### GridRegion
+
+```ts
+type GridRegion = 'header' | 'content' | 'footer'
+```
+
+- `header` is optional
+- `content` is always rendered
+- `footer` is optional
+
+---
+
+### NormalizedGridItem
+
+Internal view-model derived from top-level default-slot VNodes.
+
+```ts
+interface NormalizedGridItem {
+  key: string | number
+  order: number
+  width: number
+  height: number
+  x: number
+  y: number
+}
+```
+
+- `key` comes from `vnode.key` when available; fallback generation is internal only
+- `order` always reflects original slot order
+- `width`, `height`, `x`, and `y` are computed layout values, not public API
+
+---
+
+### LayoutSnapshot
+
+Internal measurement state used to animate reflow.
+
+```ts
+interface LayoutSnapshot {
+  containerHeight: number
+  columns: number
+  gapPx: number
+  items: NormalizedGridItem[]
+}
+```
+
+---
+
+## State Transitions
+
+### Header resolution
+
+```text
+header slot present -> render slot content
+header slot absent + title present -> render title text
+neither present -> omit header wrapper
+```
+
+### Footer resolution
+
+```text
+footer slot present -> render footer wrapper
+footer slot absent  -> omit footer wrapper
+```
+
+### Layout mode resolution
+
+```text
+mode omitted / invalid -> 'grid'
+mode 'grid'           -> row-first column placement
+mode 'masonry'        -> shortest-column placement
+```
+
+### Column resolution
+
+```text
+columns omitted          -> 3
+columns positive integer -> use as-is
+columns invalid          -> 3
+```
+
+### Reflow cycle
+
+```text
+slot items change / container resizes / item height changes
+-> measure rendered items
+-> compute next LayoutSnapshot
+-> animate wrappers from previous positions to next positions
+```
+
+---
+
+## Validation Rules
+
+| Rule | Detail |
+|------|--------|
+| Default slot may be empty | Component still renders the content region |
+| Header slot wins over title | No duplicate title output |
+| Footer is slot-only | No footer prop is supported |
+| Arbitrary child markup is allowed | The component never requires a specific item object shape |
+| Stable top-level keys are recommended | Reorder animation fidelity depends on keyed slot children |
+| DOM order stays stable | Visual layout may reposition items, but source order is unchanged |

--- a/specs/006-add-nyx-grid/plan.md
+++ b/specs/006-add-nyx-grid/plan.md
@@ -1,0 +1,138 @@
+# Implementation Plan: NyxGrid Layout Primitive
+
+**Branch**: `006-add-nyx-grid` | **Date**: 2026-03-26 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `specs/006-add-nyx-grid/spec.md`
+
+## Summary
+
+Implement `NyxGrid` as a layout primitive with optional header and footer regions, a slotted content stage, configurable columns and gap sizing, and two layout modes: standard grid and masonry. To satisfy the smooth reflow requirement without adding dependencies, the component should normalize top-level slot children into internally wrapped items and drive their positions with measured layout calculations plus transform-based transitions.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.7 / Vue 3.5
+**Primary Dependencies**: Vue 3 (`computed`, `ref`, `useSlots`, `watch`, `nextTick`, lifecycle hooks), SCSS
+**Storage**: N/A - layout state is ephemeral DOM measurement only
+**Testing**: Vitest + `@vue/test-utils` (unit), Storybook 8 for API verification, Playwright optional if Storybook interaction coverage is insufficient
+**Target Platform**: Browser - published as `nyx-kit` npm library
+**Project Type**: UI component library
+**Performance Goals**: Smooth visual reflow for typical dashboard/gallery counts without external animation libraries; layout recomputation bounded to rendered child count
+**Constraints**: No new npm dependencies; must preserve arbitrary slot content; must use design tokens for spacing/typography; must keep DOM order predictable; must support graceful fallback for invalid props
+**Scale/Scope**: Single exported component plus local types/styles/stories/tests and synced docs/spec artifacts
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Gate | Status | Notes |
+|------|--------|-------|
+| Docs-first (Constitution I) | PASS | Relevant architecture docs were read; `docs/specs/components/NyxGrid.spec.md` is added as the living component spec |
+| Spec before code (Constitution II) | PASS | Product-level feature spec exists in `specs/006-add-nyx-grid/spec.md` |
+| Minimal diff (Constitution III) | PASS | Scope is isolated to the new component, exports, docs, and README naming sync |
+| Consumer-library contract (Constitution IV) | PASS | Public API is additive: new exported component with documented props/slots/CSS hooks |
+| Test-first for non-trivial logic (Constitution V) | PASS | Plan includes unit tests for layout sanitization and animated reflow behavior |
+| Design tokens (Constitution VI) | PASS | Gap, typography, spacing, borders, and transitions are token-backed |
+| Consistency (Constitution VII) | PASS | Header/footer slot conventions and prop naming align with existing component model |
+
+*Post-design re-check: All gates still pass. No exceptions required.*
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/006-add-nyx-grid/
+├── plan.md              ← this file
+├── research.md          ← Phase 0 output
+├── data-model.md        ← Phase 1 output
+├── quickstart.md        ← Phase 1 output
+├── contracts/
+│   └── component-api.md ← Phase 1 output
+└── tasks.md             ← Phase 2 output
+```
+
+### Source Code
+
+```text
+src/components/NyxGrid/
+├── NyxGrid.vue          ← root structure, slot normalization, measurement, layout switching
+├── NyxGrid.scss         ← structural, token-driven styles, item transitions
+├── NyxGrid.types.ts     ← props, mode union, internal layout item types
+├── NyxGrid.spec.ts      ← prop fallback, slot precedence, layout mode, animation hooks
+├── NyxGrid.stories.ts   ← title/header/footer combinations, grid mode, masonry mode, dynamic reflow
+└── index.ts             ← export { default as NyxGrid } from './NyxGrid.vue'
+
+src/components/index.ts  ← public component export
+src/main.ts              ← package root export surface if needed by current project structure
+
+docs/specs/components/
+└── NyxGrid.spec.md      ← living source-of-truth component contract
+```
+
+**Structure Decision**: Single-project component-library layout. The feature lives in a dedicated `src/components/NyxGrid/` folder plus export wiring and synchronized docs. No new packages, utilities, or cross-cutting style-token changes are planned.
+
+---
+
+## Phase 0 Findings Applied
+
+1. Keep the public name `NyxGrid`; the feature is still primarily a grid container even though one mode uses masonry-style compaction.
+2. Use semantic structure: root `<section>`, optional `<header>`, content stage, optional `<footer>`.
+3. Prefer transform-based FLIP-style movement on internally wrapped items over pure CSS masonry so the component can animate insert/remove/reflow predictably.
+4. Require no component-specific item data model; consumers provide arbitrary keyed slot children.
+
+## Implementation Outline
+
+### Step 1 - Define the public contract
+
+Create `NyxGrid.types.ts` and codify:
+- `title?: string`
+- `mode?: 'grid' | 'masonry'`
+- `columns?: number`
+- `gap?: NyxSize`
+
+Also define sanitized internal values for `resolvedColumns`, `resolvedGapToken`, and measured item metadata.
+
+### Step 2 - Build the semantic shell
+
+`NyxGrid.vue` should render:
+- Root `<section class="nyx-grid">`
+- Optional `<header class="nyx-grid__header">` with header slot first, then `title` fallback
+- Required content stage container
+- Optional `<footer class="nyx-grid__footer">`
+
+Header/footer wrappers render only when content exists, following the component-model slot convention.
+
+### Step 3 - Normalize slot children into layout items
+
+Use `useSlots()` to collect top-level default-slot VNodes, discard empty/comment nodes, and wrap each item in an internal shell with a stable key. Implementation should preserve consumer order and document that keyed children produce the best reorder animation fidelity.
+
+### Step 4 - Compute layout positions for both modes
+
+Use a single measurement pipeline so both modes share animation behavior:
+- `grid` mode: place items row-by-row into fixed columns
+- `masonry` mode: place each next item into the shortest current column
+- Container height is the max column bottom
+- Invalid `columns` resolves to the documented default before layout
+
+### Step 5 - Animate reflow without snapping
+
+Track previous and next item positions, then animate item wrappers via CSS `transform` / `transition`. Recompute after mount, slot changes, resize, and observed item height changes. The implementation can use `ResizeObserver` and `requestAnimationFrame`; no external package is needed.
+
+### Step 6 - Add token-driven styles
+
+`NyxGrid.scss` should provide:
+- layout spacing tokens mapped from `gap`
+- surface spacing between header/content/footer
+- wrapper styles for moving items
+- reduced-motion fallback that keeps layout functional while shortening or disabling movement
+
+### Step 7 - Add docs, stories, and tests
+
+- `docs/specs/components/NyxGrid.spec.md`
+- `NyxGrid.stories.ts` with title-only, custom-header, footer, masonry, and live add/remove stories
+- `NyxGrid.spec.ts` covering wrapper omission, header precedence, prop sanitization, mode switching, and motion class/transform updates
+
+---
+
+## Complexity Tracking
+
+No Constitution violations. No complexity exceptions required.

--- a/specs/006-add-nyx-grid/quickstart.md
+++ b/specs/006-add-nyx-grid/quickstart.md
@@ -1,0 +1,97 @@
+# Quickstart: NyxGrid
+
+**Branch**: `006-add-nyx-grid` | **Date**: 2026-03-26
+
+---
+
+## Basic usage
+
+```vue
+<script setup lang="ts">
+import { NyxGrid, NyxCard } from 'nyx-kit/components'
+import { NyxGridMode, NyxSize } from 'nyx-kit/types'
+
+const cards = [
+  { id: 'alpha', title: 'Alpha' },
+  { id: 'beta', title: 'Beta' },
+  { id: 'gamma', title: 'Gamma' },
+]
+</script>
+
+<template>
+  <NyxGrid title="Overview" :columns="3" :gap="NyxSize.Medium">
+    <NyxCard v-for="card in cards" :key="card.id" :title="card.title">
+      Card content
+    </NyxCard>
+  </NyxGrid>
+</template>
+```
+
+---
+
+## Custom header and footer
+
+```vue
+<script setup lang="ts">
+import { NyxButton, NyxGrid, NyxCard } from 'nyx-kit/components'
+
+const cards = [
+  { id: 'alpha', title: 'Alpha' },
+  { id: 'beta', title: 'Beta' },
+]
+</script>
+
+<NyxGrid :columns="2">
+  <template #header>
+    <div class="flex" style="justify-content: space-between; width: 100%;">
+      <h2>Gallery</h2>
+      <NyxButton>Refresh</NyxButton>
+    </div>
+  </template>
+
+  <NyxCard v-for="item in cards" :key="item.id" :title="item.title" />
+
+  <template #footer>
+    <small>{{ cards.length }} items</small>
+  </template>
+</NyxGrid>
+```
+
+---
+
+## Masonry mode
+
+```vue
+<script setup lang="ts">
+import { NyxGrid } from 'nyx-kit/components'
+import { NyxGridMode, NyxSize } from 'nyx-kit/types'
+</script>
+
+<template>
+  <NyxGrid :mode="NyxGridMode.Masonry" :columns="4" :gap="NyxSize.Small">
+  <article v-for="photo in photos" :key="photo.id">
+    <img :src="photo.src" :alt="photo.alt">
+  </article>
+</NyxGrid>
+</template>
+```
+
+---
+
+## Numeric gap values
+
+```vue
+<NyxGrid :columns="3" :gap="0">
+  <NyxCard v-for="card in cards" :key="card.id" :title="card.title" />
+</NyxGrid>
+```
+
+---
+
+## Notes
+
+- Use stable Vue keys on top-level children for the best insert/remove/reorder transitions.
+- `columns` falls back to `3` when omitted or invalid and applies in both grid and masonry modes.
+- `gap` defaults to `NyxSize.Medium`; token values are scaled 1.5x and numeric values are interpreted as rem units.
+- `title` is ignored when a `header` slot is present.
+- `NyxGrid` does not impose item semantics; cards, articles, media, and plain divs are all valid.

--- a/specs/006-add-nyx-grid/research.md
+++ b/specs/006-add-nyx-grid/research.md
@@ -1,0 +1,83 @@
+# Research: NyxGrid Layout Primitive
+
+**Branch**: `006-add-nyx-grid` | **Date**: 2026-03-26
+
+---
+
+## Finding 1: Public naming
+
+**Decision**: Keep the public component name `NyxGrid`.
+
+**Rationale**: The consumer mental model is still a grid container with a masonry variant, not a general-purpose page layout system. Renaming to `NyxLayout` would imply broader responsibilities that the feature spec explicitly excludes.
+
+**Alternatives considered**: `NyxLayout` was rejected because it suggests flex, split-pane, and shell patterns beyond this feature's scope.
+
+---
+
+## Finding 2: Structural semantics
+
+**Decision**: Use a semantic root `<section>` with optional `<header>` and `<footer>` wrappers plus a dedicated content container.
+
+**Rationale**: This matches the requested structure, aligns with existing slot-wrapper conventions, and keeps the component meaningful without imposing list or table semantics on arbitrary child content.
+
+**Alternatives considered**: A generic `<div>` shell was rejected because the request explicitly centers the component on section-like layout structure.
+
+---
+
+## Finding 3: Layout engine strategy
+
+**Decision**: Use a measurement-driven internal layout engine that computes item positions for both `grid` and `masonry` modes.
+
+**Rationale**: A shared positioning engine makes smooth reflow practical in both modes and avoids a split implementation where standard grid animates cleanly but masonry snaps or cannot preserve order predictably.
+
+**Alternatives considered**: Native CSS Grid alone was rejected because it does not solve masonry packing. CSS columns were rejected because they make deterministic reflow animation and predictable horizontal reading order harder.
+
+---
+
+## Finding 4: Animation approach
+
+**Decision**: Animate item movement with transform-based FLIP-style transitions on internal wrappers.
+
+**Rationale**: Transform transitions are performant, dependency-free, and compatible with insert/remove/reorder updates as long as each slotted child has a stable Vue key.
+
+**Alternatives considered**: Pure opacity fades were rejected because they do not satisfy the re-alignment requirement. External animation libraries were rejected by repository policy.
+
+---
+
+## Finding 5: Slot item contract
+
+**Decision**: Keep the API fully slot-driven and require no item data shape, while documenting that keyed top-level slot children are the supported path for reorder animations.
+
+**Rationale**: The feature is explicitly a layout primitive. Introducing an item array prop would make the component too opinionated and duplicate what consumers already have in template space.
+
+**Alternatives considered**: A `items` prop plus render callback was rejected because it would narrow the component to one rendering style and violate FR-018.
+
+---
+
+## Finding 6: Column sanitization
+
+**Decision**: Accept `columns` as a consumer prop but sanitize to a positive integer with a documented default of `3`.
+
+**Rationale**: A three-column default is a reasonable desktop-oriented starting point for dashboard and gallery layouts, while sanitization fulfills the invalid-value fallback requirement.
+
+**Alternatives considered**: Defaulting to `1` was rejected because it under-delivers on the component's main value as a grid primitive. Defaulting to `auto-fit` was rejected because the feature spec asks for explicit column count control.
+
+---
+
+## Finding 7: Gap mapping
+
+**Decision**: Map `gap: NyxSize` onto existing spacing tokens and default to `NyxSize.Medium`.
+
+**Rationale**: This keeps the API consistent with the library's shared size scale and avoids hard-coded spacing values.
+
+**Alternatives considered**: Accepting raw CSS length strings was rejected because it breaks token discipline and creates a one-off API.
+
+---
+
+## Finding 8: Accessibility and motion fallback
+
+**Decision**: Keep the content region semantically neutral, preserve DOM order, and support reduced-motion behavior by minimizing transform animation duration when motion should be limited.
+
+**Rationale**: The component should not override the semantics of consumer-provided child content, and motion-sensitive users still need a functional, predictable layout.
+
+**Alternatives considered**: Applying `role="list"`/`role="listitem"` was rejected because arbitrary slotted children may already carry their own semantics.

--- a/specs/006-add-nyx-grid/spec.md
+++ b/specs/006-add-nyx-grid/spec.md
@@ -1,0 +1,134 @@
+# Feature Specification: NyxGrid Layout Component
+
+**Feature Branch**: `006-add-nyx-grid`  
+**Created**: 2026-03-26  
+**Status**: Draft  
+**Input**: User description: "i want to create a new component used for layout purposes: NyxGrid. This is essentially a wrapper for an element (<section>) in CSS's display: grid mode. This component has three seperate internals:
+- <header> => can be filled by slot for custom html, or by a \"title\" prop
+- <section> => this is the grid container
+- <footer> => only a slot
+
+NyxGrid takes the following props:
+- title (optional)
+- mode: either default grid mode, out-of-the-box, or \"masonry\", where items
+- gap: NyxSize
+
+when items disappear or are injected, the grid should cleanly adjust: no hard cuts, use transitions/animations to re-align.
+
+other things I missed? do you have a better name? Masonry isn't exactly the same as a grid, so calling it \"NyxGrid\" feels a bit odd. But maybe there are no better alternatives."
+
+## Clarifications
+
+### Session 2026-03-26
+
+- Q: How should `columns` behave when `mode="masonry"`? → A: `columns` controls column count in both grid and masonry modes.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Compose a reusable content grid (Priority: P1)
+
+As a consumer of the component library, I want a single layout component that provides an optional header, a grid content region, an optional footer, and configurable column count so I can assemble repeatable dashboard, gallery, and card-list layouts without rebuilding the surrounding structure each time.
+
+**Why this priority**: The core value of the feature is giving consumers a ready-made layout primitive for common content grouping patterns.
+
+**Independent Test**: Can be fully tested by rendering the component with a title, several child items, and a footer slot, then verifying that each region appears in the correct order and the content area arranges child items in a grid.
+
+**Acceptance Scenarios**:
+
+1. **Given** a consumer provides a `title` and grid content, **When** the component renders, **Then** it shows a header region before the content region and displays the provided title text.
+2. **Given** a consumer provides content in the default slot, **When** the component renders, **Then** it places that content in the central layout region configured as a grid.
+3. **Given** a consumer provides a column count, **When** the component renders, **Then** the content region uses that value to determine how many columns are used in both standard grid and masonry modes.
+4. **Given** a consumer provides footer slot content, **When** the component renders, **Then** it shows a footer region after the content region.
+
+---
+
+### User Story 2 - Customize structural regions (Priority: P2)
+
+As a consumer, I want to replace the default header text with custom header content and omit unused regions so the component fits a wider range of layouts without forcing empty wrappers or duplicate content.
+
+**Why this priority**: Flexible composition keeps the component useful across simple and rich layouts while staying lightweight.
+
+**Independent Test**: Can be fully tested by rendering the component once with a custom header slot and once without header or footer content, then verifying wrapper regions only appear when needed and custom header content takes precedence over the plain title.
+
+**Acceptance Scenarios**:
+
+1. **Given** a consumer provides both a `title` and custom header content, **When** the component renders, **Then** the custom header content is shown and the plain title is not rendered separately.
+2. **Given** a consumer provides no `title`, no header slot, and no footer slot, **When** the component renders, **Then** only the central content region is shown.
+
+---
+
+### User Story 3 - Switch between standard and masonry layouts (Priority: P3)
+
+As a consumer, I want to choose between a standard grid arrangement and a masonry-style arrangement so the same component can support evenly sized content collections and variable-height collections.
+
+**Why this priority**: Multiple layout modes broaden the usefulness of the component, but the component is still valuable as a standard grid without masonry.
+
+**Independent Test**: Can be fully tested by rendering one instance in standard mode and one in masonry mode with variable-height items, then verifying the chosen mode affects item arrangement while preserving the same header and footer structure.
+
+**Acceptance Scenarios**:
+
+1. **Given** the component uses the default layout mode, **When** items have different heights, **Then** items follow the standard grid flow rather than masonry compaction.
+2. **Given** the component uses masonry mode with variable-height items, **When** it renders, **Then** items are packed to minimize visible vertical gaps compared with the standard layout mode.
+3. **Given** a consumer changes the column count for an existing layout, **When** the component reflows in either mode, **Then** items transition into the new arrangement without hard cuts.
+
+---
+
+### Edge Cases
+
+- What happens when both `title` and header slot content are supplied at the same time? The header slot takes precedence and no duplicate title content is shown.
+- What happens when the default slot is empty? The component still renders valid structure, but the content region does not inject placeholder items or fallback text.
+- What happens when `gap` is not provided? The component uses the library's default medium gap value.
+- What happens when `gap` is a number? The component interprets the number as a rem value, including `0` for no gap.
+- What happens when `columns` is not provided? The component uses its documented default column count in both grid and masonry modes.
+- What happens when `columns` is zero, negative, or non-whole? The component rejects the invalid value and falls back to the documented default.
+- What happens when items are added, removed, or reordered after initial render? The layout reflows smoothly, without abrupt visual jumps between positions.
+- What happens when the consumer passes a layout mode value outside the supported set? The component rejects the unsupported value and falls back to the standard mode behaviour.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST provide a new layout component named `NyxGrid` for arranging slotted child content within a reusable container.
+- **FR-002**: The system MUST render the component as three ordered structural regions: an optional header region, a required content region, and an optional footer region.
+- **FR-003**: Users MUST be able to supply grid items through the default slot.
+- **FR-004**: Users MUST be able to populate the header region either with a `title` prop or a dedicated header slot.
+- **FR-005**: The system MUST prioritize dedicated header slot content over the `title` prop when both are provided.
+- **FR-006**: Users MUST be able to populate the footer region only through a dedicated footer slot.
+- **FR-007**: The system MUST omit the header wrapper when neither a `title` prop nor header slot content is provided.
+- **FR-008**: The system MUST omit the footer wrapper when no footer slot content is provided.
+- **FR-009**: The system MUST support a `mode` prop with exactly two consumer-facing options: standard grid and masonry.
+- **FR-010**: The system MUST treat standard grid as the default layout mode when `mode` is not specified.
+- **FR-011**: The system MUST support a `columns` prop that controls the number of content columns shown in both standard grid and masonry modes.
+- **FR-012**: The system MUST define and document a default column count used when `columns` is not specified.
+- **FR-013**: The system MUST handle invalid `columns` values by falling back to the documented default rather than producing a broken layout.
+- **FR-014**: The system MUST support a `gap` prop that accepts either the library's shared size scale or a numeric rem value and applies that spacing consistently between content items.
+- **FR-014a**: The system MUST scale named size-token gap values by 1.5x before applying them.
+- **FR-014b**: The system MUST treat numeric gap values as rem units, including `0` as a valid no-gap value.
+- **FR-015**: The system MUST preserve the same header, content, and footer API regardless of the selected layout mode.
+- **FR-016**: The system MUST animate layout changes when content items are inserted, removed, reordered, or redistributed because of a column-count change so surrounding items visibly transition into their new positions instead of snapping.
+- **FR-017**: The system MUST keep the content order stable and predictable during animated reflow so consumers do not lose track of item sequence.
+- **FR-018**: The system MUST expose the component as a generic layout primitive and MUST NOT require the content items to follow a component-specific data shape.
+
+### Key Entities *(include if feature involves data)*
+
+- **Grid Layout Mode**: The arrangement style applied to the content region; supported values are standard grid and masonry.
+- **Column Configuration**: The consumer-provided or default rule that determines how many content columns the layout uses in both standard grid and masonry modes.
+- **Grid Region**: A named section of the component structure; header and footer are optional, while the content region is always present.
+- **Grid Item Collection**: The set of consumer-provided child elements displayed inside the content region and affected by spacing, mode selection, and animated reflow.
+
+### Assumptions
+
+- `NyxGrid` remains the working public name because the primary mental model is a grid container with an optional masonry arrangement, and introducing a broader name such as `NyxLayout` would imply additional layouts outside this feature's scope.
+- The initial scope is limited to structural layout concerns; it includes explicit column count control but does not include responsive presets, item spanning APIs, filtering, sorting, or drag-and-drop behaviour.
+- Masonry mode is intended for collections with variable item heights and should compact items vertically while preserving reading order.
+- Consumers are responsible for the content semantics of individual items inside the layout.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A consumer can create a layout with header, content, and footer regions using one documented component without requiring additional wrapper components.
+- **SC-002**: In component demos covering standard and masonry modes, 100% of item insertions and removals result in visible reflow transitions rather than abrupt position changes.
+- **SC-003**: In acceptance testing, consumers can switch between the two supported layout modes by changing a single prop without changing their slot structure.
+- **SC-004**: In acceptance testing, consumers can change the column count with a single prop and the layout updates without requiring changes to child item markup.
+- **SC-005**: In documentation and stories, consumers can demonstrate all supported header states: title only, custom header content, and no header.

--- a/specs/006-add-nyx-grid/tasks.md
+++ b/specs/006-add-nyx-grid/tasks.md
@@ -1,0 +1,198 @@
+# Tasks: NyxGrid Layout Primitive
+
+**Input**: Design documents from `/specs/006-add-nyx-grid/`
+**Prerequisites**: `plan.md`, `spec.md`, `research.md`, `data-model.md`, `contracts/component-api.md`, `quickstart.md`
+
+**Tests**: Include unit tests because the plan explicitly calls for test coverage of non-trivial layout, sanitization, and animated reflow behavior.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g. `US1`, `US2`, `US3`)
+- Every task includes exact file path references
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Create the component workspace and wire the new export surface.
+
+- [X] T001 Create the `NyxGrid` component scaffold in `src/components/NyxGrid/NyxGrid.vue`, `src/components/NyxGrid/NyxGrid.scss`, `src/components/NyxGrid/NyxGrid.types.ts`, `src/components/NyxGrid/NyxGrid.spec.ts`, `src/components/NyxGrid/NyxGrid.stories.ts`, and `src/components/NyxGrid/index.ts`
+- [X] T002 Register `NyxGrid` exports in `src/components/index.ts` and `src/main.ts`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Build the shared contract and layout engine pieces required by all user stories.
+
+**⚠️ CRITICAL**: No user story work should begin until this phase is complete.
+
+- [X] T003 Define public props and internal layout types in `src/components/NyxGrid/NyxGrid.types.ts`
+- [X] T004 Implement default-slot normalization and stable item wrapper key handling in `src/components/NyxGrid/NyxGrid.vue`
+- [X] T005 Implement `mode`, `columns`, and `gap` sanitization plus token resolution in `src/components/NyxGrid/NyxGrid.vue`
+- [X] T006 Implement the shared layout snapshot, measurement lifecycle, and container sizing pipeline in `src/components/NyxGrid/NyxGrid.vue`
+- [X] T007 Implement base structural styles and token-driven spacing hooks in `src/components/NyxGrid/NyxGrid.scss`
+
+**Checkpoint**: Foundation ready - user story implementation can now begin.
+
+---
+
+## Phase 3: User Story 1 - Compose a reusable content grid (Priority: P1) 🎯 MVP
+
+**Goal**: Deliver the semantic section shell, default grid layout, configurable columns, gap handling, and optional title/footer output.
+
+**Independent Test**: Render `NyxGrid` with a `title`, several keyed children, `columns`, and a `footer` slot in `src/components/NyxGrid/NyxGrid.stories.ts`, then verify the header/content/footer order and standard grid arrangement in `src/components/NyxGrid/NyxGrid.spec.ts`.
+
+### Tests for User Story 1
+
+- [X] T008 [P] [US1] Add unit tests for title rendering, footer rendering, default `columns`, invalid `columns` fallback, and `gap` resolution in `src/components/NyxGrid/NyxGrid.spec.ts`
+
+### Implementation for User Story 1
+
+- [X] T009 [US1] Implement the semantic root `<section>`, fallback title header, content stage, and footer slot rendering in `src/components/NyxGrid/NyxGrid.vue`
+- [X] T010 [US1] Implement standard grid item positioning and content container sizing in `src/components/NyxGrid/NyxGrid.vue`
+- [X] T011 [P] [US1] Add title, columns, gap, and footer stories in `src/components/NyxGrid/NyxGrid.stories.ts`
+
+**Checkpoint**: User Story 1 should be fully functional and testable as the MVP.
+
+---
+
+## Phase 4: User Story 2 - Customize structural regions (Priority: P2)
+
+**Goal**: Allow custom header content and clean omission of unused header/footer wrappers.
+
+**Independent Test**: Render `NyxGrid` with both `title` and `header` slot content, then render it again with no header/footer inputs in `src/components/NyxGrid/NyxGrid.stories.ts`; verify slot precedence and wrapper omission in `src/components/NyxGrid/NyxGrid.spec.ts`.
+
+### Tests for User Story 2
+
+- [X] T012 [P] [US2] Add unit tests for header-slot precedence over `title` and omission of empty header/footer wrappers in `src/components/NyxGrid/NyxGrid.spec.ts`
+
+### Implementation for User Story 2
+
+- [X] T013 [US2] Implement slot-first header resolution and conditional header/footer wrapper suppression in `src/components/NyxGrid/NyxGrid.vue`
+- [X] T014 [P] [US2] Add custom-header, footer-slot, and content-only stories in `src/components/NyxGrid/NyxGrid.stories.ts`
+
+**Checkpoint**: User Story 2 should work independently without relying on masonry mode.
+
+---
+
+## Phase 5: User Story 3 - Switch between standard and masonry layouts (Priority: P3)
+
+**Goal**: Support masonry layout mode and smooth animated reflow for insert, remove, reorder, and column-count changes.
+
+**Independent Test**: Render one `NyxGrid` story in `grid` mode and one in `masonry` mode with variable-height children in `src/components/NyxGrid/NyxGrid.stories.ts`, then verify mode fallback and reflow-trigger behavior in `src/components/NyxGrid/NyxGrid.spec.ts`.
+
+### Tests for User Story 3
+
+- [X] T015 [P] [US3] Add unit tests for `mode='masonry'`, invalid `mode` fallback, and animated reflow triggers on item and column changes in `src/components/NyxGrid/NyxGrid.spec.ts`
+
+### Implementation for User Story 3
+
+- [X] T016 [US3] Implement masonry shortest-column placement and invalid-mode fallback behavior in `src/components/NyxGrid/NyxGrid.vue`
+- [X] T017 [US3] Implement FLIP-style transform transitions, resize and item-size observation, and reduced-motion behavior in `src/components/NyxGrid/NyxGrid.vue` and `src/components/NyxGrid/NyxGrid.scss`
+- [X] T018 [P] [US3] Add masonry and dynamic add/remove/reflow stories in `src/components/NyxGrid/NyxGrid.stories.ts`
+
+**Checkpoint**: All user stories should now be independently functional.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Align docs and usage guidance with the final implementation.
+
+- [X] T019 Update the living component contract in `docs/specs/components/NyxGrid.spec.md` and `specs/006-add-nyx-grid/contracts/component-api.md` to match the shipped implementation
+- [X] T020 Validate and refine usage examples in `specs/006-add-nyx-grid/quickstart.md` and `README.md` to match the final `NyxGrid` API
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies - can start immediately
+- **Foundational (Phase 2)**: Depends on Setup completion - blocks all user stories
+- **User Story 1 (Phase 3)**: Depends on Foundational completion
+- **User Story 2 (Phase 4)**: Depends on Foundational completion and can reuse the semantic shell from User Story 1
+- **User Story 3 (Phase 5)**: Depends on Foundational completion and builds on the shared layout pipeline from User Story 1
+- **Polish (Phase 6)**: Depends on completion of the desired user stories
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: Can start after Phase 2 - no dependency on later stories
+- **User Story 2 (P2)**: Can start after Phase 2, but is simplest after User Story 1 establishes the semantic shell
+- **User Story 3 (P3)**: Can start after Phase 2, but is simplest after User Story 1 establishes the shared layout stage
+
+### Within Each User Story
+
+- Unit tests should be written before the matching implementation tasks in the same story
+- `src/components/NyxGrid/NyxGrid.types.ts` should be complete before expanding `src/components/NyxGrid/NyxGrid.vue`
+- `src/components/NyxGrid/NyxGrid.vue` behavior should be in place before story coverage in `src/components/NyxGrid/NyxGrid.stories.ts`
+- Cross-cutting docs should be updated only after the implementation details are stable
+
+### Parallel Opportunities
+
+- `T001` and `T002` can be split across teammates once the component name is fixed
+- After Phase 2, test-writing tasks `T008`, `T012`, and `T015` can be prepared independently from story-writing tasks
+- Story tasks `T011`, `T014`, and `T018` are parallelizable once their corresponding `src/components/NyxGrid/NyxGrid.vue` behavior exists
+- Documentation tasks `T019` and `T020` can run in parallel after implementation stabilizes
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+# Parallelizable work after foundational tasks are complete:
+Task: "Add unit tests for title rendering, footer rendering, default columns, invalid columns fallback, and gap resolution in src/components/NyxGrid/NyxGrid.spec.ts"
+Task: "Add title, columns, gap, and footer stories in src/components/NyxGrid/NyxGrid.stories.ts"
+```
+
+## Parallel Example: User Story 2
+
+```bash
+# Parallelizable work after the semantic shell exists:
+Task: "Add unit tests for header-slot precedence over title and omission of empty wrappers in src/components/NyxGrid/NyxGrid.spec.ts"
+Task: "Add custom-header, footer-slot, and content-only stories in src/components/NyxGrid/NyxGrid.stories.ts"
+```
+
+## Parallel Example: User Story 3
+
+```bash
+# Parallelizable work after masonry behavior lands in NyxGrid.vue:
+Task: "Add unit tests for masonry mode, invalid mode fallback, and animated reflow triggers in src/components/NyxGrid/NyxGrid.spec.ts"
+Task: "Add masonry and dynamic add/remove/reflow stories in src/components/NyxGrid/NyxGrid.stories.ts"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup
+2. Complete Phase 2: Foundational
+3. Complete Phase 3: User Story 1
+4. Validate `src/components/NyxGrid/NyxGrid.spec.ts` and `src/components/NyxGrid/NyxGrid.stories.ts`
+5. Stop for review before extending into header customization or masonry behavior
+
+### Incremental Delivery
+
+1. Ship the core grid shell in User Story 1
+2. Add slot-first structural customization in User Story 2
+3. Add masonry mode and animated reflow in User Story 3
+4. Finish with docs and usage polish in Phase 6
+
+### Parallel Team Strategy
+
+1. One developer completes Phase 1 and Phase 2
+2. A second developer can prepare tests and stories while core implementation proceeds in `src/components/NyxGrid/NyxGrid.vue`
+3. After MVP, masonry behavior and docs/story expansion can be split across teammates without file collisions except in `src/components/NyxGrid/NyxGrid.vue`
+
+---
+
+## Notes
+
+- All tasks follow the required `- [ ] T### [P] [US#] Description with file path` checklist format
+- `[P]` markers only appear on tasks that can proceed independently without editing the same file at the same time as a prerequisite task
+- User stories remain independently testable even though later stories build on the same component files
+- No new npm dependencies are included in this plan

--- a/src/components/NyxGrid/NyxGrid.scss
+++ b/src/components/NyxGrid/NyxGrid.scss
@@ -3,6 +3,7 @@
   --nyx-grid-region-gap: var(--nyx-pad-md);
   --nyx-grid-title-size: var(--nyx-font-size-lg);
   --nyx-grid-columns: 3;
+  --nyx-grid-masonry-height: auto;
 
   display: flex;
   flex-direction: column;
@@ -46,10 +47,16 @@
   &--masonry {
     .nyx-grid__content {
       display: block;
+      min-height: var(--nyx-grid-masonry-height);
     }
 
     .nyx-grid__content > * {
       position: absolute;
+      box-sizing: border-box;
+      width: var(--nyx-grid-item-width, 100%);
+      max-width: var(--nyx-grid-item-width, 100%);
+      left: var(--nyx-grid-item-left, 0);
+      top: var(--nyx-grid-item-top, 0);
     }
   }
 }

--- a/src/components/NyxGrid/NyxGrid.scss
+++ b/src/components/NyxGrid/NyxGrid.scss
@@ -1,0 +1,61 @@
+.nyx-grid {
+  --nyx-grid-gap: var(--nyx-gap-md);
+  --nyx-grid-region-gap: var(--nyx-pad-md);
+  --nyx-grid-title-size: var(--nyx-font-size-lg);
+  --nyx-grid-columns: 3;
+
+  display: flex;
+  flex-direction: column;
+  gap: var(--nyx-grid-region-gap);
+  width: 100%;
+  color: var(--nyx-c-text-1);
+
+  &__header,
+  &__footer {
+    display: flex;
+    flex-direction: column;
+    gap: var(--nyx-gap-sm);
+  }
+
+  &__title {
+    margin: 0;
+    font-size: var(--nyx-grid-title-size);
+    line-height: 1.2;
+    color: var(--nyx-c-text-1);
+  }
+
+  &__content {
+    position: relative;
+    display: grid;
+    grid-template-columns: repeat(var(--nyx-grid-columns, 1), minmax(0, 1fr));
+    gap: var(--nyx-grid-gap);
+    width: 100%;
+    min-height: 0;
+  }
+
+  &__content > * {
+    box-sizing: border-box;
+    min-width: 0;
+    width: 100%;
+    max-width: none;
+    transition:
+      transform var(--nyx-speed-regular) ease,
+      opacity var(--nyx-speed-fast) ease;
+  }
+
+  &--masonry {
+    .nyx-grid__content {
+      display: block;
+    }
+
+    .nyx-grid__content > * {
+      position: absolute;
+    }
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .nyx-grid__content > * {
+    transition-duration: 0.01ms;
+  }
+}

--- a/src/components/NyxGrid/NyxGrid.scss
+++ b/src/components/NyxGrid/NyxGrid.scss
@@ -32,6 +32,7 @@
     gap: var(--nyx-grid-gap);
     width: 100%;
     min-height: 0;
+    overflow: hidden;
   }
 
   &__content > * {

--- a/src/components/NyxGrid/NyxGrid.spec.ts
+++ b/src/components/NyxGrid/NyxGrid.spec.ts
@@ -201,8 +201,8 @@ describe('NyxGrid', () => {
 
     expect(wrapper.classes()).toContain('nyx-grid--masonry')
     expect(wrapper.attributes('style')).toContain('--nyx-grid-columns: 2')
-    expect(items[0].style.left).toBe('0px')
-    expect(items[1].style.left).not.toBe(items[0].style.left)
+    expect(items[0].style.getPropertyValue('--nyx-grid-item-left')).toBe('0px')
+    expect(items[1].style.getPropertyValue('--nyx-grid-item-left')).not.toBe(items[0].style.getPropertyValue('--nyx-grid-item-left'))
   })
 
   it('lays out masonry items left to right before stacking downward', async () => {
@@ -225,13 +225,13 @@ describe('NyxGrid', () => {
 
     const items = wrapper.findAll('.nyx-grid__content > *').map(node => node.element as HTMLElement)
 
-    expect(items[0].style.top).toBe('0px')
-    expect(items[1].style.top).toBe('0px')
-    expect(items[2].style.top).toBe('0px')
-    expect(Number.parseFloat(items[1].style.left)).toBeGreaterThan(Number.parseFloat(items[0].style.left))
-    expect(Number.parseFloat(items[2].style.left)).toBeGreaterThan(Number.parseFloat(items[1].style.left))
-    expect(Number.parseFloat(items[3].style.top)).toBeGreaterThan(0)
-    expect(items[3].style.left).toBe(items[0].style.left)
+    expect(items[0].style.getPropertyValue('--nyx-grid-item-top')).toBe('0px')
+    expect(items[1].style.getPropertyValue('--nyx-grid-item-top')).toBe('0px')
+    expect(items[2].style.getPropertyValue('--nyx-grid-item-top')).toBe('0px')
+    expect(Number.parseFloat(items[1].style.getPropertyValue('--nyx-grid-item-left'))).toBeGreaterThan(Number.parseFloat(items[0].style.getPropertyValue('--nyx-grid-item-left')))
+    expect(Number.parseFloat(items[2].style.getPropertyValue('--nyx-grid-item-left'))).toBeGreaterThan(Number.parseFloat(items[1].style.getPropertyValue('--nyx-grid-item-left')))
+    expect(Number.parseFloat(items[3].style.getPropertyValue('--nyx-grid-item-top'))).toBeGreaterThan(0)
+    expect(items[3].style.getPropertyValue('--nyx-grid-item-left')).toBe(items[0].style.getPropertyValue('--nyx-grid-item-left'))
   })
 
   it('reflows keyed items when their order changes', async () => {

--- a/src/components/NyxGrid/NyxGrid.spec.ts
+++ b/src/components/NyxGrid/NyxGrid.spec.ts
@@ -1,0 +1,303 @@
+import { beforeAll, afterAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { defineComponent, nextTick, ref } from 'vue'
+import { mount } from '@vue/test-utils'
+import { NyxSize } from '@/types'
+import NyxCard from '../NyxCard/NyxCard.vue'
+import NyxGrid from './NyxGrid.vue'
+import { NyxGridMode } from './NyxGrid.types'
+
+const originalClientWidth = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'clientWidth')
+const originalOffsetHeight = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'offsetHeight')
+const originalGetBoundingClientRect = HTMLElement.prototype.getBoundingClientRect
+
+class MockResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+beforeAll(() => {
+  vi.stubGlobal('ResizeObserver', MockResizeObserver)
+  vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+    callback(0)
+    return 1
+  })
+  vi.stubGlobal('cancelAnimationFrame', vi.fn())
+
+  Object.defineProperty(HTMLElement.prototype, 'clientWidth', {
+    configurable: true,
+    get() {
+      return this.classList.contains('nyx-grid__content') ? 900 : 0
+    },
+  })
+
+  Object.defineProperty(HTMLElement.prototype, 'offsetHeight', {
+    configurable: true,
+    get() {
+      const ownHeight = Number(this.getAttribute('data-height'))
+      const firstChildHeight = Number(this.firstElementChild?.getAttribute('data-height'))
+      return ownHeight || firstChildHeight || 120
+    },
+  })
+
+  HTMLElement.prototype.getBoundingClientRect = function getBoundingClientRect() {
+    const left = Number.parseFloat(this.style.left || '0')
+    const top = Number.parseFloat(this.style.top || '0')
+    const width = Number.parseFloat(this.style.width || '0') || this.clientWidth
+    const height = this.offsetHeight
+
+    return {
+      x: left,
+      y: top,
+      left,
+      top,
+      width,
+      height,
+      right: left + width,
+      bottom: top + height,
+      toJSON() {
+        return this
+      },
+    } as DOMRect
+  }
+})
+
+afterAll(() => {
+  if (originalClientWidth) Object.defineProperty(HTMLElement.prototype, 'clientWidth', originalClientWidth)
+  if (originalOffsetHeight) Object.defineProperty(HTMLElement.prototype, 'offsetHeight', originalOffsetHeight)
+  HTMLElement.prototype.getBoundingClientRect = originalGetBoundingClientRect
+  vi.unstubAllGlobals()
+})
+
+beforeEach(() => {
+  vi.restoreAllMocks()
+})
+
+async function flushLayout() {
+  await nextTick()
+  await nextTick()
+}
+
+describe('NyxGrid', () => {
+  it('renders as a section with title, content items, and footer', async () => {
+    const wrapper = mount(NyxGrid, {
+      props: {
+        title: 'Overview',
+      },
+      slots: {
+        default: '<div data-height="120">Alpha</div><div data-height="140">Beta</div>',
+        footer: '<small class="grid-footer">2 items</small>',
+      },
+    })
+
+    await flushLayout()
+
+    expect(wrapper.find('section.nyx-grid').exists()).toBe(true)
+    expect(wrapper.find('.nyx-grid__title').text()).toBe('Overview')
+    expect(wrapper.find('.grid-footer').exists()).toBe(true)
+    expect(wrapper.findAll('.nyx-grid__content > *')).toHaveLength(2)
+  })
+
+  it('omits header and footer wrappers when no related content is provided', async () => {
+    const wrapper = mount(NyxGrid, {
+      slots: {
+        default: '<div data-height="120">Only content</div>',
+      },
+    })
+
+    await flushLayout()
+
+    expect(wrapper.find('.nyx-grid__header').exists()).toBe(false)
+    expect(wrapper.find('.nyx-grid__footer').exists()).toBe(false)
+  })
+
+  it('prioritizes the header slot over the title prop', async () => {
+    const wrapper = mount(NyxGrid, {
+      props: {
+        title: 'Fallback title',
+      },
+      slots: {
+        header: '<div class="custom-header">Custom header</div>',
+        default: '<div data-height="100">Body</div>',
+      },
+    })
+
+    await flushLayout()
+
+    expect(wrapper.find('.custom-header').exists()).toBe(true)
+    expect(wrapper.find('.nyx-grid__title').exists()).toBe(false)
+  })
+
+  it('sanitizes invalid columns and invalid gap values to documented defaults', async () => {
+    const wrapper = mount(NyxGrid, {
+      props: {
+        columns: 0,
+        gap: 'invalid' as NyxSize,
+      },
+      slots: {
+        default: '<div data-height="120">One</div><div data-height="120">Two</div><div data-height="120">Three</div>',
+      },
+    })
+
+    await flushLayout()
+
+    expect(wrapper.attributes('style')).toContain('calc(var(--nyx-gap-md) * 1.5)')
+    expect(wrapper.attributes('style')).toContain('--nyx-grid-columns: 3')
+  })
+
+  it('accepts numeric gap values as rem units, including zero', async () => {
+    const wrapper = mount(NyxGrid, {
+      props: {
+        gap: 0,
+      },
+      slots: {
+        default: '<div data-height="120">One</div><div data-height="120">Two</div>',
+      },
+    })
+
+    await flushLayout()
+
+    expect(wrapper.attributes('style')).toContain('--nyx-grid-gap: 0rem')
+  })
+
+  it('falls back to grid mode for invalid mode values', async () => {
+    const wrapper = mount(NyxGrid, {
+      props: {
+        mode: 'tiles' as never,
+      },
+      slots: {
+        default: '<div data-height="100">One</div>',
+      },
+    })
+
+    await flushLayout()
+
+    expect(wrapper.classes()).toContain('nyx-grid--grid')
+    expect(wrapper.classes()).not.toContain('nyx-grid--masonry')
+  })
+
+  it('uses columns in masonry mode and recalculates positions when columns change', async () => {
+    const wrapper = mount(NyxGrid, {
+      props: {
+        mode: NyxGridMode.Masonry,
+        columns: 3,
+      },
+      slots: {
+        default: [
+          '<div data-height="100">One</div>',
+          '<div data-height="180">Two</div>',
+          '<div data-height="120">Three</div>',
+          '<div data-height="140">Four</div>',
+        ],
+      },
+    })
+
+    await flushLayout()
+
+    await wrapper.setProps({ columns: 2 })
+    await flushLayout()
+
+    const items = wrapper.findAll('.nyx-grid__content > *').map(node => node.element as HTMLElement)
+
+    expect(wrapper.classes()).toContain('nyx-grid--masonry')
+    expect(wrapper.attributes('style')).toContain('--nyx-grid-columns: 2')
+    expect(items[0].style.left).toBe('0px')
+    expect(items[1].style.left).not.toBe(items[0].style.left)
+  })
+
+  it('lays out masonry items left to right before stacking downward', async () => {
+    const wrapper = mount(NyxGrid, {
+      props: {
+        mode: NyxGridMode.Masonry,
+        columns: 3,
+      },
+      slots: {
+        default: [
+          '<div data-height="100">One</div>',
+          '<div data-height="140">Two</div>',
+          '<div data-height="80">Three</div>',
+          '<div data-height="120">Four</div>',
+        ],
+      },
+    })
+
+    await flushLayout()
+
+    const items = wrapper.findAll('.nyx-grid__content > *').map(node => node.element as HTMLElement)
+
+    expect(items[0].style.top).toBe('0px')
+    expect(items[1].style.top).toBe('0px')
+    expect(items[2].style.top).toBe('0px')
+    expect(Number.parseFloat(items[1].style.left)).toBeGreaterThan(Number.parseFloat(items[0].style.left))
+    expect(Number.parseFloat(items[2].style.left)).toBeGreaterThan(Number.parseFloat(items[1].style.left))
+    expect(Number.parseFloat(items[3].style.top)).toBeGreaterThan(0)
+    expect(items[3].style.left).toBe(items[0].style.left)
+  })
+
+  it('reflows keyed items when their order changes', async () => {
+    const Demo = defineComponent({
+      components: { NyxGrid },
+      setup() {
+        const items = ref([
+          { id: 'a', label: 'Alpha', height: 120 },
+          { id: 'b', label: 'Beta', height: 180 },
+          { id: 'c', label: 'Gamma', height: 140 },
+        ])
+
+        return {
+          items,
+          NyxGridMode,
+          reverse() {
+            items.value = [...items.value].reverse()
+          },
+        }
+      },
+      template: `
+        <NyxGrid :mode="NyxGridMode.Masonry" :columns="2">
+          <div v-for="item in items" :key="item.id" :data-height="item.height">{{ item.label }}</div>
+        </NyxGrid>
+      `,
+    })
+
+    const wrapper = mount(Demo)
+
+    await flushLayout()
+
+    wrapper.vm.reverse()
+    await flushLayout()
+
+    const afterFirst = wrapper.findAll('.nyx-grid__content > *')[0].element as HTMLElement
+
+    expect(afterFirst.textContent).toContain('Gamma')
+    expect(wrapper.findAll('.nyx-grid__content > *')).toHaveLength(3)
+  })
+
+  it('renders component children such as NyxCard inside the grid', async () => {
+    const Demo = defineComponent({
+      components: { NyxGrid, NyxCard },
+      data() {
+        return {
+          cards: [
+            { id: 'a', title: 'Alpha' },
+            { id: 'b', title: 'Beta' },
+          ],
+        }
+      },
+      template: `
+        <NyxGrid title="Cards" :columns="2">
+          <NyxCard v-for="card in cards" :key="card.id" :title="card.title">
+            <p>{{ card.title }}</p>
+          </NyxCard>
+        </NyxGrid>
+      `,
+    })
+
+    const wrapper = mount(Demo)
+
+    await flushLayout()
+
+    expect(wrapper.findAll('.nyx-card')).toHaveLength(2)
+    expect(wrapper.text()).toContain('Alpha')
+    expect(wrapper.text()).toContain('Beta')
+  })
+})

--- a/src/components/NyxGrid/NyxGrid.stories.ts
+++ b/src/components/NyxGrid/NyxGrid.stories.ts
@@ -1,0 +1,251 @@
+import { defineComponent, h, ref } from 'vue'
+import { X as LucideX } from 'lucide-vue-next'
+import { NyxSize, NyxTheme, NyxVariant } from '@/types'
+import NyxButton from '../NyxButton/NyxButton.vue'
+import NyxCard from '../NyxCard/NyxCard.vue'
+import NyxGrid from './NyxGrid.vue'
+import { NyxGridMode } from './NyxGrid.types'
+
+type NyxGridStoryArgs = {
+  title?: string
+  mode?: NyxGridMode
+  columns?: number
+  gap?: NyxSize | number
+}
+
+const modeOptions = {
+  'NyxGridMode.Grid': NyxGridMode.Grid,
+  'NyxGridMode.Masonry': NyxGridMode.Masonry,
+}
+
+type StoryCard = {
+  id: string
+  title: string
+  lines: string[]
+}
+
+const gapOptions = {
+  'NyxSize.XSmall': NyxSize.XSmall,
+  'NyxSize.Small': NyxSize.Small,
+  'NyxSize.Medium': NyxSize.Medium,
+  'NyxSize.Large': NyxSize.Large,
+  'NyxSize.XLarge': NyxSize.XLarge,
+}
+
+const baseCards: StoryCard[] = [
+  { id: 'alpha', title: 'Alpha', lines: ['Short summary block.', 'Useful for compact cards.'] },
+  { id: 'beta', title: 'Beta', lines: ['A slightly longer card.', 'This one gives the layout more height.', 'Good for masonry demos.'] },
+  { id: 'gamma', title: 'Gamma', lines: ['Medium sized content.', 'Balanced placeholder copy.'] },
+  { id: 'delta', title: 'Delta', lines: ['Tall card example.', 'Adds visible stagger to the column flow.', 'Useful for checking reflow.', 'Keeps the demo lively.'] },
+  { id: 'epsilon', title: 'Epsilon', lines: ['Another compact block.', 'Works well in tighter rows.'] },
+]
+
+function renderCard(card: StoryCard, footer?: () => ReturnType<typeof h>) {
+  return h(
+    NyxCard,
+    {
+      key: card.id,
+      title: card.title,
+      variant: NyxVariant.Soft,
+    },
+    {
+      default: () => h(
+        'div',
+        { style: 'display:flex;flex-direction:column;gap:0.5rem;' },
+        card.lines.map((line, index) => h(
+          'p',
+          {
+            key: `${card.id}-${index}`,
+            style: 'margin:0;color:var(--nyx-c-text-2);',
+          },
+          line,
+        ))
+      ),
+      footer,
+    }
+  )
+}
+
+function renderCards(cards: StoryCard[]) {
+  return cards.map(card => renderCard(card))
+}
+
+function createGridStory(options?: {
+  footerText?: string
+  headerSlot?: () => ReturnType<typeof h>
+  cards?: StoryCard[]
+}) {
+  return (args: NyxGridStoryArgs) => defineComponent({
+    setup() {
+      return () => h(
+        NyxGrid,
+        args,
+        {
+          header: options?.headerSlot,
+          default: () => renderCards(options?.cards ?? baseCards),
+          footer: options?.footerText
+            ? () => h('small', { style: 'color:var(--nyx-c-text-2);' }, options.footerText)
+            : undefined,
+        }
+      )
+    },
+  })
+}
+
+export default {
+  title: 'Components/NyxGrid',
+  component: NyxGrid,
+  argTypes: {
+    mode: {
+      control: { type: 'select' },
+      options: Object.keys(modeOptions),
+      mapping: modeOptions,
+    },
+    columns: {
+      control: { type: 'number' },
+    },
+    gap: {
+      control: { type: 'select' },
+      options: Object.keys(gapOptions),
+      mapping: gapOptions,
+    },
+  },
+}
+
+export const Default = {
+  render: createGridStory(),
+  args: {
+    title: 'Overview',
+    columns: 3,
+    gap: NyxSize.Medium,
+  },
+}
+
+export const Footer = {
+  render: createGridStory({ footerText: `${baseCards.length} placeholder cards` }),
+  args: {
+    title: 'Overview',
+    columns: 3,
+    gap: NyxSize.Medium,
+  },
+}
+
+export const CustomHeader = {
+  render: createGridStory({
+    headerSlot: () => h(
+      'div',
+      { style: 'display:flex;justify-content:space-between;gap:1rem;align-items:center;' },
+      [
+        h('div', [
+          h('h2', { style: 'margin:0;' }, 'Gallery'),
+          h('p', { style: 'margin:0;color:var(--nyx-c-text-2);' }, 'Header slot overrides the title prop.'),
+        ]),
+        h(NyxButton, { theme: NyxTheme.Primary }, { default: () => 'Refresh' }),
+      ]
+    ),
+    footerText: 'Custom footer content',
+  }),
+  args: {
+    title: 'Fallback title',
+    columns: 2,
+    gap: NyxSize.Large,
+  },
+}
+
+export const ContentOnly = {
+  render: createGridStory({ cards: baseCards.slice(0, 3) }),
+  args: {
+    columns: 2,
+    gap: NyxSize.Small,
+  },
+}
+
+export const Masonry = {
+  render: createGridStory(),
+  args: {
+    title: 'Masonry Layout',
+    mode: NyxGridMode.Masonry,
+    columns: 3,
+    gap: NyxSize.Medium,
+  },
+}
+
+export const DynamicReflow = {
+  render: () => defineComponent({
+    setup() {
+      const cards = ref([...baseCards])
+      const columns = ref(3)
+      const nextId = ref(baseCards.length + 1)
+
+      const addCard = () => {
+        const index = nextId.value
+        cards.value = [
+          ...cards.value,
+          {
+            id: `stub-${index}`,
+            title: `Stub ${index}`,
+            lines: [
+              'Newly added placeholder card.',
+              index % 2 === 0 ? 'Compact body copy.' : 'A little extra content to vary the height.',
+              ...(index % 3 === 0 ? ['Additional line to exaggerate masonry movement.'] : []),
+            ],
+          },
+        ]
+        nextId.value += 1
+      }
+
+      const removeCard = (id: string) => {
+        cards.value = cards.value.filter(card => card.id !== id)
+      }
+
+      return () => h(NyxGrid, {
+        title: 'Dynamic Reflow',
+        mode: NyxGridMode.Masonry,
+        columns: columns.value,
+        gap: NyxSize.Medium,
+      }, {
+        header: () => h(
+          'div',
+          { style: 'display:flex;justify-content:space-between;align-items:center;gap:1rem;flex-wrap:wrap;' },
+          [
+            h('div', [
+              h('h2', { style: 'margin:0;' }, 'Dynamic Reflow'),
+              h('p', { style: 'margin:0;color:var(--nyx-c-text-2);' }, 'Add and remove NyxCard placeholders to observe animated realignment.'),
+            ]),
+            h('div', { style: 'display:flex;gap:0.5rem;flex-wrap:wrap;' }, [
+              h(NyxButton, { theme: NyxTheme.Success, onClick: addCard }, { default: () => 'Add card' }),
+              h(NyxButton, {
+                theme: NyxTheme.Info,
+                variant: NyxVariant.Outline,
+                onClick: () => { columns.value = columns.value === 3 ? 2 : 3 },
+              }, { default: () => 'Toggle columns' }),
+            ]),
+          ]
+        ),
+        default: () => cards.value.map(card => renderCard(card, () => h(
+          'div',
+          { style: 'display:flex;justify-content:flex-end;' },
+          [
+            h(NyxButton, {
+              theme: NyxTheme.Danger,
+              variant: NyxVariant.Ghost,
+              onClick: () => removeCard(card.id),
+            }, {
+              default: () => h(LucideX, { size: 16 }),
+            }),
+          ]
+        ))),
+        footer: () => h('small', { style: 'color:var(--nyx-c-text-2);' }, `${cards.value.length} cards in the grid`),
+      })
+    },
+  }),
+}
+
+export const ZeroGap = {
+  render: createGridStory(),
+  args: {
+    title: 'Zero Gap',
+    columns: 3,
+    gap: 0,
+  },
+}

--- a/src/components/NyxGrid/NyxGrid.types.ts
+++ b/src/components/NyxGrid/NyxGrid.types.ts
@@ -1,0 +1,29 @@
+import type { VNode } from 'vue'
+import type { NyxSize } from '@/types'
+
+export enum NyxGridMode {
+  Grid = 'grid',
+  Masonry = 'masonry',
+}
+
+export interface NyxGridProps {
+  title?: string
+  mode?: NyxGridMode
+  columns?: number
+  gap?: NyxSize | number
+}
+
+export interface NyxGridItem {
+  key: string | number
+  order: number
+  vnode: VNode
+}
+
+export interface NyxGridLayoutItem {
+  key: string | number
+  order: number
+  width: number
+  height: number
+  x: number
+  y: number
+}

--- a/src/components/NyxGrid/NyxGrid.vue
+++ b/src/components/NyxGrid/NyxGrid.vue
@@ -1,0 +1,275 @@
+<script setup lang="ts">
+import './NyxGrid.scss'
+import {
+  computed,
+  nextTick,
+  onBeforeUnmount,
+  onMounted,
+  useSlots,
+  useTemplateRef,
+  watch,
+  type CSSProperties,
+} from 'vue'
+import { NyxSize } from '@/types'
+import { NyxGridMode, type NyxGridProps } from './NyxGrid.types'
+
+const DEFAULT_COLUMNS = 3
+const GAP_REM_MAP: Record<NyxSize, number> = {
+  [NyxSize.XSmall]: 0.25,
+  [NyxSize.Small]: 0.5,
+  [NyxSize.Medium]: 0.75,
+  [NyxSize.Large]: 1,
+  [NyxSize.XLarge]: 1.25,
+}
+
+const props = withDefaults(defineProps<NyxGridProps>(), {
+  mode: NyxGridMode.Grid,
+  columns: DEFAULT_COLUMNS,
+  gap: NyxSize.Medium,
+})
+
+const slots = useSlots()
+const elGrid = useTemplateRef<HTMLElement>('elGrid')
+const elContent = useTemplateRef<HTMLDivElement>('elContent')
+
+let layoutFrame = 0
+let resizeObserver: ResizeObserver | null = null
+let mutationObserver: MutationObserver | null = null
+const observedElements = new Set<HTMLElement>()
+
+const hasHeader = computed(() => !!slots.header || !!props.title)
+const hasFooter = computed(() => !!slots.footer)
+
+const resolvedMode = computed<NyxGridMode>(() => (
+  props.mode === NyxGridMode.Masonry ? NyxGridMode.Masonry : NyxGridMode.Grid
+))
+
+const resolvedColumns = computed(() => {
+  const candidate = Number(props.columns)
+  return Number.isInteger(candidate) && candidate > 0 ? candidate : DEFAULT_COLUMNS
+})
+
+const resolvedGap = computed<NyxSize>(() => (
+  Object.values(NyxSize).includes(props.gap as NyxSize) ? props.gap as NyxSize : NyxSize.Medium
+))
+
+const resolvedGapValue = computed(() => {
+  if (typeof props.gap === 'number' && Number.isFinite(props.gap) && props.gap >= 0) {
+    return `${props.gap}rem`
+  }
+
+  return `calc(var(--nyx-gap-${resolvedGap.value}) * 1.5)`
+})
+
+const rootStyle = computed<CSSProperties>(() => ({
+  '--nyx-grid-gap': resolvedGapValue.value,
+  '--nyx-grid-columns': String(resolvedColumns.value),
+}))
+
+function getContentElements() {
+  if (!elContent.value) return []
+
+  return Array.from(elContent.value.children).filter(
+    (node): node is HTMLElement => node instanceof HTMLElement
+  )
+}
+
+function resetMasonryElement(element: HTMLElement) {
+  element.style.position = ''
+  element.style.left = ''
+  element.style.top = ''
+  element.style.width = ''
+  element.style.maxWidth = ''
+  element.style.boxSizing = ''
+}
+
+function syncObservedElements() {
+  if (!resizeObserver) return
+
+  const nextElements = new Set(getContentElements())
+
+  observedElements.forEach((element) => {
+    if (!nextElements.has(element)) {
+      resizeObserver?.unobserve(element)
+      observedElements.delete(element)
+    }
+  })
+
+  nextElements.forEach((element) => {
+    if (!observedElements.has(element)) {
+      resizeObserver?.observe(element)
+      observedElements.add(element)
+    }
+  })
+}
+
+function getGapPx() {
+  if (typeof window === 'undefined') return 0
+
+  const token = `--nyx-gap-${resolvedGap.value}`
+  const source = elGrid.value ?? document.documentElement
+  const rootFontSize = Number.parseFloat(getComputedStyle(document.documentElement).fontSize) || 16
+
+  if (typeof props.gap === 'number' && Number.isFinite(props.gap) && props.gap >= 0) {
+    return props.gap * rootFontSize
+  }
+
+  const resolvedValue = getComputedStyle(source).getPropertyValue(token).trim()
+  const parsed = Number.parseFloat(resolvedValue)
+
+  if (Number.isFinite(parsed) && parsed > 0) {
+    if (resolvedValue.endsWith('rem')) {
+      return parsed * rootFontSize * 1.5
+    }
+
+    if (resolvedValue.endsWith('px')) {
+      return parsed * 1.5
+    }
+
+    return parsed * 1.5
+  }
+
+  return GAP_REM_MAP[resolvedGap.value] * rootFontSize * 1.5
+}
+
+function layoutMasonry() {
+  const contentElement = elContent.value
+
+  if (!contentElement || resolvedMode.value !== 'masonry') return
+
+  const elements = getContentElements()
+
+  syncObservedElements()
+
+  if (elements.length === 0) {
+    contentElement.style.height = ''
+    return
+  }
+
+  const gapPx = getGapPx()
+  const availableWidth = contentElement.clientWidth
+
+  if (!availableWidth) {
+    contentElement.style.height = ''
+    elements.forEach(resetMasonryElement)
+    return
+  }
+
+  const columnWidth = Math.max(0, (availableWidth - (gapPx * Math.max(0, resolvedColumns.value - 1))) / resolvedColumns.value)
+
+  if (!columnWidth) {
+    contentElement.style.height = ''
+    elements.forEach(resetMasonryElement)
+    return
+  }
+
+  const columnBottoms = Array.from({ length: resolvedColumns.value }, () => 0)
+
+  elements.forEach((element, index) => {
+    const columnIndex = index % resolvedColumns.value
+    const x = columnIndex * (columnWidth + gapPx)
+    const y = columnBottoms[columnIndex]
+
+    element.style.position = 'absolute'
+    element.style.boxSizing = 'border-box'
+    element.style.setProperty('width', `${columnWidth}px`)
+    element.style.setProperty('max-width', `${columnWidth}px`)
+    element.style.left = `${x}px`
+    element.style.top = `${y}px`
+
+    columnBottoms[columnIndex] += element.offsetHeight + gapPx
+  })
+
+  contentElement.style.height = `${Math.max(0, ...columnBottoms.map(bottom => bottom - gapPx))}px`
+}
+
+function resetMasonryLayout() {
+  const contentElement = elContent.value
+  if (!contentElement) return
+
+  contentElement.style.height = ''
+  getContentElements().forEach(resetMasonryElement)
+}
+
+function scheduleLayout() {
+  if (typeof window === 'undefined') return
+
+  if (layoutFrame) {
+    cancelAnimationFrame(layoutFrame)
+  }
+
+  nextTick(() => {
+    layoutFrame = requestAnimationFrame(() => {
+      layoutFrame = 0
+
+      if (resolvedMode.value === NyxGridMode.Masonry) {
+        layoutMasonry()
+        return
+      }
+
+      resetMasonryLayout()
+    })
+  })
+}
+
+watch([resolvedMode, resolvedColumns, resolvedGap], () => {
+  scheduleLayout()
+})
+
+onMounted(() => {
+  if (typeof window !== 'undefined' && 'ResizeObserver' in window) {
+    resizeObserver = new ResizeObserver(() => {
+      scheduleLayout()
+    })
+
+    if (elContent.value) {
+      resizeObserver.observe(elContent.value)
+    }
+  }
+
+  if (typeof window !== 'undefined' && 'MutationObserver' in window && elContent.value) {
+    mutationObserver = new MutationObserver(() => {
+      scheduleLayout()
+    })
+    mutationObserver.observe(elContent.value, { childList: true })
+  }
+
+  window.addEventListener('resize', scheduleLayout)
+  scheduleLayout()
+})
+
+onBeforeUnmount(() => {
+  if (layoutFrame) {
+    cancelAnimationFrame(layoutFrame)
+  }
+
+  window.removeEventListener('resize', scheduleLayout)
+  mutationObserver?.disconnect()
+  resizeObserver?.disconnect()
+  mutationObserver = null
+  resizeObserver = null
+  observedElements.clear()
+})
+</script>
+
+<template>
+  <section
+    ref="elGrid"
+    class="nyx-grid"
+    :class="[`nyx-grid--${resolvedMode}`]"
+    :style="rootStyle"
+  >
+    <header v-if="hasHeader" class="nyx-grid__header">
+      <slot v-if="$slots.header" name="header" />
+      <h2 v-else class="nyx-grid__title">{{ props.title }}</h2>
+    </header>
+
+    <div ref="elContent" class="nyx-grid__content">
+      <slot />
+    </div>
+
+    <footer v-if="hasFooter" class="nyx-grid__footer">
+      <slot name="footer" />
+    </footer>
+  </section>
+</template>

--- a/src/components/NyxGrid/NyxGrid.vue
+++ b/src/components/NyxGrid/NyxGrid.vue
@@ -75,12 +75,9 @@ function getContentElements() {
 }
 
 function resetMasonryElement(element: HTMLElement) {
-  element.style.position = ''
-  element.style.left = ''
-  element.style.top = ''
-  element.style.width = ''
-  element.style.maxWidth = ''
-  element.style.boxSizing = ''
+  element.style.removeProperty('--nyx-grid-item-width')
+  element.style.removeProperty('--nyx-grid-item-left')
+  element.style.removeProperty('--nyx-grid-item-top')
 }
 
 function syncObservedElements() {
@@ -142,7 +139,7 @@ function layoutMasonry() {
   syncObservedElements()
 
   if (elements.length === 0) {
-    contentElement.style.height = ''
+    contentElement.style.removeProperty('--nyx-grid-masonry-height')
     return
   }
 
@@ -150,7 +147,7 @@ function layoutMasonry() {
   const availableWidth = contentElement.clientWidth
 
   if (!availableWidth) {
-    contentElement.style.height = ''
+    contentElement.style.removeProperty('--nyx-grid-masonry-height')
     elements.forEach(resetMasonryElement)
     return
   }
@@ -158,7 +155,7 @@ function layoutMasonry() {
   const columnWidth = Math.max(0, (availableWidth - (gapPx * Math.max(0, resolvedColumns.value - 1))) / resolvedColumns.value)
 
   if (!columnWidth) {
-    contentElement.style.height = ''
+    contentElement.style.removeProperty('--nyx-grid-masonry-height')
     elements.forEach(resetMasonryElement)
     return
   }
@@ -170,24 +167,24 @@ function layoutMasonry() {
     const x = columnIndex * (columnWidth + gapPx)
     const y = columnBottoms[columnIndex]
 
-    element.style.position = 'absolute'
-    element.style.boxSizing = 'border-box'
-    element.style.setProperty('width', `${columnWidth}px`)
-    element.style.setProperty('max-width', `${columnWidth}px`)
-    element.style.left = `${x}px`
-    element.style.top = `${y}px`
+    element.style.setProperty('--nyx-grid-item-width', `${columnWidth}px`)
+    element.style.setProperty('--nyx-grid-item-left', `${x}px`)
+    element.style.setProperty('--nyx-grid-item-top', `${y}px`)
 
     columnBottoms[columnIndex] += element.offsetHeight + gapPx
   })
 
-  contentElement.style.height = `${Math.max(0, ...columnBottoms.map(bottom => bottom - gapPx))}px`
+  contentElement.style.setProperty(
+    '--nyx-grid-masonry-height',
+    `${Math.max(0, ...columnBottoms.map(bottom => bottom - gapPx))}px`
+  )
 }
 
 function resetMasonryLayout() {
   const contentElement = elContent.value
   if (!contentElement) return
 
-  contentElement.style.height = ''
+  contentElement.style.removeProperty('--nyx-grid-masonry-height')
   getContentElements().forEach(resetMasonryElement)
 }
 

--- a/src/components/NyxGrid/index.ts
+++ b/src/components/NyxGrid/index.ts
@@ -1,0 +1,1 @@
+export { default as NyxGrid } from './NyxGrid.vue'

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -8,6 +8,7 @@ import NyxCarousel from './NyxCarousel/NyxCarousel.vue'
 import NyxCheckbox from './NyxCheckbox/NyxCheckbox.vue'
 import NyxForm from './NyxForm/NyxForm.vue'
 import NyxFormField from './NyxForm/NyxFormField.vue'
+import NyxGrid from './NyxGrid/NyxGrid.vue'
 import NyxInput from './NyxInput/NyxInput.vue'
 import NyxMedia from './NyxMedia/NyxMedia.vue'
 import NyxModal from './NyxModal/NyxModal.vue'
@@ -34,6 +35,7 @@ export {
   NyxCheckbox,
   NyxForm,
   NyxFormField,
+  NyxGrid,
   NyxInput,
   NyxMedia,
   NyxModal,

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,7 @@ import { type App } from 'vue'
 import { vClickOutside } from './directives'
 import type { NyxKitOptions } from './types'
 import { initColourMode } from './composables/useNyxColourMode'
+export { NyxGrid } from './components'
 
 export type { NyxKitPrimitive, NyxKitDefaults, NyxKitOptions, NyxColourModeOptions } from './types'
 


### PR DESCRIPTION
## Summary
- add the new `NyxGrid` layout component with optional header/footer regions, enum-based mode selection, column control, and configurable gap behavior
- implement standard grid and masonry layout support with Storybook examples for static usage and dynamic add/remove behavior using `NyxCard`
- add the full spec-kit artifact set and living docs for `NyxGrid`, plus export and repo housekeeping updates needed to publish and validate it