### PR TITLE
feat(NyxEditor): add footer meta

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,7 @@ The project constitution is at `.specify/memory/constitution.md`.
 - N/A - layout state is ephemeral DOM measurement only (006-add-nyx-grid)
 - TypeScript 5.7 / Vue 3.5 + Vue 3, `@tiptap/vue-3`, `@tiptap/starter-kit`, `@tiptap/extension-underline`, `@tiptap/extension-task-list`, `@tiptap/extension-task-item`, `tiptap-markdown`, SCSS (007-editor-comment-annotations)
 - N/A - comment threads and persisted annotations are consumer-owned inputs (007-editor-comment-annotations)
+- TypeScript 5.x + Vue 3.5 + Vue 3, `@tiptap/vue-3`, Tiptap `StarterKit`, `tiptap-markdown`, existing internal NyxEditor sub-components/composables (008-editor-footer-info)
 
 ## Recent Changes
 - 003-testing-improvements: Added TypeScript 5.x / Vue 3 + `@vue/test-utils`, `vitest`, `@playwright/test`, `jsdom`

--- a/docs/specs/components/NyxEditor.spec.md
+++ b/docs/specs/components/NyxEditor.spec.md
@@ -26,7 +26,7 @@ NyxEditor provides an opinionated but flexible rich-text editing experience. It 
 - **Zen mode**: custom bubble menu — listens to `onSelectionUpdate`, reads `window.getSelection().getRangeAt(0).getBoundingClientRect()` to position a `<Teleport>`-ed `div` above the selection, and renders `NyxEditorToolbarContent` inside the teleported shell. It emits `selection` as a `NyxAnnotationAnchor` whenever a non-empty selection exists. The annotation action emits the same anchor shape through `annotation:create`. `@mousedown` on the bubble sets a `suppressNextHide` flag (cleared with `requestAnimationFrame`) so that clicking a formatting button does not collapse the bubble before the command fires.
 - Annotation rendering is implemented as a Tiptap/ProseMirror decoration plugin that reads the two-way `annotations` model and decorates matching ranges with annotation classes and `data-nyx-annotation-*` attributes.
 - **Toolbar mode**: renders an internal `NyxEditorToolbar` wrapper above the editor content; that wrapper hosts the shared `NyxEditorToolbarContent` controls. _(See Known Limitations — not yet rendering in Storybook.)_
-- A default footer renders structural path information on the left and word count on the right; the same payload is exposed through a scoped `footer` slot.
+- A default footer renders structural path information on the left and word count on the right when `hasFooter` is `true`; the footer also becomes visible automatically when a scoped `footer` slot is present.
 - The editor root is capped at `100dvh`; editor content/source areas scroll internally so the footer remains pinned to the bottom edge of the component.
 - v-model syncs bi-directionally via `onUpdate` (editor → model) and a `watch` (model → editor)
 - `useNyxProps` is used for visual prop integration (theme, size, variant, pixel)
@@ -43,6 +43,7 @@ NyxEditor provides an opinionated but flexible rich-text editing experience. It 
 | `pixel` | `boolean` | `false` | Pixel-art mode |
 | `disabled` | `boolean` | `false` | Makes the editor read-only |
 | `placeholder` | `string` | `''` | Placeholder shown when editor is empty |
+| `hasFooter` | `boolean` | `false` | Requests the default footer region; the footer also becomes visible automatically when a scoped `footer` slot is provided |
 | `annotationStatusTheme` | `NyxAnnotationStatusTheme` | partial map with built-in defaults | Maps annotation status values to the theme tokens used for highlight styling; missing keys fall back to `NyxTheme.Primary` |
 
 ## Emits

--- a/docs/specs/components/NyxEditor.spec.md
+++ b/docs/specs/components/NyxEditor.spec.md
@@ -20,11 +20,14 @@ NyxEditor provides an opinionated but flexible rich-text editing experience. It 
 - Uses `useEditor` and `EditorContent` from `@tiptap/vue-3`
 - Extensions loaded: `StarterKit`, `Underline`, `TaskList`, `TaskItem` always; `Markdown` (from `tiptap-markdown`) when `format` is `markdown`
 - Annotation-specific logic is extracted into the internal `useEditorAnnotations` composition so anchor generation, decoration mapping, and annotation focus/blur events do not live directly in the component body.
+- Footer-specific logic is extracted into the internal `useEditorMeta` composition so caret-aware structure and word-count calculation stay derived from editor state.
 - Formatting controls are centralized in an internal `NyxEditorToolbarContent` sub-component that renders the shared button groups for both toolbar mode and the zen bubble menu.
 - **Toolbar mode** uses an internal `NyxEditorToolbar` wrapper component so `NyxEditor` does not own the toolbar shell markup directly.
 - **Zen mode**: custom bubble menu — listens to `onSelectionUpdate`, reads `window.getSelection().getRangeAt(0).getBoundingClientRect()` to position a `<Teleport>`-ed `div` above the selection, and renders `NyxEditorToolbarContent` inside the teleported shell. It emits `selection` as a `NyxAnnotationAnchor` whenever a non-empty selection exists. The annotation action emits the same anchor shape through `annotation:create`. `@mousedown` on the bubble sets a `suppressNextHide` flag (cleared with `requestAnimationFrame`) so that clicking a formatting button does not collapse the bubble before the command fires.
 - Annotation rendering is implemented as a Tiptap/ProseMirror decoration plugin that reads the two-way `annotations` model and decorates matching ranges with annotation classes and `data-nyx-annotation-*` attributes.
 - **Toolbar mode**: renders an internal `NyxEditorToolbar` wrapper above the editor content; that wrapper hosts the shared `NyxEditorToolbarContent` controls. _(See Known Limitations — not yet rendering in Storybook.)_
+- A default footer renders structural path information on the left and word count on the right; the same payload is exposed through a scoped `footer` slot.
+- The editor root is capped at `100dvh`; editor content/source areas scroll internally so the footer remains pinned to the bottom edge of the component.
 - v-model syncs bi-directionally via `onUpdate` (editor → model) and a `watch` (model → editor)
 - `useNyxProps` is used for visual prop integration (theme, size, variant, pixel)
 
@@ -64,6 +67,12 @@ NyxEditor provides an opinionated but flexible rich-text editing experience. It 
 
 The source toggle button (top-right corner of the editor) also drives `v-model:source`.
 
+## Slots
+
+| Slot | Scope | Purpose |
+|---|---|---|
+| `footer` | `{ meta: NyxEditorMeta }` | Custom footer presentation using editor-computed meta data |
+
 ## Keyboard behaviour
 
 Inherited from Tiptap/ProseMirror defaults:
@@ -100,6 +109,30 @@ Ownership split:
 - Consumer-owned: `id`, `tone`, and external comment/thread metadata stored outside the editor
 - Editor-managed: live `anchor.range` and `anchor.context` values when document edits remap annotation positions
 - Preserved as original selection text: `anchor.text` unless the contract is intentionally revised later
+
+## Footer model
+
+Shared editor types define the footer contract:
+
+- `NyxEditorMeta`: `{ segments, pathText, wordCount, selection }`
+- `NyxEditorMetaPathSegment`: structured path segment for heading titles, paragraphs, lists, and list items
+- `NyxEditorMetaSelection`: `{ from, to, empty }`
+
+The default footer shows:
+
+- left side: `meta.pathText`
+- right side: `${meta.wordCount} words`
+
+Display conventions:
+
+- heading segments render only the heading title text, without literal tag names such as `h1`
+- list segments render as `list`
+- list-item segments render as `item N`
+- paragraph segments render as `paragraph N`
+- paragraph numbering resets within the current heading section instead of counting across the full document
+- default footer separators render as chevron icons rather than literal `>` text
+
+The scoped `footer` slot receives the same `NyxEditorMeta` payload used by the default footer under the `meta` slot prop.
 
 ## Mode names
 

--- a/specs/008-editor-footer-info/checklists/requirements.md
+++ b/specs/008-editor-footer-info/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: NyxEditor Footer Info
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-03-28
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Validation completed in one pass.
+- Scope covers the default footer display plus footer-slot customization data.

--- a/specs/008-editor-footer-info/contracts/component-api.md
+++ b/specs/008-editor-footer-info/contracts/component-api.md
@@ -1,0 +1,38 @@
+# Component API Contract: NyxEditor Footer Info
+
+**Branch**: `008-editor-footer-info` | **Date**: 2026-03-28
+
+This document captures the public NyxEditor contract additions for footer information.
+
+## NyxEditor Footer Behavior
+
+### Default footer
+
+| Area | Contract |
+|------|----------|
+| Left side | Shows the current structural path from heading context to the active block |
+| Right side | Shows the current document word count |
+| Visibility | Footer renders by default |
+
+### Footer slot
+
+| Slot | Scope | Purpose |
+|------|-------|---------|
+| `footer` | `{ meta: NyxEditorMeta }` | Allows consumers to customize footer presentation using editor-provided meta data |
+
+### Footer payload
+
+| Field | Type | Purpose |
+|-------|------|---------|
+| `segments` | `NyxEditorMetaPathSegment[]` | Structured caret path data for custom rendering |
+| `pathText` | `string` | Display-ready structural path string using concise labels |
+| `wordCount` | `number` | Current editable document word count |
+| `selection` | `NyxEditorMetaSelection` | Current caret/selection metadata relevant to footer updates |
+
+### Scope boundaries
+
+| In scope | Out of scope |
+|----------|--------------|
+| Default footer path display | Consumer-side recomputation of editor structure |
+| Default footer word count | External analytics or document-metadata systems |
+| Scoped footer slot payload | Arbitrary editor-layout customization outside the footer region |

--- a/specs/008-editor-footer-info/data-model.md
+++ b/specs/008-editor-footer-info/data-model.md
@@ -1,0 +1,75 @@
+# Data Model: NyxEditor Footer Info
+
+**Branch**: `008-editor-footer-info` | **Date**: 2026-03-28
+
+## Entities
+
+### NyxEditorMeta
+
+The complete footer state used by the default footer UI and exposed to the `footer` slot.
+
+**Fields**:
+- `segments`: ordered structural path segments from heading context to the current block
+- `pathText`: display-ready footer text for the left side
+- `wordCount`: total word count for the editable document
+- `selection`: current caret/selection metadata relevant to footer updates
+
+**Validation rules**:
+- Must always be derivable from current editor state
+- Must update when content changes or caret position changes
+- Must remain available whether or not a custom footer slot is provided
+
+### NyxEditorMetaPathSegment
+
+One segment in the structural path shown in the footer.
+
+**Fields**:
+- `type`: segment category such as heading, paragraph, list, or list item
+- `label`: human-readable text for display
+- `index`: optional positional index when relevant
+- `level`: optional heading depth when relevant
+
+**Validation rules**:
+- Segment order follows document hierarchy from outer context to active block
+- List and paragraph segments include index data when the spec requires it
+
+### NyxEditorMetaSelection
+
+Selection metadata used to describe the current caret or selection state.
+
+**Fields**:
+- `from`: current selection start position
+- `to`: current selection end position
+- `empty`: whether the selection is collapsed to a caret
+
+**Validation rules**:
+- Must reflect the live editor selection
+- Must support collapsed caret positions, not only non-empty selections
+
+## Relationships
+
+| From | Relationship | To |
+|------|--------------|----|
+| `NyxEditorMeta` | contains many | `NyxEditorMetaPathSegment` |
+| `NyxEditorMeta` | contains one | `NyxEditorMetaSelection` |
+
+## State Transitions
+
+### Footer refresh flow
+
+```text
+Editor creates or updates
+-> current selection/caret changes or content changes
+-> footer info is recomputed from editor state
+-> default footer and footer slot receive the updated footer info
+```
+
+## Edge Rules
+
+| Case | Expected model behavior |
+|------|-------------------------|
+| Caret inside heading | Footer path reflects the heading as the active block |
+| Caret inside paragraph below headings | Footer path includes heading context plus paragraph index |
+| Caret inside list item | Footer path includes heading context, list type, and list item index |
+| Empty document | Footer info still exists with empty or minimal path and zero word count |
+| Custom footer slot | Receives the same `NyxEditorMeta` used by the default footer |

--- a/specs/008-editor-footer-info/plan.md
+++ b/specs/008-editor-footer-info/plan.md
@@ -1,0 +1,126 @@
+# Implementation Plan: NyxEditor Footer Info
+
+**Branch**: `008-editor-footer-info` | **Date**: 2026-03-28 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/008-editor-footer-info/spec.md`
+
+## Summary
+
+Add a default `NyxEditor` footer that shows the current caret-aware document path on the left and live word count on the right, while exposing the same footer data through a scoped `footer` slot for consumer customization.
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.x + Vue 3.5  
+**Primary Dependencies**: Vue 3, `@tiptap/vue-3`, Tiptap `StarterKit`, `tiptap-markdown`, existing internal NyxEditor sub-components/composables  
+**Storage**: N/A  
+**Testing**: Vitest + `@vue/test-utils`; Storybook for API verification; Playwright only if browser-level caret/footer behavior proves unreliable in unit coverage  
+**Target Platform**: Browser, published component library  
+**Project Type**: Vue component library  
+**Performance Goals**: Footer updates feel immediate during caret movement and content edits in normal single-document editing flows  
+**Constraints**: Must follow docs-first workflow; keep changes additive to the `NyxEditor` public contract; use existing editor-state data instead of reparsing serialized markdown/html; use design-token-based styling; keep footer calculations inside `NyxEditor` rather than offloading them to consumers  
+**Scale/Scope**: One existing component (`NyxEditor`), shared editor types, stories, specs, and unit coverage; no new runtime dependencies
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Gate | Status | Notes |
+|------|--------|-------|
+| Docs Are the Source of Truth | ✓ PASS | `docs/specs/components/NyxEditor.spec.md` already exists and must be updated with footer props/slots/data |
+| Spec Before Code | ✓ PASS | Feature spec exists in `specs/008-editor-footer-info/spec.md`; implementation will also update the living NyxEditor doc spec |
+| Minimal Diff | ✓ PASS | Scope is limited to NyxEditor, shared editor types, stories, and tests |
+| Consumer-Library Contract | ✓ PASS | Footer support is additive via default UI plus scoped slot payload |
+| Test-First for Non-Trivial Logic | ✓ PASS | Footer path and word-count logic require unit coverage; E2E only if browser behavior needs it |
+| Design Token Discipline | ✓ PASS | Footer styling stays within existing NyxEditor SCSS/token patterns |
+| Consistency Over Local Optimisation | ✓ PASS | Slot naming follows existing `footer` convention from component-model docs |
+
+*Post-design re-check: All gates still pass. Footer information remains an additive NyxEditor contract with synced docs and stories.*
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/008-editor-footer-info/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── component-api.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+src/components/NyxEditor/
+├── NyxEditor.vue
+├── NyxEditor.scss
+├── NyxEditor.types.ts
+├── NyxEditor.spec.ts
+├── NyxEditor.stories.ts
+├── NyxEditorBubbleMenu/
+├── NyxEditorToolbar/
+├── NyxEditorToolbarContent/
+└── useEditorAnnotations.ts
+
+src/types/
+└── editor.ts
+
+docs/specs/components/
+└── NyxEditor.spec.md
+```
+
+**Structure Decision**: Keep the footer feature inside the existing `NyxEditor` component boundary, with any shared footer-state helper colocated in `src/components/NyxEditor/` and any new public payload types added to `src/types/editor.ts`.
+
+## Phase 0: Research
+
+Research will confirm three design choices before implementation:
+
+1. Derive footer info directly from Tiptap editor state rather than serialized markdown/html
+2. Represent the caret path as structured segments plus a preformatted display string
+3. Expose footer customization through the existing `footer` slot naming convention used elsewhere in the library
+
+## Phase 1: Design & Contracts
+
+Design outputs will include:
+
+- `research.md` documenting editor-state and slot-pattern decisions
+- `data-model.md` for footer info, structural path segments, and slot payload
+- `contracts/component-api.md` capturing the default footer behavior and `footer` slot payload contract
+- `quickstart.md` showing default and custom footer usage
+
+## Implementation Steps
+
+### Step 1 - Add shared footer data types
+
+- Add public meta data interfaces to `src/types/editor.ts`
+- Keep the payload focused on structured path data, display-ready path text, word count, and caret/selection metadata
+
+### Step 2 - Compute footer info from editor state
+
+- Add footer-state calculation inside `NyxEditor` or a colocated helper/composition
+- Recompute footer data on editor creation, content updates, and caret/selection updates
+- Support collapsed caret positions as well as non-empty selections
+
+### Step 3 - Render the default footer
+
+- Add a footer region to `NyxEditor.vue`
+- Show structural path on the left and word count on the right using the computed footer info
+- Style the footer in `NyxEditor.scss` using existing editor tokens and layout patterns
+- Cap the component at `100dvh` and keep editor content/source regions scrollable so the footer stays pinned to the bottom
+
+### Step 4 - Expose footer customization via slot
+
+- Add a scoped `footer` slot in `NyxEditor.vue`
+- Pass the full footer payload to the slot while preserving the default footer as the fallback
+
+### Step 5 - Sync docs, stories, and tests
+
+- Update `docs/specs/components/NyxEditor.spec.md` with footer architecture, slot scope, and default behavior
+- Add Storybook coverage in `src/components/NyxEditor/NyxEditor.stories.ts` for default and custom footer rendering
+- Add unit tests in `src/components/NyxEditor/NyxEditor.spec.ts` for path calculation, word count, and slot payload consistency
+
+## Complexity Tracking
+
+No constitution violations or special complexity exceptions are required.

--- a/specs/008-editor-footer-info/quickstart.md
+++ b/specs/008-editor-footer-info/quickstart.md
@@ -1,0 +1,41 @@
+# Quickstart: NyxEditor Footer Info
+
+**Branch**: `008-editor-footer-info` | **Date**: 2026-03-28
+
+## Default footer
+
+Render `NyxEditor` normally and the footer appears automatically.
+
+```vue
+<NyxEditor v-model="content" />
+```
+
+Expected behavior:
+- the left side shows the current structural path for the caret location using heading titles, `list`, `item N`, and `paragraph N`
+- the right side shows the current document word count
+
+## Custom footer slot
+
+Consumers can override the footer content while using the same editor-provided footer data.
+
+```vue
+<NyxEditor v-model="content">
+  <template #footer="{ meta }">
+    <div class="my-editor-footer">
+      <span>{{ meta.pathText }}</span>
+      <strong>{{ meta.wordCount }} words</strong>
+    </div>
+  </template>
+</NyxEditor>
+```
+
+Expected behavior:
+- the slot receives the same footer data used by the default footer
+- footer content updates when the caret moves or document text changes
+
+## Validation scenarios
+
+1. Place the caret inside a paragraph beneath nested headings and verify the footer path updates
+2. Place the caret inside a list item and verify the footer path includes list type and item index
+3. Add or remove text and verify the word count updates
+4. Render a custom footer slot and verify `meta.pathText` and `meta.wordCount` stay in sync with editor state

--- a/specs/008-editor-footer-info/research.md
+++ b/specs/008-editor-footer-info/research.md
@@ -1,0 +1,49 @@
+# Research: NyxEditor Footer Info
+
+**Branch**: `008-editor-footer-info` | **Date**: 2026-03-28
+
+## Decision 1: Drive footer info from editor state
+
+**Decision**: Compute footer structure and word count directly from the current Tiptap editor state.
+
+**Rationale**: The footer must track the live caret position, including collapsed selections, and respond to document edits immediately. Serialized markdown or HTML does not provide reliable caret-aware structure without extra parsing.
+
+**Alternatives considered**:
+- Recompute from serialized markdown/html — rejected because it loses direct selection/caret context and adds unnecessary parsing overhead.
+
+## Decision 2: Use a structured footer payload plus display-ready text
+
+**Decision**: Represent footer data as structured path segments alongside a preformatted path string and numeric word count.
+
+**Rationale**: The default footer needs a ready-to-render string, while the scoped slot needs structured data so consumers can customize presentation without reparsing the string.
+
+**Alternatives considered**:
+- Expose only a path string — rejected because it limits slot customization.
+- Expose only segments — rejected because the default footer would have to reformat them repeatedly in the render path.
+
+## Decision 3: Use the existing `footer` slot convention
+
+**Decision**: Expose footer customization through a scoped `footer` slot.
+
+**Rationale**: `docs/architecture/component-model.md` already standardizes `footer` as the slot name for bottom content regions. Reusing that convention keeps `NyxEditor` aligned with the rest of the component library.
+
+**Alternatives considered**:
+- Introduce a custom slot name like `editor-footer` — rejected because it adds inconsistency without extra value.
+
+## Decision 4: Keep the footer visible by default
+
+**Decision**: Render the footer by default and use the scoped slot only to override the inner content.
+
+**Rationale**: The feature spec assumes default footer visibility and positions the slot as a customization surface, not as an opt-in toggle for whether a footer exists at all.
+
+**Alternatives considered**:
+- Make the footer opt-in — rejected because it weakens the default user value described in the spec.
+
+## Decision 5: Keep implementation within the NyxEditor boundary
+
+**Decision**: Implement footer-state logic within `NyxEditor` or a small colocated helper/composition in `src/components/NyxEditor/`.
+
+**Rationale**: The footer depends on editor-internal state and should stay close to the editor lifecycle. This keeps the change surgical and avoids introducing a broader cross-component abstraction prematurely.
+
+**Alternatives considered**:
+- Add a generic cross-editor utility outside `NyxEditor` — rejected because the current need is specific to this editor and does not yet justify a broader abstraction.

--- a/specs/008-editor-footer-info/spec.md
+++ b/specs/008-editor-footer-info/spec.md
@@ -1,0 +1,111 @@
+# Feature Specification: NyxEditor Footer Info
+
+**Feature Branch**: `008-editor-footer-info`  
+**Created**: 2026-03-28  
+**Status**: Draft  
+**Input**: User description: "i made a boilerplate for the editor footer content, by default it will show:
+- document structure up until the current caret on the left-hand side of the footer
+  => h1 title > h2 title > ul > li [index]
+  => h1 title > h2 title > paragraph [index]
+- word count on the right-hand side of the footer
+
+this information should also be passed back to the template using the slot for customization"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Read document context at the caret (Priority: P1)
+
+As an editor user, I can see the current document path in the footer so I understand where my caret sits inside the document structure while editing.
+
+**Why this priority**: The footer only provides value if it immediately tells the user where they are in the document without extra clicks or inspection.
+
+**Independent Test**: Can be fully tested by moving the caret across headings, paragraphs, and list items and verifying that the footer updates to the correct structural path each time.
+
+**Acceptance Scenarios**:
+
+1. **Given** the caret is inside a paragraph under nested headings, **When** the footer is visible, **Then** the left side shows the heading titles followed by `paragraph N`, where `N` is counted within the current heading section rather than across the whole document.
+2. **Given** the caret is inside a list item under nested headings, **When** the footer is visible, **Then** the left side shows the heading titles followed by `list` and `item N`.
+3. **Given** the caret moves to a different block, **When** the editor updates the current selection, **Then** the footer reflects the new structural path without requiring manual refresh.
+
+---
+
+### User Story 2 - See document length at a glance (Priority: P2)
+
+As an editor user, I can see the current word count in the footer so I can monitor document length while editing.
+
+**Why this priority**: Word count is a common editorial signal and complements the structural path without changing the editing flow.
+
+**Independent Test**: Can be fully tested by editing text content and verifying that the right side of the footer updates the displayed word count accordingly.
+
+**Acceptance Scenarios**:
+
+1. **Given** the document contains text, **When** the footer renders, **Then** the right side shows the current word count.
+2. **Given** the user adds or removes words, **When** the editor content changes, **Then** the word count updates to match the current document content.
+3. **Given** the document contains headings, lists, and paragraphs, **When** the footer calculates word count, **Then** the displayed count reflects the full editable document content rather than only the current block.
+
+---
+
+### User Story 3 - Customize footer presentation with slot data (Priority: P3)
+
+As a consuming project, I can receive the footer information through a slot so I can customize how the footer content is rendered without recomputing editor-specific state outside the component.
+
+**Why this priority**: Consumers need flexibility in presentation, but should not have to reproduce caret-path and count logic themselves.
+
+**Independent Test**: Can be fully tested by rendering `NyxEditor` with a footer slot and verifying that the slot receives the same structural path and word-count data shown by the default footer.
+
+**Acceptance Scenarios**:
+
+1. **Given** a consuming project provides a footer slot, **When** the editor renders, **Then** the slot receives the current footer data needed for custom rendering.
+2. **Given** the caret moves or document content changes, **When** the footer data updates, **Then** the slot receives the updated values in sync with the default footer state.
+3. **Given** no custom slot is provided, **When** the editor renders, **Then** the default footer layout still shows structural path on the left and word count on the right.
+
+---
+
+### Edge Cases
+
+- The caret is inside a heading itself, rather than inside a paragraph or list item below it.
+- The caret is inside nested lists and the footer must identify the correct active list type and item index.
+- The document is empty or contains only whitespace.
+- The caret is inside a paragraph before any heading exists in the document.
+- The document structure changes while the caret stays in place, causing the structural path to update.
+- A consumer provides a custom footer slot but only uses part of the slot data.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: `NyxEditor` MUST render a default footer area.
+- **FR-002**: The default footer MUST show the current document structure path on the left side.
+- **FR-003**: The document structure path MUST reflect the document hierarchy from the relevant heading context down to the block containing the current caret.
+- **FR-004**: For list content, the structure path MUST identify the active list type and the current item index.
+- **FR-005**: For paragraph content, the structure path MUST identify the paragraph and its index within the current structural scope.
+- **FR-006**: The default footer MUST show the current word count on the right side.
+- **FR-007**: Word count MUST update when the editable document content changes.
+- **FR-008**: The structural path MUST update when the current caret position changes.
+- **FR-009**: `NyxEditor` MUST expose the footer data through a slot so consuming projects can customize footer rendering.
+- **FR-010**: The slot payload MUST include both the structural path data and the word-count data shown by the default footer.
+- **FR-011**: The default footer MUST still render when no custom slot is provided.
+- **FR-012**: The footer feature MUST remain scoped to informational display and slot customization; it MUST NOT require consuming projects to recompute editor structure metadata outside the component.
+- **FR-013**: `NyxEditor` MUST cap its overall height at `100dvh` and keep the editable content area scrollable so the footer remains visible at the bottom of the component.
+
+### Key Entities *(include if feature involves data)*
+
+- **Editor Meta**: The current editor footer state, including structural path and word count.
+- **Structural Path Segment**: One part of the caret path, such as a heading title, list type, list item index, or paragraph index.
+- **Footer Meta Payload**: The data object passed to a consumer-provided footer slot for custom rendering.
+
+## Assumptions
+
+- The footer is visible by default rather than opt-in for the initial feature scope.
+- Structural path text uses concise labels: heading titles without literal tag names, `list`, `item N`, and `paragraph N`.
+- Word count is based on the editable document text rather than raw serialized markup.
+- The slot is intended for custom presentation, not for replacing editor-internal footer calculations.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: In acceptance testing, users can identify the current caret location within the document structure from the footer in 100% of tested heading, paragraph, and list scenarios.
+- **SC-002**: In acceptance testing, the footer updates structural path information immediately after caret movement across tested document blocks without requiring manual refresh.
+- **SC-003**: In editing regression tests, word count updates correctly after text insertion and deletion in 100% of covered scenarios.
+- **SC-004**: In integration testing, consuming projects can render a custom footer from slot payload data without reimplementing editor-side structure parsing.

--- a/specs/008-editor-footer-info/tasks.md
+++ b/specs/008-editor-footer-info/tasks.md
@@ -1,0 +1,188 @@
+# Tasks: NyxEditor Footer Info
+
+**Input**: Design documents from `/specs/008-editor-footer-info/`
+**Prerequisites**: plan.md, spec.md
+
+**Tests**: No additional test tasks are generated because the specification does not explicitly require a test-first workflow. Validation remains part of implementation and polish tasks.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., [US1], [US2], [US3])
+- Include exact file paths in descriptions
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Prepare the documentation and source locations for the new NyxEditor footer feature.
+
+- [x] T001 Review the current editor implementation and footer spec in `src/components/NyxEditor/NyxEditor.vue`, `docs/specs/components/NyxEditor.spec.md`, and `specs/008-editor-footer-info/spec.md`
+- [x] T002 Create or update the feature planning artifacts in `specs/008-editor-footer-info/` so implementation decisions stay aligned with the footer spec
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Establish the shared footer data model and editor wiring required by all user stories.
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete
+
+- [x] T003 Define typed footer data structures for NyxEditor in `src/types/editor.ts`
+- [x] T004 Update the NyxEditor public contract for footer data, slots, and any new internal props or models in `src/components/NyxEditor/NyxEditor.types.ts`
+- [x] T005 Implement shared footer-state calculation helpers or an internal composition for caret path and word count in `src/components/NyxEditor/`
+- [x] T006 Wire footer-state updates into editor lifecycle events in `src/components/NyxEditor/NyxEditor.vue` so content and caret changes both refresh footer info
+- [x] T007 Update the living NyxEditor component spec in `docs/specs/components/NyxEditor.spec.md` to describe the footer architecture, slot payload, and default footer behavior
+
+**Checkpoint**: Footer data model and update path are ready for story-by-story UI work
+
+---
+
+## Phase 3: User Story 1 - Read document context at the caret (Priority: P1) 🎯 MVP
+
+**Goal**: Show the current caret-aware structural path in the default footer.
+
+**Independent Test**: Move the caret through headings, paragraphs, and list items and verify the footer updates to the correct structure path each time.
+
+### Implementation for User Story 1
+
+- [x] T008 [US1] Implement default footer shell markup in `src/components/NyxEditor/NyxEditor.vue`
+- [x] T009 [US1] Render the left-side structural path from footer data in `src/components/NyxEditor/NyxEditor.vue`
+- [x] T010 [US1] Add footer styling for structure-path presentation in `src/components/NyxEditor/NyxEditor.scss`
+- [x] T011 [US1] Add or update editor unit coverage for caret-path calculation across headings, paragraphs, and list items in `src/components/NyxEditor/NyxEditor.spec.ts`
+- [x] T012 [US1] Add a Storybook example demonstrating default structural-path updates in `src/components/NyxEditor/NyxEditor.stories.ts`
+
+**Checkpoint**: User Story 1 should be independently functional and show the current document path in the footer
+
+---
+
+## Phase 4: User Story 2 - See document length at a glance (Priority: P2)
+
+**Goal**: Show a live word count in the default footer.
+
+**Independent Test**: Edit text content and verify that the footer word count updates to match the current document.
+
+### Implementation for User Story 2
+
+- [x] T013 [US2] Extend the shared footer data model with document word count in `src/types/editor.ts` and `src/components/NyxEditor/`
+- [x] T014 [US2] Render the right-side word count in the default footer in `src/components/NyxEditor/NyxEditor.vue`
+- [x] T015 [US2] Update footer styling for left/right footer layout in `src/components/NyxEditor/NyxEditor.scss`
+- [x] T016 [US2] Add or update editor unit coverage for word-count updates in `src/components/NyxEditor/NyxEditor.spec.ts`
+- [x] T017 [US2] Update Storybook coverage so the default footer also demonstrates the live word count in `src/components/NyxEditor/NyxEditor.stories.ts`
+
+**Checkpoint**: User Stories 1 and 2 should both work independently, with structure path and word count visible in the default footer
+
+---
+
+## Phase 5: User Story 3 - Customize footer presentation with slot data (Priority: P3)
+
+**Goal**: Expose footer data through a scoped slot for consumer customization.
+
+**Independent Test**: Render `NyxEditor` with a footer slot and verify the slot receives the same path and word-count data shown by the default footer.
+
+### Implementation for User Story 3
+
+- [x] T018 [US3] Add the `footer` scoped slot API to `src/components/NyxEditor/NyxEditor.vue`
+- [x] T019 [US3] Pass the complete footer payload to the slot while preserving the default footer fallback in `src/components/NyxEditor/NyxEditor.vue`
+- [x] T020 [US3] Document the footer slot scope and payload in `docs/specs/components/NyxEditor.spec.md`
+- [x] T021 [US3] Add a Storybook example of a custom footer slot consuming the footer payload in `src/components/NyxEditor/NyxEditor.stories.ts`
+- [x] T022 [US3] Add or update unit coverage for footer slot payload consistency in `src/components/NyxEditor/NyxEditor.spec.ts`
+
+**Checkpoint**: All user stories should now be independently functional, including custom footer rendering via slot data
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final consistency, docs sync, and validation across the full feature.
+
+- [x] T023 [P] Sync feature artifacts with the final design in `specs/008-editor-footer-info/spec.md`, `specs/008-editor-footer-info/plan.md`, and `specs/008-editor-footer-info/tasks.md`
+- [x] T024 Update the NyxEditor showcase/default story to demonstrate the footer feature in `src/components/NyxEditor/NyxEditor.stories.ts`
+- [x] T025 Run implementation validation with `pnpm exec vue-tsc --build`, `pnpm exec vitest run src/components/NyxEditor/NyxEditor.spec.ts`, and `pnpm exec vite build`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies - can start immediately
+- **Foundational (Phase 2)**: Depends on Setup completion - BLOCKS all user stories
+- **User Story 1 (Phase 3)**: Depends on Foundational completion
+- **User Story 2 (Phase 4)**: Depends on Foundational completion and can build on the same footer shell from US1
+- **User Story 3 (Phase 5)**: Depends on Foundational completion and should be implemented after the default footer payload is available
+- **Polish (Phase 6)**: Depends on all desired user stories being complete
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: Can start after Foundational - no dependency on other stories
+- **User Story 2 (P2)**: Can start after Foundational - may reuse US1 footer shell but remains independently testable
+- **User Story 3 (P3)**: Can start after Foundational - depends conceptually on the footer payload defined earlier but remains independently testable once payload exists
+
+### Within Each User Story
+
+- Shared data/model work before rendering work
+- Component rendering before story/demo updates
+- Story updates before final validation
+
+### Parallel Opportunities
+
+- T003 and T004 can run in parallel once the footer payload shape is agreed
+- T011 and T012 can run in parallel after the default footer structure-path implementation is in place
+- T016 and T017 can run in parallel after the word-count implementation is in place
+- T020 and T021 can run in parallel after the footer slot is wired
+- T023 and T024 can run in parallel before final validation
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+# After the default footer structure path is implemented:
+Task: "Add or update editor unit coverage for caret-path calculation in src/components/NyxEditor/NyxEditor.spec.ts"
+Task: "Add a Storybook example demonstrating default structural-path updates in src/components/NyxEditor/NyxEditor.stories.ts"
+```
+
+## Parallel Example: User Story 3
+
+```bash
+# After the footer slot payload is wired:
+Task: "Document the footer slot scope and payload in docs/specs/components/NyxEditor.spec.md"
+Task: "Add a Storybook example of a custom footer slot in src/components/NyxEditor/NyxEditor.stories.ts"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup
+2. Complete Phase 2: Foundational
+3. Complete Phase 3: User Story 1
+4. **STOP and VALIDATE**: Verify the footer path updates correctly across headings, paragraphs, and list items
+
+### Incremental Delivery
+
+1. Complete Setup + Foundational to establish footer data calculation
+2. Add User Story 1 for structural path visibility
+3. Add User Story 2 for word count
+4. Add User Story 3 for custom footer slot rendering
+5. Finish with polish and full validation
+
+### Suggested MVP Scope
+
+- **MVP**: User Story 1 only
+- Rationale: The structural path is the core new footer capability; word count and slot customization extend it but are not required to prove the footer concept
+
+---
+
+## Notes
+
+- All tasks follow the required checklist format with IDs, story labels where needed, and file paths.
+- Total tasks: 25
+- Task count by user story:
+  - **US1**: 5
+  - **US2**: 5
+  - **US3**: 5
+- Parallel opportunities identified in foundational and story-specific follow-up tasks.

--- a/src/components/NyxEditor/NyxEditor.scss
+++ b/src/components/NyxEditor/NyxEditor.scss
@@ -19,6 +19,7 @@
   display: flex;
   flex-direction: column;
   width: 100%;
+  max-height: 100dvh;
   border-radius: var(--nyx-radius-md);
   border: var(--nyx-border-size-editor) solid transparent;
   overflow: hidden;
@@ -227,8 +228,9 @@
   // ─── Source textarea ─────────────────────────────────────────────────
 
   &__source {
+    flex: 1;
     min-height: 120px;
-    overflow: hidden;
+    overflow: auto;
     padding: var(--nyx-pad-editor);
     font-size: var(--nyx-font-size-editor);
     font-family: var(--nyx-font-family-mono, monospace);
@@ -246,6 +248,8 @@
 
   &__content {
     flex: 1;
+    min-height: 0;
+    overflow: auto;
 
     .tiptap {
       min-height: 120px;
@@ -383,6 +387,48 @@
         }
       }
     }
+  }
+
+  &__footer {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--nyx-gap-editor);
+    padding: calc(var(--nyx-pad-editor) * 0.5) var(--nyx-pad-editor);
+    border-top: var(--nyx-border-size-editor) solid rgba(var(--nyx-rgb-editor), 0.2);
+    color: var(--nyx-c-editor-alt);
+    font-size: calc(var(--nyx-font-size-editor) * 0.875);
+    opacity: 0.8;
+  }
+
+  &__footer-path,
+  &__footer-word-count {
+    min-width: 0;
+  }
+
+  &__footer-path {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    gap: 0.35rem;
+    overflow: hidden;
+    white-space: nowrap;
+  }
+
+  &__footer-segment {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  &__footer-separator {
+    flex-shrink: 0;
+    color: rgba(var(--nyx-rgb-editor), 0.45);
+  }
+
+  &__footer-word-count {
+    flex-shrink: 0;
+    font-variant-numeric: tabular-nums;
   }
 
 }

--- a/src/components/NyxEditor/NyxEditor.spec.ts
+++ b/src/components/NyxEditor/NyxEditor.spec.ts
@@ -309,6 +309,9 @@ describe('NyxEditor', () => {
     mockEditor.state.selection = { empty: true, from: 18, to: 18 }
 
     const wrapper = mount(NyxEditor, {
+      props: {
+        hasFooter: true,
+      },
       slots: {
         footer: ({ meta }: any) => h('div', { class: 'custom-footer' }, `${meta.pathText} :: ${meta.wordCount}`),
       },

--- a/src/components/NyxEditor/NyxEditor.spec.ts
+++ b/src/components/NyxEditor/NyxEditor.spec.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, it, expect, vi } from 'vitest'
 import { mount } from '@vue/test-utils'
-import { shallowRef } from 'vue'
+import { h, shallowRef } from 'vue'
 import {
   NyxAnnotationAttachment,
   NyxAnnotationInteraction,
@@ -12,13 +12,16 @@ import {
   NyxSize,
 } from '@/types'
 import NyxEditor from './NyxEditor.vue'
+import { createEditorMeta } from './useEditorMeta'
+
+const createMockEditorDoc = () => ({
+  textBetween: vi.fn(() => ''),
+})
 
 const mockEditor = {
   state: {
     selection: { empty: true, from: 1, to: 1 },
-    doc: {
-      textBetween: vi.fn(() => ''),
-    },
+    doc: createMockEditorDoc(),
     tr: {
       setMeta: vi.fn(() => ({ type: 'annotation-meta-transaction' })),
     },
@@ -58,6 +61,45 @@ const mockEditor = {
 
 let editorOptions: Record<string, any> = {}
 
+const createTestNode = (typeName: string, options: { text?: string, attrs?: Record<string, unknown>, children?: any[] } = {}) => {
+  const children = options.children ?? []
+  const textContent = options.text ?? children.map((child) => child.textContent).join(' ')
+
+  return {
+    type: { name: typeName },
+    attrs: options.attrs ?? {},
+    textContent,
+    childCount: children.length,
+    child: (index: number) => children[index],
+    nodeSize: Math.max(textContent.length + 2, 2 + children.reduce((sum, child) => sum + child.nodeSize, 0)),
+    children,
+  }
+}
+
+const createTestDoc = (children: any[]) => {
+  const doc = createTestNode('doc', { children, text: children.map((child) => child.textContent).join(' ') })
+
+  return {
+    ...doc,
+    content: { size: doc.nodeSize },
+    textBetween: (from: number, to: number) => doc.textContent.slice(Math.max(0, from), Math.max(from, to)),
+    descendants: (callback: (node: any, pos: number, parent: any, index: number) => void) => {
+      const walk = (nodes: any[], parent: any, startPos: number) => {
+        let pos = startPos
+        nodes.forEach((node, index) => {
+          callback(node, pos, parent, index)
+          if (node.children?.length) {
+            walk(node.children, node, pos + 1)
+          }
+          pos += node.nodeSize
+        })
+      }
+
+      walk(children, doc, 0)
+    },
+  }
+}
+
 // Tiptap relies on browser APIs not available in jsdom; mock the integration layer
 vi.mock('@tiptap/vue-3', () => ({
   useEditor: (options: Record<string, any>) => {
@@ -72,8 +114,8 @@ vi.mock('tiptap-markdown', () => ({ Markdown: {} }))
 vi.mock('./NyxEditorBubbleMenu/NyxEditorBubbleMenu.vue', () => ({
   default: {
     name: 'NyxEditorBubbleMenu',
-    emits: ['mousedown', 'create'],
-    template: '<button class="nyx-editor__bubble-comment" @click="$emit(\'create\')" />',
+    emits: ['mousedown', 'annotation:create'],
+    template: '<button class="nyx-editor__bubble-comment" @click="$emit(\'annotation:create\')" />',
   },
 }))
 
@@ -81,10 +123,84 @@ describe('NyxEditor', () => {
   beforeEach(() => {
     editorOptions = {}
     mockEditor.state.selection = { empty: true, from: 1, to: 1 }
-    mockEditor.state.doc.textBetween.mockReset()
+    mockEditor.state.doc = createMockEditorDoc()
     mockEditor.state.doc.textBetween.mockReturnValue('')
     mockEditor.state.tr.setMeta.mockClear()
     mockEditor.view.dispatch.mockClear()
+  })
+
+  it('builds meta for paragraphs beneath nested headings', () => {
+    const doc = createTestDoc([
+      createTestNode('heading', { text: 'Main Title', attrs: { level: 1 } }),
+      createTestNode('heading', { text: 'Section Title', attrs: { level: 2 } }),
+      createTestNode('paragraph', { text: 'First paragraph body' }),
+      createTestNode('paragraph', { text: 'Second paragraph body' }),
+    ])
+
+    const meta = createEditorMeta({
+      doc,
+      selection: { from: 35, to: 35, empty: true },
+    } as never)
+
+    expect(meta.pathText).toBe('Main Title / Section Title / paragraph 1')
+    expect(meta.wordCount).toBe(10)
+  })
+
+  it('resets paragraph numbering per heading section', () => {
+    const doc = createTestDoc([
+      createTestNode('heading', { text: 'Main Title', attrs: { level: 1 } }),
+      createTestNode('heading', { text: 'Section One', attrs: { level: 2 } }),
+      createTestNode('paragraph', { text: 'First section paragraph one' }),
+      createTestNode('paragraph', { text: 'First section paragraph two' }),
+      createTestNode('heading', { text: 'Section Two', attrs: { level: 2 } }),
+      createTestNode('paragraph', { text: 'Second section paragraph one' }),
+    ])
+
+    const meta = createEditorMeta({
+      doc,
+      selection: { from: 105, to: 105, empty: true },
+    } as never)
+
+    expect(meta.pathText).toBe('Main Title / Section Two / paragraph 1')
+  })
+
+  it('builds meta for list items beneath nested headings', () => {
+    const doc = createTestDoc([
+      createTestNode('heading', { text: 'Main Title', attrs: { level: 1 } }),
+      createTestNode('heading', { text: 'Section Title', attrs: { level: 2 } }),
+      createTestNode('bulletList', {
+        children: [
+          createTestNode('listItem', { text: 'First item' }),
+          createTestNode('listItem', { text: 'Second item' }),
+        ],
+      }),
+    ])
+
+    const meta = createEditorMeta({
+      doc,
+      selection: { from: 42, to: 42, empty: true },
+    } as never)
+
+    expect(meta.pathText).toBe('Main Title / Section Title / list / item 2')
+  })
+
+  it('treats task items as list entries in meta', () => {
+    const doc = createTestDoc([
+      createTestNode('heading', { text: 'Main Title', attrs: { level: 1 } }),
+      createTestNode('taskList', {
+        children: [
+          createTestNode('taskItem', { text: 'First task' }),
+          createTestNode('taskItem', { text: 'Second task' }),
+        ],
+      }),
+    ])
+
+    const meta = createEditorMeta({
+      doc,
+      selection: { from: 25, to: 25, empty: true },
+    } as never)
+
+    expect(meta.pathText).toBe('Main Title / list / item 2')
   })
 
   it('emits selection when the editor selection changes', () => {
@@ -183,6 +299,25 @@ describe('NyxEditor', () => {
   it('renders EditorContent', () => {
     const wrapper = mount(NyxEditor)
     expect(wrapper.find('.nyx-editor__content').exists()).toBe(true)
+  })
+
+  it('passes meta through the footer slot', async () => {
+    mockEditor.state.doc = createTestDoc([
+      createTestNode('heading', { text: 'Main Title', attrs: { level: 1 } }),
+      createTestNode('paragraph', { text: 'Paragraph body words' }),
+    ]) as any
+    mockEditor.state.selection = { empty: true, from: 18, to: 18 }
+
+    const wrapper = mount(NyxEditor, {
+      slots: {
+        footer: ({ meta }: any) => h('div', { class: 'custom-footer' }, `${meta.pathText} :: ${meta.wordCount}`),
+      },
+    })
+
+    editorOptions.onCreate?.()
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.find('.custom-footer').text()).toBe('Main Title / paragraph 1 :: 5')
   })
 
   it('accepts consumer-provided annotations', () => {

--- a/src/components/NyxEditor/NyxEditor.stories.ts
+++ b/src/components/NyxEditor/NyxEditor.stories.ts
@@ -216,6 +216,7 @@ export const Showcase = (args: NyxEditorProps & { modelValue?: string, annotatio
       v-bind="args"
       v-model="content"
       v-model:annotations="annotations"
+      style="max-height: 42dvh;"
     />
   `,
 })
@@ -349,6 +350,39 @@ export const SelectionAndAnnotationEvents = () => defineComponent({
         placeholder="Annotation blur event payload"
       />
     </div>
+  `,
+})
+
+export const FooterSlot = () => defineComponent({
+  components: { NyxEditor },
+  setup() {
+    const content = ref(showcaseContent)
+    const annotations = ref(showcaseAnnotations.map((annotation) => ({
+      ...annotation,
+      anchor: {
+        ...annotation.anchor,
+        context: { ...annotation.anchor.context },
+        range: { ...annotation.anchor.range },
+      },
+    })))
+
+    return { content, annotations, showcaseStatusTheme }
+  },
+  template: `
+    <nyx-editor
+      v-model="content"
+      v-model:annotations="annotations"
+      :mode="'${NyxEditorMode.Zen}'"
+      :toolbar="'${NyxEditorToolbar.Full}'"
+      :annotation-status-theme="showcaseStatusTheme"
+    >
+      <template #footer="{ meta }">
+        <div style="display: flex; width: 100%; justify-content: space-between; gap: 1rem; font-size: 0.875rem; opacity: 0.9;">
+          <span>{{ meta.pathText }}</span>
+          <strong>{{ meta.wordCount }} words</strong>
+        </div>
+      </template>
+    </nyx-editor>
   `,
 })
 

--- a/src/components/NyxEditor/NyxEditor.stories.ts
+++ b/src/components/NyxEditor/NyxEditor.stories.ts
@@ -225,6 +225,7 @@ Showcase.args = {
   modelValue: showcaseContent,
   annotations: showcaseAnnotations,
   annotationStatusTheme: showcaseStatusTheme,
+  hasFooter: true,
   mode: NyxEditorMode.Zen,
   format: NyxEditorFormat.Markdown,
   toolbar: NyxEditorToolbar.Full,

--- a/src/components/NyxEditor/NyxEditor.types.ts
+++ b/src/components/NyxEditor/NyxEditor.types.ts
@@ -9,6 +9,7 @@ import type {
 import type {
   NyxAnnotation,
   NyxAnnotationAnchor,
+  NyxEditorMeta,
   NyxAnnotationStatusTheme,
 } from '@/types/editor'
 
@@ -34,4 +35,8 @@ export interface NyxEditorEmits {
   (event: 'annotation:create', anchor: NyxAnnotationAnchor): void
   (event: 'annotation:focus', id: string): void
   (event: 'annotation:blur', id: string): void
+}
+
+export interface NyxEditorSlots {
+  footer(props: { meta: NyxEditorMeta }): any
 }

--- a/src/components/NyxEditor/NyxEditor.types.ts
+++ b/src/components/NyxEditor/NyxEditor.types.ts
@@ -24,6 +24,7 @@ export interface NyxEditorProps {
   disabled?: boolean
   placeholder?: string
   hasSourceToggle?: boolean
+  hasFooter?: boolean
   annotationStatusTheme?: NyxAnnotationStatusTheme
 }
 

--- a/src/components/NyxEditor/NyxEditor.vue
+++ b/src/components/NyxEditor/NyxEditor.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import './NyxEditor.scss'
-import { computed, ref, shallowRef, watch, nextTick } from 'vue'
+import { computed, ref, shallowRef, watch, nextTick, useSlots } from 'vue'
 import { useEditor, EditorContent, type Editor } from '@tiptap/vue-3'
 import StarterKit from '@tiptap/starter-kit'
 import UnderlineExtension from '@tiptap/extension-underline'
@@ -33,6 +33,7 @@ const props = withDefaults(defineProps<NyxEditorProps>(), {
   disabled: false,
   placeholder: '',
   hasSourceToggle: false,
+  hasFooter: false,
   annotationStatusTheme: (): NyxAnnotationStatusTheme => ({
     [NyxAnnotationStatus.Unresolved]: NyxTheme.Primary,
     [NyxAnnotationStatus.Draft]: NyxTheme.Info,
@@ -44,7 +45,7 @@ const props = withDefaults(defineProps<NyxEditorProps>(), {
 })
 
 const emit = defineEmits<NyxEditorEmits>()
-defineSlots<NyxEditorSlots>()
+const slots = defineSlots<NyxEditorSlots>()
 
 const model = defineModel<string>({ default: '' })
 const sourceModel = defineModel<boolean>('source', { default: false })
@@ -54,6 +55,7 @@ const editorRef = shallowRef<Editor | null | undefined>(undefined)
 const { classList } = useNyxProps(props, { origin: 'NyxEditor' })
 const annotations = computed(() => annotationsModel.value)
 const annotationStatusTheme = computed(() => props.annotationStatusTheme)
+const isFooterVisible = computed(() => props.hasFooter || !!slots.footer)
 
 const {
   annotationExtension,
@@ -237,7 +239,7 @@ watch(() => annotationsModel.value, () => {
       @annotation:create="onCreateAnnotation"
     />
 
-    <footer class="nyx-editor__footer">
+    <footer v-if="isFooterVisible" class="nyx-editor__footer">
       <slot name="footer" :meta="meta">
         <span class="nyx-editor__footer-path" aria-label="Document structure">
           <template v-if="meta.segments.length">

--- a/src/components/NyxEditor/NyxEditor.vue
+++ b/src/components/NyxEditor/NyxEditor.vue
@@ -7,7 +7,7 @@ import UnderlineExtension from '@tiptap/extension-underline'
 import TaskList from '@tiptap/extension-task-list'
 import TaskItem from '@tiptap/extension-task-item'
 import { Markdown, type MarkdownStorage } from 'tiptap-markdown'
-import type { NyxEditorProps, NyxEditorEmits } from './NyxEditor.types'
+import type { NyxEditorProps, NyxEditorEmits, NyxEditorSlots } from './NyxEditor.types'
 import type {
   NyxAnnotation,
   NyxAnnotationStatusTheme,
@@ -23,7 +23,8 @@ import { useNyxProps } from '@/composables'
 import NyxEditorBubbleMenu from './NyxEditorBubbleMenu/NyxEditorBubbleMenu.vue'
 import NyxEditorToolbar from './NyxEditorToolbar/NyxEditorToolbar.vue'
 import useEditorAnnotations from './useEditorAnnotations'
-import { FileCode } from 'lucide-vue-next'
+import useEditorMeta from './useEditorMeta'
+import { ChevronRight, FileCode } from 'lucide-vue-next'
 
 const props = withDefaults(defineProps<NyxEditorProps>(), {
   mode: NyxEditorMode.Zen,
@@ -43,6 +44,7 @@ const props = withDefaults(defineProps<NyxEditorProps>(), {
 })
 
 const emit = defineEmits<NyxEditorEmits>()
+defineSlots<NyxEditorSlots>()
 
 const model = defineModel<string>({ default: '' })
 const sourceModel = defineModel<boolean>('source', { default: false })
@@ -70,6 +72,8 @@ const {
   onFocus: (id) => emit('annotation:focus', id),
   onBlur: (id) => emit('annotation:blur', id),
 })
+
+const { meta, refreshMeta } = useEditorMeta(editorRef)
 
 // ── Source textarea auto-resize ──────────────────────────────────────
 const sourceRef = ref<HTMLTextAreaElement | null>(null)
@@ -138,10 +142,12 @@ const editor = useEditor({
   editable: !props.disabled,
   onCreate: () => {
     syncAnnotationDecorations()
+    refreshMeta()
   },
   onUpdate: () => {
     const content = getContent()
     model.value = content
+    refreshMeta()
     emit('change', content)
   },
   onTransaction: ({ transaction }) => {
@@ -151,6 +157,7 @@ const editor = useEditor({
   },
   onSelectionUpdate: () => {
     updateBubble()
+    refreshMeta()
 
     const anchor = getCurrentSelectionAnchor()
     if (anchor) emit('selection', anchor)
@@ -165,6 +172,7 @@ const editor = useEditor({
 
 watch(editor, (value) => {
   editorRef.value = value
+  refreshMeta()
 }, { immediate: true })
 
 watch(() => model.value, (value) => {
@@ -172,6 +180,7 @@ watch(() => model.value, (value) => {
   const current = getContent()
   if (value !== current) {
     editor.value.commands.setContent(value, { emitUpdate: false })
+    refreshMeta()
   }
 })
 
@@ -192,7 +201,7 @@ watch(() => annotationsModel.value, () => {
       v-if="props.mode === 'toolbar'"
       :editor="editor ?? null"
       :toolbar="props.toolbar"
-      @create="onCreateAnnotation"
+      @annotation:create="onCreateAnnotation"
     />
 
     <!-- Source toggle button -->
@@ -225,8 +234,22 @@ watch(() => annotationsModel.value, () => {
       :visible="bubbleVisible"
       :toolbar="props.toolbar"
       @mousedown="onBubbleMousedown"
-      @create="onCreateAnnotation"
+      @annotation:create="onCreateAnnotation"
     />
 
+    <footer class="nyx-editor__footer">
+      <slot name="footer" :meta="meta">
+        <span class="nyx-editor__footer-path" aria-label="Document structure">
+          <template v-if="meta.segments.length">
+            <template v-for="(segment, index) in meta.segments" :key="`${segment.type}-${segment.label}-${index}`">
+              <ChevronRight v-if="index > 0" :size="12" class="nyx-editor__footer-separator" aria-hidden="true" />
+              <span class="nyx-editor__footer-segment">{{ segment.label }}</span>
+            </template>
+          </template>
+          <span v-else class="nyx-editor__footer-segment">Document</span>
+        </span>
+        <span class="nyx-editor__footer-word-count">{{ meta.wordCount }} words</span>
+      </slot>
+    </footer>
   </div>
 </template>

--- a/src/components/NyxEditor/NyxEditorToolbar/NyxEditorToolbar.vue
+++ b/src/components/NyxEditor/NyxEditorToolbar/NyxEditorToolbar.vue
@@ -14,7 +14,7 @@ const emit = defineEmits<{
 </script>
 
 <template>
-  <div
+  <header
     class="nyx-editor__toolbar"
     role="toolbar"
     aria-label="Text formatting"
@@ -27,5 +27,5 @@ const emit = defineEmits<{
       :show-undo-redo="true"
       @annotation:create="emit('annotation:create')"
     />
-  </div>
+  </header>
 </template>

--- a/src/components/NyxEditor/useEditorMeta.ts
+++ b/src/components/NyxEditor/useEditorMeta.ts
@@ -1,0 +1,175 @@
+import { ref, type Ref } from 'vue'
+import type { Editor } from '@tiptap/vue-3'
+import type {
+  NyxEditorMeta,
+  NyxEditorMetaPathSegment,
+  NyxEditorMetaSelection,
+} from '@/types/editor'
+
+type MetaNodeLike = {
+  type: { name: string }
+  attrs?: Record<string, unknown>
+  textContent?: string
+  nodeSize: number
+  childCount?: number
+  child?: (index: number) => MetaNodeLike
+}
+
+type MetaDocLike = MetaNodeLike & {
+  content: { size: number }
+  textBetween: (from: number, to: number, blockSeparator?: string, leafText?: string) => string
+  descendants: (callback: (node: MetaNodeLike, pos: number, parent: MetaNodeLike | null, index: number) => boolean | void) => void
+}
+
+type MetaSelectionLike = {
+  from: number
+  to: number
+  empty: boolean
+}
+
+type MetaStateLike = {
+  doc: MetaDocLike
+  selection: MetaSelectionLike
+}
+
+const EMPTY_SELECTION: NyxEditorMetaSelection = {
+  from: 0,
+  to: 0,
+  empty: true,
+}
+
+export const createEmptyMeta = (): NyxEditorMeta => ({
+  segments: [],
+  pathText: 'Document',
+  wordCount: 0,
+  selection: { ...EMPTY_SELECTION },
+})
+
+const normalizeWhitespace = (value: string) => value.replace(/\s+/g, ' ').trim()
+
+const countIndexedSiblings = (parent: MetaNodeLike | null, typeName: string, currentIndex: number) => {
+  if (!parent?.child || typeof parent.childCount !== 'number') return currentIndex + 1
+
+  let count = 0
+  for (let index = 0; index <= currentIndex; index += 1) {
+    if (parent.child(index)?.type.name === typeName) count += 1
+  }
+
+  return Math.max(count, 1)
+}
+
+const getListType = (typeName: string) => {
+  if (typeName === 'orderedList') return 'ordered'
+  if (typeName === 'taskList') return 'task'
+  return 'bullet'
+}
+
+const getListLabel = (_typeName: string) => 'list'
+
+const containsPosition = (node: MetaNodeLike, pos: number, selectionPos: number) => {
+  return selectionPos >= pos && selectionPos <= pos + node.nodeSize
+}
+
+export const createEditorMeta = (state: MetaStateLike | null | undefined): NyxEditorMeta => {
+  if (!state?.doc || typeof state.doc.textBetween !== 'function') return createEmptyMeta()
+
+  const selection = state.selection ?? EMPTY_SELECTION
+  const contentSize = state.doc.content?.size ?? 0
+  const text = normalizeWhitespace(state.doc.textBetween(0, contentSize, ' ', ' '))
+  const wordCount = text ? text.split(/\s+/).length : 0
+  const headingStack: NyxEditorMetaPathSegment[] = []
+  const paragraphCountsBySection = new Map<string, number>()
+  const selectionPos = selection.from
+
+  let activeSegments: NyxEditorMetaPathSegment[] = []
+  let activeScore = 0
+
+  state.doc.descendants?.((node, pos, parent, index) => {
+    if (node.type.name === 'heading') {
+      const level = Number(node.attrs?.level ?? 1)
+      const label = normalizeWhitespace(node.textContent ?? '') || 'untitled'
+
+      while (headingStack.length && (headingStack[headingStack.length - 1].level ?? 1) >= level) {
+        headingStack.pop()
+      }
+
+      const segment: NyxEditorMetaPathSegment = {
+        type: 'heading',
+        label,
+        level,
+      }
+
+      headingStack.push(segment)
+
+      if (containsPosition(node, pos, selectionPos) && activeScore < 1) {
+        activeSegments = [...headingStack]
+        activeScore = 1
+      }
+    }
+
+    if (node.type.name === 'paragraph') {
+      const sectionKey = headingStack.map((segment) => segment.label).join('>') || 'root'
+      const paragraphIndex = (paragraphCountsBySection.get(sectionKey) ?? 0) + 1
+
+      paragraphCountsBySection.set(sectionKey, paragraphIndex)
+
+      if (!containsPosition(node, pos, selectionPos) || activeScore >= 2) return
+
+      activeSegments = [
+        ...headingStack,
+        {
+          type: 'paragraph',
+          label: `paragraph ${paragraphIndex}`,
+          index: paragraphIndex,
+        },
+      ]
+      activeScore = 2
+    }
+
+    if ((node.type.name === 'listItem' || node.type.name === 'taskItem') && containsPosition(node, pos, selectionPos) && activeScore <= 3) {
+      const listTypeName = parent?.type.name ?? 'bulletList'
+      const listType = getListType(listTypeName)
+      const itemIndex = index + 1
+
+      activeSegments = [
+        ...headingStack,
+        {
+          type: 'list',
+          label: getListLabel(listTypeName),
+          listType,
+        },
+        {
+          type: 'list-item',
+          label: `item ${itemIndex}`,
+          index: itemIndex,
+          listType,
+        },
+      ]
+      activeScore = 3
+    }
+  })
+
+  return {
+    segments: activeSegments,
+    pathText: activeSegments.length ? activeSegments.map((segment) => segment.label).join(' / ') : 'Document',
+    wordCount,
+    selection: {
+      from: selection.from,
+      to: selection.to,
+      empty: selection.empty,
+    },
+  }
+}
+
+export default function useEditorMeta(editor: Ref<Editor | null | undefined>) {
+  const meta = ref<NyxEditorMeta>(createEmptyMeta())
+
+  const refreshMeta = () => {
+    meta.value = createEditorMeta(editor.value?.state as MetaStateLike | undefined)
+  }
+
+  return {
+    meta,
+    refreshMeta,
+  }
+}

--- a/src/types/editor.ts
+++ b/src/types/editor.ts
@@ -45,3 +45,27 @@ export interface NyxAnnotation {
   attachment: NyxAnnotationAttachment
   tone?: string
 }
+
+export type NyxEditorMetaPathSegmentType = 'heading' | 'paragraph' | 'list' | 'list-item'
+export type NyxEditorMetaListType = 'bullet' | 'ordered' | 'task'
+
+export interface NyxEditorMetaPathSegment {
+  type: NyxEditorMetaPathSegmentType
+  label: string
+  index?: number
+  level?: number
+  listType?: NyxEditorMetaListType
+}
+
+export interface NyxEditorMetaSelection {
+  from: number
+  to: number
+  empty: boolean
+}
+
+export interface NyxEditorMeta {
+  segments: NyxEditorMetaPathSegment[]
+  pathText: string
+  wordCount: number
+  selection: NyxEditorMetaSelection
+}


### PR DESCRIPTION
## Summary
- add a default NyxEditor footer that shows caret-aware document structure on the left and live word count on the right
- expose the same editor meta through the `footer` slot so consuming apps can fully customize footer rendering
- add editor meta types, extraction logic, Storybook coverage, and unit tests for paragraph/list path behavior

## Details
- derive footer meta from live editor state in `useEditorMeta`
- normalize structure labels to use heading titles, `list`, `item N`, and section-scoped `paragraph N`
- keep the footer pinned to the bottom of the editor while content scrolls inside the editor body
- add icon-based footer separators with distinct styling from the text
- add support for task-list items in the structure path

## Verification
- `pnpm exec vitest run src/components/NyxEditor/NyxEditor.spec.ts`
- `pnpm exec vue-tsc --build`
- `pnpm exec vite build`