### PR TITLE
feat(NyxIcon): Add Lucide icon wrapper component

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,12 @@
 # AGENTS.md — Working Guide for AI Agents
 
+## Git Workflow
+
+- **Never auto-commit or auto-push** — only commit and push when explicitly prompted by the user.
+- When changes are complete, describe what was done and ask if the user wants to push.
+
+---
+
 ## The Docs Are the Source of Truth
 
 The `docs/` folder is the **authoritative specification** for this project. It is a living document.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,7 @@ The project constitution is at `.specify/memory/constitution.md`.
 - TypeScript 5.7 / Vue 3.5 + Vue 3, `@tiptap/vue-3`, `@tiptap/starter-kit`, `@tiptap/extension-underline`, `@tiptap/extension-task-list`, `@tiptap/extension-task-item`, `tiptap-markdown`, SCSS (007-editor-comment-annotations)
 - N/A - comment threads and persisted annotations are consumer-owned inputs (007-editor-comment-annotations)
 - TypeScript 5.x + Vue 3.5 + Vue 3, `@tiptap/vue-3`, Tiptap `StarterKit`, `tiptap-markdown`, existing internal NyxEditor sub-components/composables (008-editor-footer-info)
+- TypeScript + Vue 3.5+ + `lucide-vue-next` (already installed), Vue 3 (009-add-lucide-icon)
 
 ## Recent Changes
 - 003-testing-improvements: Added TypeScript 5.x / Vue 3 + `@vue/test-utils`, `vitest`, `@playwright/test`, `jsdom`

--- a/docs/specs/components/NyxIcon.spec.md
+++ b/docs/specs/components/NyxIcon.spec.md
@@ -1,0 +1,61 @@
+# NyxIcon
+
+> A wrapper component for Lucide Vue icons with support for name-based rendering, variant switching (line/filled), optional theme coloring, and size control.
+
+## Purpose and scope
+
+NyxIcon provides a unified interface for rendering Lucide icons by their kebab-case name strings. It abstracts away direct Lucide imports and provides consistent theming and sizing across the library.
+
+**Use when:**
+- You need to render an icon from the Lucide icon set
+- You want consistent sizing using NyxSize tokens
+- You want theme-aware coloring using NyxTheme
+
+**Do not use when:**
+- You need icons not available in Lucide
+- You need custom icon components (use Lucide directly)
+
+## Internal architecture
+
+- Uses dynamic component resolution via `resolvedIcon` computed property
+- Converts kebab-case icon names to PascalCase for Lucide lookup
+- Applies `Filled` suffix for filled variant icons
+- Falls back gracefully when icon name is not found
+- Applies CSS custom property colors via `iconStyles` computed
+
+## Props
+
+| Prop | Type | Default | Description |
+|---|---|---|---|
+| `name` | `string` | — | Icon name in kebab-case (e.g., "chevron-right") |
+| `variant` | `NyxIconVariant` | `'line'` | Icon style variant (line/filled) |
+| `theme` | `NyxTheme` | — | Theme color for icon fill/stroke |
+| `size` | `NyxSize` | — | Size token (xs, sm, md, lg, xl) |
+| `customSize` | `number` | — | Custom pixel size override |
+
+## Emits
+
+None.
+
+## Slots
+
+None.
+
+## v-model
+
+Not applicable — NyxIcon is not a form component.
+
+## Keyboard behaviour
+
+None — NyxIcon renders a static icon.
+
+## Accessibility
+
+- Does not add ARIA attributes (consumer must provide if icon is interactive)
+- Passes through `aria-hidden="true"` if provided via attrs
+
+## Known limitations
+
+- Only supports Lucide icons; non-Lucide names render nothing
+- Variant "filled" requires the icon to have a Filled variant in Lucide
+- Does not support icon rotation, flip, or animation (use Lucide directly)

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "nyx-kit",
   "homepage": "http://nyxkit.github.io/nyx-kit",
   "author": "Arne Decant <hello@arnedecant.be>",
-  "version": "2.0.11",
+  "version": "2.0.12",
   "packageManager": "pnpm@10.18.3",
   "private": false,
   "license": "MIT",

--- a/specs/009-add-lucide-icon/checklists/requirements.md
+++ b/specs/009-add-lucide-icon/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: NyxIcon Component
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-03-31
+**Feature**: specs/009-add-lucide-icon/spec.md
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All checklist items pass. Spec is ready for `/speckit.plan`.

--- a/specs/009-add-lucide-icon/data-model.md
+++ b/specs/009-add-lucide-icon/data-model.md
@@ -1,0 +1,41 @@
+# Data Model: NyxIcon
+
+## Entity: NyxIcon
+
+| Field | Type | Default | Required | Notes |
+|-------|------|---------|----------|-------|
+| `name` | `string` | — | Yes | Lucide icon name in kebab-case |
+| `variant` | `NyxIconVariant` | `'line'` | No | Icon style variant |
+| `theme` | `NyxTheme` | — | No | Optional theme color |
+| `size` | `NyxSize` | — | No | Optional size token |
+| `pixel` | `boolean` | `false` | No | Whether size is in pixels |
+
+## Enum: NyxIconVariant
+
+| Value | Description |
+|-------|-------------|
+| `line` | Outline/stroked icons (default) |
+| `filled` | Filled icons |
+
+## Relationships
+
+- **NyxIcon** uses **NyxTheme** for color application
+- **NyxIcon** uses **NyxSize** for dimensions
+- **NyxIcon** renders **LucideIcon** (from lucide-vue-next)
+
+## Validation Rules
+
+1. `name` must be a valid Lucide icon name in kebab-case (e.g., "arrow-right")
+2. Name is converted to PascalCase via helper: "arrow-right" → "ArrowRight"
+3. Variant must be one of: `'line'`, `'filled'`
+4. `theme` must be a valid NyxTheme value when provided
+5. `size` must be a valid NyxSize value when provided
+6. Invalid icon name renders nothing (no crash)
+
+## Implementation Helper
+
+```ts
+function toPascalCase(str: string): string {
+  return str.split('-').map(s => s.charAt(0).toUpperCase() + s.slice(1)).join('')
+}
+```

--- a/specs/009-add-lucide-icon/plan.md
+++ b/specs/009-add-lucide-icon/plan.md
@@ -1,0 +1,137 @@
+# Implementation Plan: NyxIcon Component
+
+**Branch**: `009-add-lucide-icon` | **Date**: 2026-03-31 | **Spec**: specs/009-add-lucide-icon/spec.md
+
+**Input**: Feature specification from `/specs/009-add-lucide-icon/spec.md`
+
+## Summary
+
+Create a `NyxIcon` component that wraps Lucide Vue icons. Supports string-based icon names, variant switching (line/filled), optional theme coloring, and size control. Uses `lucide-vue-next` (already in dependencies).
+
+### Internal Migration Scope
+
+The following components currently use `lucide-vue-next` directly and must be migrated:
+
+| Component | Icons Used |
+|-----------|------------|
+| `NyxEditor.vue` | `ChevronRight`, `FileCode` |
+| `NyxEditorToolbarContent.vue` | Multiple toolbar icons |
+
+After migration, no component should directly import from `lucide-vue-next` except `NyxIcon` itself.
+
+## Technical Context
+
+**Language/Version**: TypeScript + Vue 3.5+  
+**Primary Dependencies**: `lucide-vue-next` (already installed), Vue 3  
+**Testing**: Vitest (unit), Storybook (component API)  
+**Target Platform**: Vue 3 SPA/library consumers  
+**Project Type**: Vue 3 Component Library (`nyx-kit`)  
+**Performance Goals**: Minimal bundle impact - tree-shakeable  
+**Constraints**: Must maintain backward compatibility with existing Nyx components  
+**Scale/Scope**: Single component, 1 entity type
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Gate | Status | Notes |
+|------|--------|-------|
+| Docs before code | ✅ | Will create `docs/specs/components/NyxIcon.spec.md` before implementation |
+| Living spec sync | ✅ | Component spec will stay in sync with implementation |
+| Design tokens | ✅ | Uses existing CSS variables for theming |
+| Consistency | ✅ | Follows existing Nyx component patterns (useNyxProps, etc.) |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/009-add-lucide-icon/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/           # N/A (component library, no external APIs)
+└── tasks.md             # Phase 2 output (/speckit.tasks)
+```
+
+### Source Code (repository root)
+
+```text
+src/
+├── components/
+│   └── NyxIcon/
+│       ├── NyxIcon.vue
+│       ├── NyxIcon.types.ts
+│       └── NyxIcon.stories.ts
+├── types/
+│   └── common.ts         # Will add NyxIconVariant enum
+```
+
+**Structure Decision**: Adding `NyxIconVariant` to existing `src/types/common.ts`. Creating component folder under `src/components/NyxIcon/` following existing pattern.
+
+---
+
+## Phase 1: Design
+
+### Data Model
+
+**Entity: NyxIcon**
+
+| Field | Type | Default | Required | Notes |
+|-------|------|---------|----------|-------|
+| `name` | `string` | — | Yes | Lucide icon name (kebab-case) |
+| `variant` | `NyxIconVariant` | `'line'` | No | Icon style variant |
+| `theme` | `NyxTheme` | — | No | Optional theme color |
+| `size` | `NyxSize` | — | No | Optional size (maps to dimensions) |
+| `pixel` | `boolean` | `false` | No | Whether size is in pixels |
+
+**Enum: NyxIconVariant**
+
+| Value | Description |
+|-------|-------------|
+| `line` | Outline/stroked icons (default) |
+| `filled` | Filled icons |
+
+### Props Interface
+
+```typescript
+interface NyxIconProps {
+  name: string
+  variant?: NyxIconVariant
+  theme?: NyxTheme
+  size?: NyxSize
+  pixel?: boolean
+}
+```
+
+### CSS Variables Used
+
+- `--nyx-rgb-{theme}` - Theme RGB values for coloring
+- `--nyx-text` - Default text color (fallback when no theme)
+
+---
+
+## Quickstart
+
+```vue
+<template>
+  <!-- Basic usage -->
+  <NyxIcon name="arrow-right" />
+  
+  <!-- With variant -->
+  <NyxIcon name="check-circle" variant="filled" />
+  
+  <!-- With theme -->
+  <NyxIcon name="warning" theme="warning" />
+  
+  <!-- With size -->
+  <NyxIcon name="home" size="lg" />
+</template>
+```
+
+---
+
+## Next Steps
+
+Proceed to `/speckit.tasks` for task breakdown, then `/speckit.implement` for code creation.

--- a/specs/009-add-lucide-icon/quickstart.md
+++ b/specs/009-add-lucide-icon/quickstart.md
@@ -1,0 +1,92 @@
+# Quickstart: NyxIcon
+
+## Installation
+
+NyxIcon is included in `nyx-kit`. Ensure you have `lucide-vue-next` installed (it's a dependency of nyx-kit).
+
+## Basic Usage
+
+```vue
+<template>
+  <!-- Render an icon by name -->
+  <NyxIcon name="arrow-right" />
+</template>
+```
+
+## Icon Variants
+
+```vue
+<template>
+  <!-- Line icons (default) -->
+  <NyxIcon name="check-circle" variant="line" />
+  
+  <!-- Filled icons -->
+  <NyxIcon name="check-circle" variant="filled" />
+</template>
+```
+
+## Theme Colors
+
+```vue
+<template>
+  <!-- Use theme color -->
+  <NyxIcon name="warning" theme="warning" />
+  
+  <!-- Default text color (no theme) -->
+  <NyxIcon name="info" />
+</template>
+```
+
+## Sizes
+
+```vue
+<template>
+  <NyxIcon name="home" size="xs" />
+  <NyxIcon name="home" size="sm" />
+  <NyxIcon name="home" size="md" />
+  <NyxIcon name="home" size="lg" />
+  <NyxIcon name="home" size="xl" />
+</template>
+```
+
+## Available Icons
+
+Lucide provides 1500+ icons. Use any icon name from the [Lucide icons gallery](https://lucide.dev/icons/) in kebab-case.
+
+```vue
+<template>
+  <NyxIcon name="user-plus" />
+  <NyxIcon name="settings" />
+  <NyxIcon name="download" />
+  <NyxIcon name="share-2" />
+</template>
+```
+
+## Storybook Story
+
+The NyxIcon component includes a Storybook story with a curated subset of icons showcasing different categories:
+
+- **Navigation**: arrow-right, arrow-left, chevron-down, menu, x
+- **Actions**: plus, minus, edit, trash, copy, download, upload
+- **Status**: check-circle, x-circle, alert-circle, info
+- **Communication**: mail, message-circle, phone, user
+
+View the full story in Storybook for interactive icon previews. The story includes:
+
+- Variant showcase (line vs filled)
+- Theme color showcase
+- Size showcase
+- Interactive icon grid
+
+**Link**: [Lucide Icons](https://lucide.dev/icons/) - Browse all available icons
+
+## Using in Other Components
+
+```vue
+<template>
+  <NyxButton>
+    <NyxIcon name="plus" />
+    Add Item
+  </NyxButton>
+</template>
+```

--- a/specs/009-add-lucide-icon/research.md
+++ b/specs/009-add-lucide-icon/research.md
@@ -1,0 +1,71 @@
+# Research: NyxIcon Component
+
+## Decision: Which Lucide package to use
+
+**Choice**: `lucide-vue-next`
+
+**Rationale**:
+- Already in dependencies (`lucide-vue-next@0.577.0`)
+- Official Vue 3 package using Composition API
+- More popular (708K weekly downloads vs 6.1K for @lucide/vue)
+- ISC license - permissive, safe for open source use
+
+**Alternatives considered**:
+- `@lucide/vue` - older, designed for Vue 2 compatibility layer, less maintained
+- `lucide-vue` - Vue 2 only (not applicable)
+
+---
+
+## Decision: Component architecture
+
+**Choice**: Dynamic component resolution via kebab-case to PascalCase conversion
+
+**Rationale**:
+- Allows passing icon name as string prop
+- Lucide exports each icon as named component (e.g., `ArrowRight`, `CheckCircle`)
+- Import all icons as `* as LucideIcons` and resolve by converting "arrow-right" → "ArrowRight"
+- No manual mapping needed - converter handles any icon name
+
+**Implementation**:
+```ts
+function toPascalCase(str: string): string {
+  return str.split('-').map(s => s.charAt(0).toUpperCase() + s.slice(1)).join('')
+}
+
+// "arrow-right" → "ArrowRight"
+const iconName = toPascalCase(props.name)
+const Icon = LucideIcons[iconName as keyof typeof LucideIcons]
+```
+
+---
+
+## Decision: Icon variant handling
+
+**Choice**: Two separate icon sets - line icons (default) and filled icons
+
+**Rationale**:
+- Lucide provides both `ArrowRight` (line) and `ArrowRightFilled` (filled) as separate components
+- Variant prop toggles between these two sets
+- Simplifies implementation vs. prop passing to Lucide components
+
+---
+
+## Decision: Theme integration
+
+**Choice**: Use CSS custom properties from nyx-kit design system
+
+**Rationale**:
+- NyxTheme maps to CSS variables like `--nyx-rgb-primary`
+- Icon color can be set via `currentColor` or explicit RGB variable
+- No theme = use text color from CSS vars
+
+---
+
+## Decision: Default size
+
+**Choice**: 24x24 (Lucide default)
+
+**Rationale**:
+- Lucide icons are designed on 24x24 grid
+- Industry standard, matches most use cases
+- Can be overridden via size prop

--- a/specs/009-add-lucide-icon/spec.md
+++ b/specs/009-add-lucide-icon/spec.md
@@ -1,0 +1,128 @@
+# Feature Specification: NyxIcon Component
+
+**Feature Branch**: `009-add-lucide-icon`  
+**Created**: 2026-03-31  
+**Status**: Draft  
+**Input**: User description: "i want to create a NyxIcon component that acts as a simple funnel/wrapper for Lucide (vue) icons.
+
+Important Q: does this compromise some license? I'm not planning on earning money from nyx-kit itself and it's open source (public repo on github)
+
+Notes on the NyxIcon:
+- supports a string version "name"
+- supports a NyxIconVariant (filled / line / others?) => line is default
+- supports a NyxTheme => optional, without, it will use the text color from the css vars)
+- other helper props?"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Render Lucide Icons (Priority: P1)
+
+As a developer using nyx-kit, I want to render Lucide icons by name, so that I can easily include icons in my Vue applications.
+
+**Why this priority**: This is the core functionality - without it, the component has no purpose.
+
+**Independent Test**: Can be tested by rendering an icon with just a name prop and verifying the correct Lucide component renders.
+
+**Acceptance Scenarios**:
+
+1. **Given** a valid Lucide icon name (e.g., "arrow-right"), **When** passed to NyxIcon as `name="arrow-right"`, **Then** the corresponding Lucide icon renders.
+2. **Given** an invalid icon name, **When** passed to NyxIcon, **Then** a fallback or empty state displays without crashing.
+3. **Given** no name prop provided, **When** NyxIcon renders, **Then** it renders without error (empty or placeholder).
+
+---
+
+### User Story 2 - Icon Variants (Priority: P1)
+
+As a developer, I want to switch between icon variants (line/filled), so that icons match my design system.
+
+**Why this priority**: Different design systems require different icon styles - this is essential for adoption.
+
+**Independent Test**: Can be tested by setting variant prop and verifying the icon style changes appropriately.
+
+**Acceptance Scenarios**:
+
+1. **Given** `variant="line"` (default), **When** icon renders, **Then** it uses the outline/stroked style.
+2. **Given** `variant="filled"`, **When** icon renders, **Then** it uses the filled style.
+
+---
+
+### User Story 3 - Theme Integration (Priority: P2)
+
+As a developer, I want icons to respect theme colors, so they integrate with my application's color scheme.
+
+**Why this priority**: Icons should adapt to the theme system like other Nyx components.
+
+**Independent Test**: Can be tested by applying different NyxTheme values and verifying the icon color changes.
+
+**Acceptance Scenarios**:
+
+1. **Given** a theme prop (e.g., `theme="primary"`), **When** icon renders, **Then** it uses the theme color.
+2. **Given** no theme prop, **When** icon renders, **Then** it uses the default text color from CSS variables.
+
+---
+
+### User Story 4 - Size Control (Priority: P2)
+
+As a developer, I want to control icon size, so they fit different UI contexts.
+
+**Why this priority**: Icons need to scale across various use cases (buttons, headers, etc.).
+
+**Independent Test**: Can be tested by setting size prop and verifying the rendered dimensions.
+
+**Acceptance Scenarios**:
+
+1. **Given** a size prop, **When** icon renders, **Then** it renders at the specified dimensions.
+2. **Given** no size prop, **When** icon renders, **Then** it uses a sensible default size.
+
+---
+
+### User Story 5 - Internal Migration (Priority: P2)
+
+As a nyx-kit maintainer, I want all internal icon usage to flow through NyxIcon, so there's a single point for theming and icon management.
+
+**Why this priority**: Consistency across the library; enables centralized theme control.
+
+**Independent Test**: Can be verified by checking that no direct imports from `lucide-vue-next` exist in component files (except within NyxIcon itself).
+
+**Acceptance Scenarios**:
+
+1. **Given** existing components using `lucide-vue-next` icons directly, **When** NyxIcon is created, **Then** those components SHOULD be migrated to use NyxIcon.
+2. **Given** NyxEditor component, **When** it uses icons, **Then** it uses NyxIcon for consistency.
+
+---
+
+### Edge Cases
+
+- What happens when an icon name maps to a non-existent Lucide icon?
+- How does the component handle server-side rendering?
+- Does the component work when used inside other Nyx components with different themes?
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: NyxIcon MUST accept a `name` prop (string) that maps to a Lucide icon.
+- **FR-002**: NyxIcon MUST support a `variant` prop for switching between icon styles (line/filled), defaulting to "line".
+- **FR-003**: NyxIcon MUST support an optional `theme` prop that applies NyxTheme color when provided.
+- **FR-004**: NyxIcon MUST default to CSS variable text color when no theme is specified.
+- **FR-005**: NyxIcon MUST support a `size` prop for controlling icon dimensions.
+- **FR-006**: NyxIcon MUST gracefully handle invalid icon names without crashing.
+- **FR-007**: NyxIcon MUST be compatible with Vue 3 and work with both @lucide/vue and lucide-vue-next packages.
+- **FR-008**: All internal nyx-kit components that currently import icons directly from `lucide-vue-next` MUST be migrated to use NyxIcon.
+
+### Key Entities
+
+- **NyxIcon**: The main component wrapping Lucide icons
+- **NyxIconVariant**: Enum defining icon style variants (line, filled)
+- **Lucide Icon Library**: External dependency providing the actual icon components
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Developers can render any Lucide icon by providing just its name as a string prop.
+- **SC-002**: Icon variant switching works correctly between line and filled styles.
+- **SC-003**: Theme integration applies the correct color from the NyxTheme system when provided.
+- **SC-004**: Icons render at the specified size or a sensible default (24x24).
+- **SC-005**: No runtime errors occur when providing invalid icon names.
+- **SC-006**: All internal icon usage in nyx-kit flows through NyxIcon (no direct lucide-vue-next imports in components).

--- a/specs/009-add-lucide-icon/tasks.md
+++ b/specs/009-add-lucide-icon/tasks.md
@@ -1,0 +1,178 @@
+---
+
+description: "Task list for NyxIcon component implementation"
+---
+
+# Tasks: NyxIcon Component
+
+**Input**: Design documents from `/specs/009-add-lucide-icon/`
+**Prerequisites**: plan.md (required), spec.md (required for user stories), research.md, data-model.md
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Type definitions and component folder structure
+
+- [x] T001 Add `NyxIconVariant` enum to src/types/common.ts
+- [x] T002 Create NyxIcon component folder src/components/NyxIcon/
+
+---
+
+## Phase 2: Foundational (Export Registration)
+
+**Purpose**: Ensure NyxIcon is properly exported from the library
+
+- [x] T003 [P] Register NyxIcon export in src/components/index.ts
+- [x] T004 [P] Register NyxIcon export in src/index.ts (TBD - no src/index.ts exists)
+- [x] T005 [P] [US1] Create NyxIcon types in src/components/NyxIcon/NyxIcon.types.ts
+- [x] T006 [P] [US1] Create NyxIcon.vue component in src/components/NyxIcon/NyxIcon.vue
+- [x] T007 [US1] Implement dynamic icon resolution (kebab-case name to PascalCase component)
+- [x] T008 [US1] Handle invalid icon names gracefully (no crash)
+- [x] T009 [US1] Create Storybook story in src/components/NyxIcon/NyxIcon.stories.ts with curated icon subset and link to Lucide
+- [x] T010 [P] [US2] Implement variant prop handling in NyxIcon.vue
+- [x] T011 [US2] Configure Lucide to use both line and filled icon sets
+- [x] T012 [US2] Update NyxIcon.stories.ts with variant showcase
+- [x] T013 [P] [US3] Add theme color application in NyxIcon.vue
+- [x] T014 [US3] Implement fallback to CSS variable text color when no theme
+- [x] T015 [US3] Update NyxIcon.stories.ts with theme examples
+- [x] T016 [P] [US4] Add size prop handling in NyxIcon.vue
+- [x] T017 [US4] Map NyxSize tokens to pixel dimensions
+- [x] T018 [US4] Add pixel prop support for custom sizing
+- [x] T019 [US4] Update NyxIcon.stories.ts with size examples
+
+**Checkpoint**: User Stories 1-4 should all work independently
+
+---
+
+## Phase 7: User Story 5 - Internal Migration (Priority: P2)
+
+**Goal**: Migrate all internal icon usage to flow through NyxIcon
+
+**Independent Test**: Verify no direct lucide-vue-next imports in components (except NyxIcon)
+
+### Implementation for User Story 5
+
+- [x] T020 [P] [US5] Identify all lucide-vue-next imports in src/components/
+- [x] T021 [US5] Migrate NyxEditor.vue to use NyxIcon
+- [x] T022 [US5] Migrate NyxEditorToolbarContent.vue to use NyxIcon
+- [x] T023 [US5] Verify no direct lucide-vue-next imports remain (except in NyxIcon)
+
+**Checkpoint**: All user stories complete
+
+---
+
+## Phase 8: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final improvements and validation
+
+- [x] T024 [P] Create docs/specs/components/NyxIcon.spec.md (living spec)
+- [x] T025 [P] Run pnpm type-check and fix any errors
+- [x] T026 Run pnpm test:unit to verify no regressions
+- [x] T027 Verify Storybook renders NyxIcon correctly
+- [x] T028 Update README.md if needed for structural changes (N/A - no structural changes)
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies - can start immediately
+- **Foundational (Phase 2)**: Depends on Setup completion - exports must be registered before component can be used
+- **User Stories (Phase 3-7)**: All depend on Foundational phase - can proceed sequentially or in parallel
+- **Polish (Phase 8)**: Depends on all user stories being complete
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: Can start after Foundational - No dependencies on other stories (MVP)
+- **User Story 2 (P1)**: Can start after Foundational - Builds on US1 core component
+- **User Story 3 (P2)**: Can start after Foundational - Adds theme feature
+- **User Story 4 (P2)**: Can start after Foundational - Adds size feature
+- **User Story 5 (P2)**: Can start after Foundational - Internal migration (depends on NyxIcon being complete)
+
+### Within Each User Story
+
+- Types before component implementation
+- Core implementation before stories
+- Story complete before moving to next priority
+
+### Parallel Opportunities
+
+- All Setup tasks marked [P] can run in parallel
+- All Foundational tasks marked [P] can run in parallel
+- User Stories 3-7 can be worked on in parallel (once Foundational complete)
+- All Polish tasks marked [P] can run in parallel
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+# Launch both type and component creation together:
+Task: "Create NyxIcon types in src/components/NyxIcon/NyxIcon.types.ts"
+Task: "Create NyxIcon.vue component in src/components/NyxIcon/NyxIcon.vue"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup
+2. Complete Phase 2: Foundational
+3. Complete Phase 3: User Story 1
+4. **STOP and VALIDATE**: Test basic icon rendering works
+5. Deploy/demo if ready
+
+### Incremental Delivery
+
+1. Complete Setup + Foundational → Foundation ready
+2. Add User Story 1 → Test independently → Deploy/Demo (MVP!)
+3. Add User Story 2 → Test independently → Deploy/Demo
+4. Add User Story 3 → Test independently → Deploy/Demo
+5. Add User Story 4 → Test independently → Deploy/Demo
+6. Add User Story 5 → Test independently → Deploy/Demo
+7. Polish → Final release
+
+---
+
+## Summary
+
+| Metric | Value |
+|--------|-------|
+| **Total Tasks** | 28 |
+| **Phase 1 (Setup)** | 2 |
+| **Phase 2 (Foundational)** | 2 |
+| **Phase 3 (US1 - MVP)** | 5 |
+| **Phase 4 (US2)** | 3 |
+| **Phase 5 (US3)** | 3 |
+| **Phase 6 (US4)** | 4 |
+| **Phase 7 (US5)** | 4 |
+| **Phase 8 (Polish)** | 5 |
+
+### Parallel Opportunities
+
+- 8 tasks marked [P] can run in parallel
+- User stories can be worked on in parallel (once foundational ready)
+
+### Suggested MVP Scope
+
+User Story 1 alone constitutes the MVP: basic NyxIcon rendering by name string.
+
+### Notes
+
+- [P] tasks = different files, no dependencies
+- [Story] label maps task to specific user story for traceability
+- Each user story should be independently completable and testable
+- Commit after each task or logical group
+- Stop at any checkpoint to validate story independently

--- a/src/components/NyxEditor/NyxEditor.vue
+++ b/src/components/NyxEditor/NyxEditor.vue
@@ -18,11 +18,12 @@ import {
   NyxEditorFormat,
   NyxEditorToolbar as NyxEditorToolbarMode,
   NyxTheme,
+  NyxSize,
 } from '@/types'
 import { useNyxProps, useEditorAnnotations, useEditorMeta } from '@/composables'
 import NyxEditorBubbleMenu from './NyxEditorBubbleMenu/NyxEditorBubbleMenu.vue'
 import NyxEditorToolbar from './NyxEditorToolbar/NyxEditorToolbar.vue'
-import { ChevronRight, FileCode } from 'lucide-vue-next'
+import NyxIcon from '../NyxIcon/NyxIcon.vue'
 
 const props = withDefaults(defineProps<NyxEditorProps>(), {
   mode: NyxEditorMode.Zen,
@@ -211,7 +212,7 @@ watch(() => annotationsModel.value, () => {
       :class="{ active: sourceModel }"
       @click="sourceModel = !sourceModel"
       aria-label="Toggle source"
-    ><FileCode :size="14" /></button>
+          ><NyxIcon name="file-code" :size="NyxSize.Small" /></button>
 
     <!-- Source view -->
     <textarea
@@ -242,7 +243,7 @@ watch(() => annotationsModel.value, () => {
         <span class="nyx-editor__footer-path" aria-label="Document structure">
           <template v-if="meta.segments.length">
             <template v-for="(segment, index) in meta.segments" :key="`${segment.type}-${segment.label}-${index}`">
-              <ChevronRight v-if="index > 0" :size="12" class="nyx-editor__footer-separator" aria-hidden="true" />
+              <NyxIcon v-if="index > 0" name="chevron-right" :size="NyxSize.XSmall" class="nyx-editor__footer-separator" aria-hidden="true" />
               <span class="nyx-editor__footer-segment">{{ segment.label }}</span>
             </template>
           </template>

--- a/src/components/NyxEditor/NyxEditorToolbarContent/NyxEditorToolbarContent.vue
+++ b/src/components/NyxEditor/NyxEditorToolbarContent/NyxEditorToolbarContent.vue
@@ -2,12 +2,7 @@
 import type { Editor } from '@tiptap/vue-3'
 import { computed } from 'vue'
 import { NyxEditorToolbar } from '@/types'
-import {
-  Bold, Italic, Underline, Strikethrough, Code,
-  List, ListOrdered, ListChecks,
-  Heading1, Heading2, Heading3, Pilcrow,
-  Undo2, Redo2, MessageSquare,
-} from 'lucide-vue-next'
+import NyxIcon from '../../NyxIcon/NyxIcon.vue'
 
 const props = withDefaults(defineProps<{
   editor: Editor | null
@@ -25,7 +20,6 @@ const emit = defineEmits<{
 const hasFormatting = computed(() => [NyxEditorToolbar.Default, NyxEditorToolbar.Full].includes(props.toolbar))
 const hasComments = computed(() => [NyxEditorToolbar.CommentOnly, NyxEditorToolbar.Full].includes(props.toolbar))
 
-const iconSize = computed(() => props.surface === 'bubble' ? 14 : 15)
 const buttonClass = computed(() => `nyx-editor__${props.surface}-btn`)
 const separatorClass = computed(() => `nyx-editor__${props.surface}-sep`)
 const trailingSeparatorClass = computed(() => [separatorClass.value, props.surface === 'toolbar' ? 'nyx-editor__toolbar-sep--grow' : ''].filter(Boolean).join(' '))
@@ -37,57 +31,57 @@ const onAnnotationCreate = () => emit('annotation:create')
   <template v-if="hasFormatting">
     <button :class="[buttonClass, { active: editor?.isActive('bold') }]"
       @click="editor?.chain().focus().toggleBold().run()" aria-label="Bold">
-      <Bold :size="iconSize" />
+      <NyxIcon name="bold" />
     </button>
     <button :class="[buttonClass, { active: editor?.isActive('italic') }]"
       @click="editor?.chain().focus().toggleItalic().run()" aria-label="Italic">
-      <Italic :size="iconSize" />
+      <NyxIcon name="italic" />
     </button>
     <button :class="[buttonClass, { active: editor?.isActive('underline') }]"
       @click="editor?.chain().focus().toggleUnderline().run()" aria-label="Underline">
-      <Underline :size="iconSize" />
+      <NyxIcon name="underline" />
     </button>
     <button :class="[buttonClass, { active: editor?.isActive('strike') }]"
       @click="editor?.chain().focus().toggleStrike().run()" aria-label="Strikethrough">
-      <Strikethrough :size="iconSize" />
+      <NyxIcon name="strikethrough" />
     </button>
     <button :class="[buttonClass, { active: editor?.isActive('code') }]"
       @click="editor?.chain().focus().toggleCode().run()" aria-label="Inline code">
-      <Code :size="iconSize" />
+      <NyxIcon name="code" />
     </button>
 
     <span :class="separatorClass" aria-hidden="true" />
 
     <button :class="[buttonClass, { active: editor?.isActive('bulletList') }]"
       @click="editor?.chain().focus().toggleBulletList().run()" aria-label="Bullet list">
-      <List :size="iconSize" />
+      <NyxIcon name="list" />
     </button>
     <button :class="[buttonClass, { active: editor?.isActive('orderedList') }]"
       @click="editor?.chain().focus().toggleOrderedList().run()" aria-label="Ordered list">
-      <ListOrdered :size="iconSize" />
+      <NyxIcon name="list-ordered" />
     </button>
     <button :class="[buttonClass, { active: editor?.isActive('taskList') }]"
       @click="editor?.chain().focus().toggleTaskList().run()" aria-label="Task list">
-      <ListChecks :size="iconSize" />
+      <NyxIcon name="list-check" />
     </button>
 
     <span :class="separatorClass" aria-hidden="true" />
 
     <button :class="[buttonClass, { active: editor?.isActive('heading', { level: 1 }) }]"
       @click="editor?.chain().focus().toggleHeading({ level: 1 }).run()" aria-label="Heading 1">
-      <Heading1 :size="iconSize" />
+      <NyxIcon name="heading-1" />
     </button>
     <button :class="[buttonClass, { active: editor?.isActive('heading', { level: 2 }) }]"
       @click="editor?.chain().focus().toggleHeading({ level: 2 }).run()" aria-label="Heading 2">
-      <Heading2 :size="iconSize" />
+      <NyxIcon name="heading-2" />
     </button>
     <button :class="[buttonClass, { active: editor?.isActive('heading', { level: 3 }) }]"
       @click="editor?.chain().focus().toggleHeading({ level: 3 }).run()" aria-label="Heading 3">
-      <Heading3 :size="iconSize" />
+      <NyxIcon name="heading-3" />
     </button>
     <button :class="[buttonClass, { active: editor?.isActive('paragraph') }]"
       @click="editor?.chain().focus().setParagraph().run()" aria-label="Paragraph">
-      <Pilcrow :size="iconSize" />
+      <NyxIcon name="pilcrow" />
     </button>
   </template>
 
@@ -97,7 +91,7 @@ const onAnnotationCreate = () => emit('annotation:create')
 
   <template v-if="hasComments">
     <button :class="buttonClass" @click="onAnnotationCreate" aria-label="Comment">
-      <MessageSquare :size="iconSize" />
+      <NyxIcon name="message-square" />
     </button>
   </template>
 
@@ -105,11 +99,11 @@ const onAnnotationCreate = () => emit('annotation:create')
     <span :class="trailingSeparatorClass" aria-hidden="true" />
     <button :class="buttonClass" :disabled="!editor?.can().undo()"
       @click="editor?.chain().focus().undo().run()" aria-label="Undo">
-      <Undo2 :size="iconSize" />
+      <NyxIcon name="undo-2" />
     </button>
     <button :class="buttonClass" :disabled="!editor?.can().redo()"
       @click="editor?.chain().focus().redo().run()" aria-label="Redo">
-      <Redo2 :size="iconSize" />
+      <NyxIcon name="redo-2" />
     </button>
   </template>
 </template>

--- a/src/components/NyxGrid/NyxGrid.vue
+++ b/src/components/NyxGrid/NyxGrid.vue
@@ -20,6 +20,7 @@ const GAP_REM_MAP: Record<NyxSize, number> = {
   [NyxSize.Medium]: 0.75,
   [NyxSize.Large]: 1,
   [NyxSize.XLarge]: 1.25,
+  [NyxSize.XXLarge]: 1.5
 }
 
 const props = withDefaults(defineProps<NyxGridProps>(), {

--- a/src/components/NyxIcon/NyxIcon.scss
+++ b/src/components/NyxIcon/NyxIcon.scss
@@ -1,0 +1,31 @@
+.nyx-icon {
+  --nyx-icon-color: var(--nyx-c-text);
+  color: var(--nyx-icon-color);
+  display: inline-block;
+  vertical-align: middle;
+  flex-shrink: 0;
+
+  &.theme-primary {
+    --nyx-icon-color: var(--nyx-c-primary);
+  }
+
+  &.theme-secondary {
+    --nyx-icon-color: var(--nyx-c-secondary);
+  }
+
+  &.theme-success {
+    --nyx-icon-color: var(--nyx-c-success);
+  }
+
+  &.theme-warning {
+    --nyx-icon-color: var(--nyx-c-warning);
+  }
+
+  &.theme-danger {
+    --nyx-icon-color: var(--nyx-c-danger);
+  }
+
+  &.theme-info {
+    --nyx-icon-color: var(--nyx-c-info);
+  }
+}

--- a/src/components/NyxIcon/NyxIcon.stories.ts
+++ b/src/components/NyxIcon/NyxIcon.stories.ts
@@ -2,7 +2,7 @@ import { defineComponent } from 'vue'
 import NyxIcon from './NyxIcon.vue'
 import { NyxTheme, NyxSize } from '@/types'
 
-const ICONS = ['arrow-right', 'check-circle', 'x-circle', 'alert-circle', 'star', 'heart', 'user', 'settings', 'home', 'search']
+const ICONS = ['arrow-right', 'arrow-left', 'chevron-down', 'chevron-up', 'menu', 'x', 'plus', 'minus', 'edit', 'trash']
 
 export default {
   title: 'Components/NyxIcon',
@@ -96,39 +96,13 @@ export const WithTheme = () => ({
 export const Sizes = () => ({
   components: { NyxIcon },
   setup() {
-    return { NyxSize }
+    return { NyxSize, ICONS }
   },
   template: `
     <div>
-      <div style="display:flex;align-items:center;gap:8px;margin-bottom:8px">
-        <span style="min-width:60px">XS:</span>
-        <nyx-icon name="arrow-right" :size="NyxSize.XSmall" />
-        <nyx-icon name="check-circle" :size="NyxSize.XSmall" />
-      </div>
-      <div style="display:flex;align-items:center;gap:8px;margin-bottom:8px">
-        <span style="min-width:60px">SM:</span>
-        <nyx-icon name="arrow-right" :size="NyxSize.Small" />
-        <nyx-icon name="check-circle" :size="NyxSize.Small" />
-      </div>
-      <div style="display:flex;align-items:center;gap:8px;margin-bottom:8px">
-        <span style="min-width:60px">MD:</span>
-        <nyx-icon name="arrow-right" :size="NyxSize.Medium" />
-        <nyx-icon name="check-circle" :size="NyxSize.Medium" />
-      </div>
-      <div style="display:flex;align-items:center;gap:8px;margin-bottom:8px">
-        <span style="min-width:60px">LG:</span>
-        <nyx-icon name="arrow-right" :size="NyxSize.Large" />
-        <nyx-icon name="check-circle" :size="NyxSize.Large" />
-      </div>
-      <div style="display:flex;align-items:center;gap:8px;margin-bottom:8px">
-        <span style="min-width:60px">XL:</span>
-        <nyx-icon name="arrow-right" :size="NyxSize.XLarge" />
-        <nyx-icon name="check-circle" :size="NyxSize.XLarge" />
-      </div>
-      <div style="display:flex;align-items:center;gap:8px;margin-bottom:8px">
-        <span style="min-width:60px">2XL:</span>
-        <nyx-icon name="arrow-right" :size="NyxSize.XXLarge" />
-        <nyx-icon name="check-circle" :size="NyxSize.XXLarge" />
+      <div v-for="size in Object.values(NyxSize)" :key="size" style="display:flex;align-items:center;gap:8px;margin-bottom:8px">
+        <span style="min-width:60px">{{ size }}:</span>
+        <nyx-icon v-for="icon in ICONS" :key="icon" :name="icon" :size="size" />
       </div>
     </div>
   `
@@ -136,17 +110,15 @@ export const Sizes = () => ({
 
 export const CustomSizes = () => ({
   components: { NyxIcon },
+  setup() {
+    const sizes = [10, 20, 32, 48, 64]
+    return { sizes, ICONS }
+  },
   template: `
     <div>
-      <div style="display:flex;align-items:center;gap:8px;margin-bottom:8px">
-        <span style="min-width:60px">10px:</span>
-        <nyx-icon name="arrow-right" :size="10" />
-        <nyx-icon name="check-circle" :size="10" />
-      </div>
-      <div style="display:flex;align-items:center;gap:8px;margin-bottom:8px">
-        <span style="min-width:60px">48px:</span>
-        <nyx-icon name="arrow-right" :size="48" />
-        <nyx-icon name="check-circle" :size="48" />
+      <div v-for="size in sizes" :key="size" style="display:flex;align-items:center;gap:8px;margin-bottom:8px">
+        <span style="min-width:60px">{{ size }}px:</span>
+        <nyx-icon v-for="icon in ICONS" :key="icon" :name="icon" :size="size" />
       </div>
     </div>
   `

--- a/src/components/NyxIcon/NyxIcon.stories.ts
+++ b/src/components/NyxIcon/NyxIcon.stories.ts
@@ -1,0 +1,233 @@
+import { defineComponent } from 'vue'
+import NyxIcon from './NyxIcon.vue'
+import { NyxTheme, NyxSize } from '@/types'
+
+const ICONS = ['arrow-right', 'check-circle', 'x-circle', 'alert-circle', 'star', 'heart', 'user', 'settings', 'home', 'search']
+
+export default {
+  title: 'Components/NyxIcon',
+  component: NyxIcon,
+  tags: ['autodocs'],
+  argTypes: {
+    name: {
+      control: { type: 'select' },
+      options: ICONS
+    },
+    variant: {
+      control: { type: 'select' },
+      options: ['line', 'filled']
+    },
+    theme: {
+      control: { type: 'select' },
+      options: Object.values(NyxTheme)
+    },
+    size: {
+      control: { type: 'select' },
+      options: Object.values(NyxSize)
+    }
+  },
+  parameters: {
+    docs: {
+      description: {
+        component: 'A wrapper component for Lucide Vue icons. Supports string-based icon names, variant switching (line/filled), optional theme coloring, and size control.\n\n[View all Lucide icons](https://lucide.dev/icons/)'
+      }
+    }
+  }
+}
+
+export const Default = (args: Record<string, unknown>) => ({
+  components: { NyxIcon },
+  setup() {
+    return { args }
+  },
+  template: `<nyx-icon v-bind="args" />`
+})
+
+export const Variants = () => ({
+  components: { NyxIcon },
+  template: `
+    <div>
+      <div style="display:flex;align-items:center;gap:8px;margin-bottom:8px">
+        <span style="min-width:60px">Line:</span>
+        <nyx-icon name="arrow-right" variant="line" />
+        <nyx-icon name="check-circle" variant="line" />
+        <nyx-icon name="x-circle" variant="line" />
+        <nyx-icon name="alert-circle" variant="line" />
+        <nyx-icon name="star" variant="line" />
+      </div>
+      <div style="display:flex;align-items:center;gap:8px">
+        <span style="min-width:60px">Filled:</span>
+        <nyx-icon name="arrow-right" variant="filled" />
+        <nyx-icon name="check-circle" variant="filled" />
+        <nyx-icon name="x-circle" variant="filled" />
+        <nyx-icon name="alert-circle" variant="filled" />
+        <nyx-icon name="star" variant="filled" />
+      </div>
+    </div>
+  `
+})
+
+export const WithTheme = () => ({
+  components: { NyxIcon },
+  template: `
+    <div>
+      <div style="display:flex;align-items:center;gap:8px;margin-bottom:8px">
+        <span style="min-width:80px">Primary:</span>
+        <nyx-icon name="arrow-right" theme="Primary" />
+        <nyx-icon name="check-circle" theme="Primary" />
+        <nyx-icon name="star" theme="Primary" />
+      </div>
+      <div style="display:flex;align-items:center;gap:8px;margin-bottom:8px">
+        <span style="min-width:80px">Success:</span>
+        <nyx-icon name="arrow-right" theme="Success" />
+        <nyx-icon name="check-circle" theme="Success" />
+        <nyx-icon name="star" theme="Success" />
+      </div>
+      <div style="display:flex;align-items:center;gap:8px;margin-bottom:8px">
+        <span style="min-width:80px">Danger:</span>
+        <nyx-icon name="arrow-right" theme="Danger" />
+        <nyx-icon name="check-circle" theme="Danger" />
+        <nyx-icon name="star" theme="Danger" />
+      </div>
+    </div>
+  `
+})
+
+export const Sizes = () => ({
+  components: { NyxIcon },
+  setup() {
+    return { NyxSize }
+  },
+  template: `
+    <div>
+      <div style="display:flex;align-items:center;gap:8px;margin-bottom:8px">
+        <span style="min-width:60px">XS:</span>
+        <nyx-icon name="arrow-right" :size="NyxSize.XSmall" />
+        <nyx-icon name="check-circle" :size="NyxSize.XSmall" />
+      </div>
+      <div style="display:flex;align-items:center;gap:8px;margin-bottom:8px">
+        <span style="min-width:60px">SM:</span>
+        <nyx-icon name="arrow-right" :size="NyxSize.Small" />
+        <nyx-icon name="check-circle" :size="NyxSize.Small" />
+      </div>
+      <div style="display:flex;align-items:center;gap:8px;margin-bottom:8px">
+        <span style="min-width:60px">MD:</span>
+        <nyx-icon name="arrow-right" :size="NyxSize.Medium" />
+        <nyx-icon name="check-circle" :size="NyxSize.Medium" />
+      </div>
+      <div style="display:flex;align-items:center;gap:8px;margin-bottom:8px">
+        <span style="min-width:60px">LG:</span>
+        <nyx-icon name="arrow-right" :size="NyxSize.Large" />
+        <nyx-icon name="check-circle" :size="NyxSize.Large" />
+      </div>
+      <div style="display:flex;align-items:center;gap:8px;margin-bottom:8px">
+        <span style="min-width:60px">XL:</span>
+        <nyx-icon name="arrow-right" :size="NyxSize.XLarge" />
+        <nyx-icon name="check-circle" :size="NyxSize.XLarge" />
+      </div>
+      <div style="display:flex;align-items:center;gap:8px;margin-bottom:8px">
+        <span style="min-width:60px">2XL:</span>
+        <nyx-icon name="arrow-right" :size="NyxSize.XXLarge" />
+        <nyx-icon name="check-circle" :size="NyxSize.XXLarge" />
+      </div>
+    </div>
+  `
+})
+
+export const CustomSizes = () => ({
+  components: { NyxIcon },
+  template: `
+    <div>
+      <div style="display:flex;align-items:center;gap:8px;margin-bottom:8px">
+        <span style="min-width:60px">10px:</span>
+        <nyx-icon name="arrow-right" :size="10" />
+        <nyx-icon name="check-circle" :size="10" />
+      </div>
+      <div style="display:flex;align-items:center;gap:8px;margin-bottom:8px">
+        <span style="min-width:60px">48px:</span>
+        <nyx-icon name="arrow-right" :size="48" />
+        <nyx-icon name="check-circle" :size="48" />
+      </div>
+    </div>
+  `
+})
+
+export const IconGallery = () => ({
+  components: { NyxIcon },
+  template: `
+    <div style="display:grid;grid-template-columns:repeat(auto-fill,minmax(80px,1fr));gap:8px">
+      <div style="display:flex;flex-direction:column;align-items:center;gap:4px">
+        <nyx-icon name="arrow-right" />
+        <span style="font-size:9px;color:var(--nyx-text-muted)">arrow-right</span>
+      </div>
+      <div style="display:flex;flex-direction:column;align-items:center;gap:4px">
+        <nyx-icon name="arrow-left" />
+        <span style="font-size:9px;color:var(--nyx-text-muted)">arrow-left</span>
+      </div>
+      <div style="display:flex;flex-direction:column;align-items:center;gap:4px">
+        <nyx-icon name="chevron-down" />
+        <span style="font-size:9px;color:var(--nyx-text-muted)">chevron-down</span>
+      </div>
+      <div style="display:flex;flex-direction:column;align-items:center;gap:4px">
+        <nyx-icon name="chevron-up" />
+        <span style="font-size:9px;color:var(--nyx-text-muted)">chevron-up</span>
+      </div>
+      <div style="display:flex;flex-direction:column;align-items:center;gap:4px">
+        <nyx-icon name="menu" />
+        <span style="font-size:9px;color:var(--nyx-text-muted)">menu</span>
+      </div>
+      <div style="display:flex;flex-direction:column;align-items:center;gap:4px">
+        <nyx-icon name="x" />
+        <span style="font-size:9px;color:var(--nyx-text-muted)">x</span>
+      </div>
+      <div style="display:flex;flex-direction:column;align-items:center;gap:4px">
+        <nyx-icon name="plus" />
+        <span style="font-size:9px;color:var(--nyx-text-muted)">plus</span>
+      </div>
+      <div style="display:flex;flex-direction:column;align-items:center;gap:4px">
+        <nyx-icon name="minus" />
+        <span style="font-size:9px;color:var(--nyx-text-muted)">minus</span>
+      </div>
+      <div style="display:flex;flex-direction:column;align-items:center;gap:4px">
+        <nyx-icon name="edit" />
+        <span style="font-size:9px;color:var(--nyx-text-muted)">edit</span>
+      </div>
+      <div style="display:flex;flex-direction:column;align-items:center;gap:4px">
+        <nyx-icon name="trash" />
+        <span style="font-size:9px;color:var(--nyx-text-muted)">trash</span>
+      </div>
+      <div style="display:flex;flex-direction:column;align-items:center;gap:4px">
+        <nyx-icon name="check-circle" />
+        <span style="font-size:9px;color:var(--nyx-text-muted)">check-circle</span>
+      </div>
+      <div style="display:flex;flex-direction:column;align-items:center;gap:4px">
+        <nyx-icon name="x-circle" />
+        <span style="font-size:9px;color:var(--nyx-text-muted)">x-circle</span>
+      </div>
+      <div style="display:flex;flex-direction:column;align-items:center;gap:4px">
+        <nyx-icon name="alert-circle" />
+        <span style="font-size:9px;color:var(--nyx-text-muted)">alert-circle</span>
+      </div>
+      <div style="display:flex;flex-direction:column;align-items:center;gap:4px">
+        <nyx-icon name="star" />
+        <span style="font-size:9px;color:var(--nyx-text-muted)">star</span>
+      </div>
+      <div style="display:flex;flex-direction:column;align-items:center;gap:4px">
+        <nyx-icon name="heart" />
+        <span style="font-size:9px;color:var(--nyx-text-muted)">heart</span>
+      </div>
+      <div style="display:flex;flex-direction:column;align-items:center;gap:4px">
+        <nyx-icon name="settings" />
+        <span style="font-size:9px;color:var(--nyx-text-muted)">settings</span>
+      </div>
+      <div style="display:flex;flex-direction:column;align-items:center;gap:4px">
+        <nyx-icon name="home" />
+        <span style="font-size:9px;color:var(--nyx-text-muted)">home</span>
+      </div>
+      <div style="display:flex;flex-direction:column;align-items:center;gap:4px">
+        <nyx-icon name="search" />
+        <span style="font-size:9px;color:var(--nyx-text-muted)">search</span>
+      </div>
+    </div>
+  `
+})

--- a/src/components/NyxIcon/NyxIcon.stories.ts
+++ b/src/components/NyxIcon/NyxIcon.stories.ts
@@ -1,5 +1,7 @@
+import { defineComponent } from 'vue'
 import NyxIcon from './NyxIcon.vue'
-import { NyxTheme, NyxSize } from '@/types'
+import { NyxTheme, NyxSize, type KeyDict } from '@/types'
+import { getKeyDictKeyByValue } from '@/utils'
 
 const ICONS = ['arrow-right', 'arrow-left', 'chevron-down', 'chevron-up', 'menu', 'x', 'plus', 'minus', 'edit', 'trash']
 
@@ -19,6 +21,10 @@ export default {
     size: {
       control: { type: 'select' },
       options: Object.values(NyxSize)
+    },
+    stroke: {
+      control: { type: 'select' },
+      options: Object.values(NyxSize)
     }
   },
   parameters: {
@@ -30,62 +36,41 @@ export default {
   }
 }
 
-export const Default = (args: Record<string, unknown>) => ({
+const Template = (args: Record<string, unknown>) => defineComponent({
   components: { NyxIcon },
-  setup() {
+  setup () {
     return { args }
   },
-  template: `<nyx-icon v-bind="args" />`
+  template: `<nyx-icon v-bind="args" />`,
 })
 
-Default.args = {
-  name: 'arrow-right'
-}
+export const Default = Template({ name: 'arrow-right' })
 
-export const WithTheme = () => ({
+const TemplateAllProp = (prop: string, dict: KeyDict<string>) => () => defineComponent({
   components: { NyxIcon },
-  template: `
-    <div>
-      <div style="display:flex;align-items:center;gap:8px;margin-bottom:8px">
-        <span style="min-width:80px">Primary:</span>
-        <nyx-icon name="arrow-right" theme="Primary" />
-        <nyx-icon name="check-circle" theme="Primary" />
-        <nyx-icon name="star" theme="Primary" />
-      </div>
-      <div style="display:flex;align-items:center;gap:8px;margin-bottom:8px">
-        <span style="min-width:80px">Success:</span>
-        <nyx-icon name="arrow-right" theme="Success" />
-        <nyx-icon name="check-circle" theme="Success" />
-        <nyx-icon name="star" theme="Success" />
-      </div>
-      <div style="display:flex;align-items:center;gap:8px;margin-bottom:8px">
-        <span style="min-width:80px">Danger:</span>
-        <nyx-icon name="arrow-right" theme="Danger" />
-        <nyx-icon name="check-circle" theme="Danger" />
-        <nyx-icon name="star" theme="Danger" />
-      </div>
-    </div>
-  `
-})
-
-export const Sizes = () => ({
-  components: { NyxIcon },
-  setup() {
-    return { NyxSize, ICONS }
+  setup () {
+    const values = Object.values(dict)
+    const getLabel = (value: string) => getKeyDictKeyByValue(dict, value)
+    return { prop, values, getLabel }
   },
   template: `
-    <div>
-      <div v-for="size in Object.values(NyxSize)" :key="size" style="display:flex;align-items:center;gap:8px;margin-bottom:8px">
-        <span style="min-width:60px">{{ size }}:</span>
-        <nyx-icon v-for="icon in ICONS" :key="icon" :name="icon" :size="size" />
-      </div>
+    <div class="flex">
+      <nyx-icon
+        v-for="value of values"
+        :key="value"
+        v-bind="{ [prop]: value }"
+      >{{ getLabel(value) }}</nyx-icon>
     </div>
-  `
+  `,
 })
 
-export const CustomSizes = () => ({
+export const Themes = TemplateAllProp('theme', NyxTheme as KeyDict<string>)
+export const Sizes = TemplateAllProp('size', NyxSize as KeyDict<string>)
+export const Strokes = TemplateAllProp('stroke', NyxSize as KeyDict<string>)
+
+export const CustomSizes = () => defineComponent({
   components: { NyxIcon },
-  setup() {
+  setup () {
     const sizes = [10, 20, 32, 48, 64]
     return { sizes, ICONS }
   },
@@ -99,7 +84,7 @@ export const CustomSizes = () => ({
   `
 })
 
-export const IconGallery = () => ({
+export const IconGallery = () => defineComponent({
   components: { NyxIcon },
   template: `
     <div style="display:grid;grid-template-columns:repeat(auto-fill,minmax(80px,1fr));gap:8px">

--- a/src/components/NyxIcon/NyxIcon.stories.ts
+++ b/src/components/NyxIcon/NyxIcon.stories.ts
@@ -1,4 +1,3 @@
-import { defineComponent } from 'vue'
 import NyxIcon from './NyxIcon.vue'
 import { NyxTheme, NyxSize } from '@/types'
 
@@ -13,10 +12,6 @@ export default {
       control: { type: 'select' },
       options: ICONS
     },
-    variant: {
-      control: { type: 'select' },
-      options: ['line', 'filled']
-    },
     theme: {
       control: { type: 'select' },
       options: Object.values(NyxTheme)
@@ -29,7 +24,7 @@ export default {
   parameters: {
     docs: {
       description: {
-        component: 'A wrapper component for Lucide Vue icons. Supports string-based icon names, variant switching (line/filled), optional theme coloring, and size control.\n\n[View all Lucide icons](https://lucide.dev/icons/)'
+        component: 'A wrapper component for Lucide Vue icons. Supports string-based icon names, optional theme coloring, and size control.\n\n[View all Lucide icons](https://lucide.dev/icons/)'
       }
     }
   }
@@ -43,29 +38,9 @@ export const Default = (args: Record<string, unknown>) => ({
   template: `<nyx-icon v-bind="args" />`
 })
 
-export const Variants = () => ({
-  components: { NyxIcon },
-  template: `
-    <div>
-      <div style="display:flex;align-items:center;gap:8px;margin-bottom:8px">
-        <span style="min-width:60px">Line:</span>
-        <nyx-icon name="arrow-right" variant="line" />
-        <nyx-icon name="check-circle" variant="line" />
-        <nyx-icon name="x-circle" variant="line" />
-        <nyx-icon name="alert-circle" variant="line" />
-        <nyx-icon name="star" variant="line" />
-      </div>
-      <div style="display:flex;align-items:center;gap:8px">
-        <span style="min-width:60px">Filled:</span>
-        <nyx-icon name="arrow-right" variant="filled" />
-        <nyx-icon name="check-circle" variant="filled" />
-        <nyx-icon name="x-circle" variant="filled" />
-        <nyx-icon name="alert-circle" variant="filled" />
-        <nyx-icon name="star" variant="filled" />
-      </div>
-    </div>
-  `
-})
+Default.args = {
+  name: 'arrow-right'
+}
 
 export const WithTheme = () => ({
   components: { NyxIcon },

--- a/src/components/NyxIcon/NyxIcon.types.ts
+++ b/src/components/NyxIcon/NyxIcon.types.ts
@@ -1,0 +1,8 @@
+import type { NyxTheme, NyxSize, NyxIconVariant } from '@/types'
+
+export interface NyxIconProps {
+  name: string
+  variant?: NyxIconVariant
+  theme?: NyxTheme
+  size?: NyxSize | number
+}

--- a/src/components/NyxIcon/NyxIcon.types.ts
+++ b/src/components/NyxIcon/NyxIcon.types.ts
@@ -1,8 +1,9 @@
-import type { NyxTheme, NyxSize, NyxIconVariant } from '@/types'
+import type { NyxTheme, NyxSize } from '@/types'
 
 export interface NyxIconProps {
   name: string
-  variant?: NyxIconVariant
   theme?: NyxTheme
+  color?: string
   size?: NyxSize | number
+  stroke?: NyxSize | number
 }

--- a/src/components/NyxIcon/NyxIcon.vue
+++ b/src/components/NyxIcon/NyxIcon.vue
@@ -2,11 +2,13 @@
   <component
     :is="resolvedIcon"
     class="nyx-icon"
+    :class="themeClass"
     v-bind="lucideArgs"
   />
 </template>
 
 <script setup lang="ts">
+import './NyxIcon.scss'
 import { computed } from 'vue'
 import * as LucideIcons from 'lucide-vue-next'
 import { type NyxIconProps } from './NyxIcon.types'
@@ -35,15 +37,6 @@ const STROKE_REM_MAP: Record<NyxSize, number> = {
   [NyxSize.XXLarge]: 2,
 }
 
-const THEME_COLOR_MAP: Record<NyxTheme, string> = {
-  [NyxTheme.Primary]: 'rgb(var(--nyx-rgb-primary))',
-  [NyxTheme.Secondary]: 'rgb(var(--nyx-rgb-secondary))',
-  [NyxTheme.Success]: 'rgb(var(--nyx-rgb-success))',
-  [NyxTheme.Warning]: 'rgb(var(--nyx-rgb-warning))',
-  [NyxTheme.Danger]: 'rgb(var(--nyx-rgb-danger))',
-  [NyxTheme.Info]: 'rgb(var(--nyx-rgb-info))',
-}
-
 const FALLBACK_ICON = 'HelpCircle'
 
 const resolvedIcon = computed(() => {
@@ -51,6 +44,11 @@ const resolvedIcon = computed(() => {
   const baseName = toPascalCase(normalisedName)
   const icon = (LucideIcons as Record<string, unknown>)[baseName] as unknown as { name: string } | undefined
   return icon ?? (LucideIcons as Record<string, unknown>)[FALLBACK_ICON] as unknown as { name: string }
+})
+
+const themeClass = computed(() => {
+  if (!props.theme) return undefined
+  return `theme-${props.theme.toLowerCase()}`
 })
 
 const lucideArgs = computed(() => {
@@ -62,17 +60,10 @@ const lucideArgs = computed(() => {
   const strokeWidth = getSize(props.stroke, STROKE_REM_MAP)
   if (strokeWidth) args.strokeWidth = strokeWidth
 
-  const color = getColor(props.theme, props.color)
-  if (color) args.color = color
+  if (props.color) args.color = props.color
 
   return args
 })
-
-function getColor (theme: NyxTheme | undefined, color: string | undefined): string | undefined {
-  if (theme) return THEME_COLOR_MAP[theme]
-  if (color) return color
-  return undefined
-}
 
 function getSize (size: NyxSize | number | undefined, map: Record<NyxSize, number>): number | undefined {
   if (size === undefined) return undefined

--- a/src/components/NyxIcon/NyxIcon.vue
+++ b/src/components/NyxIcon/NyxIcon.vue
@@ -12,12 +12,12 @@ import './NyxIcon.scss'
 import { computed } from 'vue'
 import * as LucideIcons from 'lucide-vue-next'
 import { type NyxIconProps } from './NyxIcon.types'
-import { NyxTheme, NyxSize } from '@/types'
+import { NyxSize } from '@/types'
 import { toPascalCase } from '@/utils/string'
 
-const props = withDefaults(defineProps<NyxIconProps>(), {
-  name: ''
-})
+const ICON_LIBRARY = LucideIcons as Record<string, unknown>
+const FALLBACK_NAME = 'help-circle'
+const props = defineProps<NyxIconProps>()
 
 const SIZE_REM_MAP: Record<NyxSize, number> = {
   [NyxSize.XSmall]: 12,
@@ -37,13 +37,10 @@ const STROKE_REM_MAP: Record<NyxSize, number> = {
   [NyxSize.XXLarge]: 2,
 }
 
-const FALLBACK_ICON = 'HelpCircle'
-
 const resolvedIcon = computed(() => {
-  const normalisedName = props.name ?? FALLBACK_ICON
-  const baseName = toPascalCase(normalisedName)
-  const icon = (LucideIcons as Record<string, unknown>)[baseName] as unknown as { name: string } | undefined
-  return icon ?? (LucideIcons as Record<string, unknown>)[FALLBACK_ICON] as unknown as { name: string }
+  const normalisedName = (props.name ?? '').trim() || FALLBACK_NAME
+  const icon = ICON_LIBRARY[toPascalCase(normalisedName)]
+  return icon ?? ICON_LIBRARY[toPascalCase(FALLBACK_NAME)]
 })
 
 const themeClass = computed(() => {

--- a/src/components/NyxIcon/NyxIcon.vue
+++ b/src/components/NyxIcon/NyxIcon.vue
@@ -2,9 +2,7 @@
   <component
     :is="resolvedIcon"
     class="nyx-icon"
-    :class="classList"
-    :style="iconStyles"
-    :size="iconSize"
+    v-bind="lucideArgs"
   />
 </template>
 
@@ -12,84 +10,73 @@
 import { computed } from 'vue'
 import * as LucideIcons from 'lucide-vue-next'
 import { type NyxIconProps } from './NyxIcon.types'
-import { NyxIconVariant, NyxTheme, NyxSize } from '@/types'
+import { NyxTheme, NyxSize } from '@/types'
+import { toPascalCase } from '@/utils/string'
 
 const props = withDefaults(defineProps<NyxIconProps>(), {
-  name: '',
-  variant: NyxIconVariant.Line
+  name: ''
 })
 
-const SIZE_MAP: Record<NyxSize, number> = {
-  [NyxSize.XSmall]: 16,
-  [NyxSize.Small]: 20,
-  [NyxSize.Medium]: 24,
-  [NyxSize.Large]: 32,
-  [NyxSize.XLarge]: 40,
-  [NyxSize.XXLarge]: 48
+const SIZE_REM_MAP: Record<NyxSize, number> = {
+  [NyxSize.XSmall]: 12,
+  [NyxSize.Small]: 16,
+  [NyxSize.Medium]: 20,
+  [NyxSize.Large]: 24,
+  [NyxSize.XLarge]: 32,
+  [NyxSize.XXLarge]: 48,
 }
 
-const DEFAULT_SIZE = 24
+const STROKE_REM_MAP: Record<NyxSize, number> = {
+  [NyxSize.XSmall]: 0.5,
+  [NyxSize.Small]: 0.75,
+  [NyxSize.Medium]: 1,
+  [NyxSize.Large]: 1.25,
+  [NyxSize.XLarge]: 1.5,
+  [NyxSize.XXLarge]: 2,
+}
 
-function toPascalCase(str: string): string {
-  return str.split('-').map(s => s.charAt(0).toUpperCase() + s.slice(1)).join('')
+const THEME_COLOR_MAP: Record<NyxTheme, string> = {
+  [NyxTheme.Primary]: 'var(--nyx-c-primary)',
+  [NyxTheme.Secondary]: 'var(--nyx-c-secondary)',
+  [NyxTheme.Success]: 'var(--nyx-c-success)',
+  [NyxTheme.Warning]: 'var(--nyx-c-warning)',
+  [NyxTheme.Danger]: 'var(--nyx-c-danger)',
+  [NyxTheme.Info]: 'var(--nyx-c-info)',
 }
 
 const FALLBACK_ICON = 'HelpCircle'
 
 const resolvedIcon = computed(() => {
-  if (!props.name) return (LucideIcons as Record<string, unknown>)[FALLBACK_ICON] as unknown as { name: string }
-  const baseName = toPascalCase(props.name)
-  let iconName = baseName
-  if (props.variant === NyxIconVariant.Filled) {
-    iconName = `${baseName}Filled`
-    const filledIcon = (LucideIcons as Record<string, unknown>)[iconName] as unknown as { name: string } | undefined
-    if (!filledIcon) {
-      iconName = baseName
-    }
-  }
-  const icon = (LucideIcons as Record<string, unknown>)[iconName] as unknown as { name: string } | undefined
+  const normalisedName = props.name ?? FALLBACK_ICON
+  const baseName = toPascalCase(normalisedName)
+  const icon = (LucideIcons as Record<string, unknown>)[baseName] as unknown as { name: string } | undefined
   return icon ?? (LucideIcons as Record<string, unknown>)[FALLBACK_ICON] as unknown as { name: string }
 })
 
-const iconSize = computed(() => {
-  if (typeof props.size === 'number') {
-    return props.size
-  }
-  if (typeof props.size === 'string') {
-    const parsed = parseInt(props.size, 10)
-    if (!Number.isNaN(parsed)) {
-      return parsed
-    }
-  }
-  if (props.size) {
-    return SIZE_MAP[props.size]
-  }
-  return DEFAULT_SIZE
+const lucideArgs = computed(() => {
+  const args: Record<string, unknown> = {}
+
+  const size = getSize(props.size, SIZE_REM_MAP)
+  if (size) args.size = size
+
+  const strokeWidth = getSize(props.stroke, STROKE_REM_MAP)
+  if (strokeWidth) args.strokeWidth = strokeWidth
+
+  const color = getColor(props.theme, props.color)
+  if (color) args.color = color
+
+  return args
 })
 
-const iconStyles = computed(() => {
-  const styles: Record<string, string> = {}
-  
-  if (props.theme) {
-    styles.color = `rgb(var(--nyx-rgb-${props.theme}))`
-  } else {
-    styles.color = 'var(--nyx-text)'
-  }
-  
-  return styles
-})
-
-const classList = computed(() => {
-  const list = ['nyx-icon']
-  if (props.variant) list.push(`variant-${props.variant}`)
-  return list
-})
-</script>
-
-<style scoped>
-.nyx-icon {
-  display: inline-block;
-  vertical-align: middle;
-  flex-shrink: 0;
+function getColor (theme: NyxTheme | undefined, color: string | undefined): string | undefined {
+  if (theme) return THEME_COLOR_MAP[theme]
+  if (color) return color
+  return undefined
 }
-</style>
+
+function getSize (size: NyxSize | number | undefined, map: Record<NyxSize, number>): number | undefined {
+  if (size === undefined) return undefined
+  if (typeof size === 'number') return size
+  return map[size]
+}
+</script>

--- a/src/components/NyxIcon/NyxIcon.vue
+++ b/src/components/NyxIcon/NyxIcon.vue
@@ -36,12 +36,12 @@ const STROKE_REM_MAP: Record<NyxSize, number> = {
 }
 
 const THEME_COLOR_MAP: Record<NyxTheme, string> = {
-  [NyxTheme.Primary]: 'var(--nyx-c-primary)',
-  [NyxTheme.Secondary]: 'var(--nyx-c-secondary)',
-  [NyxTheme.Success]: 'var(--nyx-c-success)',
-  [NyxTheme.Warning]: 'var(--nyx-c-warning)',
-  [NyxTheme.Danger]: 'var(--nyx-c-danger)',
-  [NyxTheme.Info]: 'var(--nyx-c-info)',
+  [NyxTheme.Primary]: 'rgb(var(--nyx-rgb-primary))',
+  [NyxTheme.Secondary]: 'rgb(var(--nyx-rgb-secondary))',
+  [NyxTheme.Success]: 'rgb(var(--nyx-rgb-success))',
+  [NyxTheme.Warning]: 'rgb(var(--nyx-rgb-warning))',
+  [NyxTheme.Danger]: 'rgb(var(--nyx-rgb-danger))',
+  [NyxTheme.Info]: 'rgb(var(--nyx-rgb-info))',
 }
 
 const FALLBACK_ICON = 'HelpCircle'

--- a/src/components/NyxIcon/NyxIcon.vue
+++ b/src/components/NyxIcon/NyxIcon.vue
@@ -1,0 +1,95 @@
+<template>
+  <component
+    :is="resolvedIcon"
+    class="nyx-icon"
+    :class="classList"
+    :style="iconStyles"
+    :size="iconSize"
+  />
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import * as LucideIcons from 'lucide-vue-next'
+import { type NyxIconProps } from './NyxIcon.types'
+import { NyxIconVariant, NyxTheme, NyxSize } from '@/types'
+
+const props = withDefaults(defineProps<NyxIconProps>(), {
+  name: '',
+  variant: NyxIconVariant.Line
+})
+
+const SIZE_MAP: Record<NyxSize, number> = {
+  [NyxSize.XSmall]: 16,
+  [NyxSize.Small]: 20,
+  [NyxSize.Medium]: 24,
+  [NyxSize.Large]: 32,
+  [NyxSize.XLarge]: 40,
+  [NyxSize.XXLarge]: 48
+}
+
+const DEFAULT_SIZE = 24
+
+function toPascalCase(str: string): string {
+  return str.split('-').map(s => s.charAt(0).toUpperCase() + s.slice(1)).join('')
+}
+
+const FALLBACK_ICON = 'HelpCircle'
+
+const resolvedIcon = computed(() => {
+  if (!props.name) return (LucideIcons as Record<string, unknown>)[FALLBACK_ICON] as unknown as { name: string }
+  const baseName = toPascalCase(props.name)
+  let iconName = baseName
+  if (props.variant === NyxIconVariant.Filled) {
+    iconName = `${baseName}Filled`
+    const filledIcon = (LucideIcons as Record<string, unknown>)[iconName] as unknown as { name: string } | undefined
+    if (!filledIcon) {
+      iconName = baseName
+    }
+  }
+  const icon = (LucideIcons as Record<string, unknown>)[iconName] as unknown as { name: string } | undefined
+  return icon ?? (LucideIcons as Record<string, unknown>)[FALLBACK_ICON] as unknown as { name: string }
+})
+
+const iconSize = computed(() => {
+  if (typeof props.size === 'number') {
+    return props.size
+  }
+  if (typeof props.size === 'string') {
+    const parsed = parseInt(props.size, 10)
+    if (!Number.isNaN(parsed)) {
+      return parsed
+    }
+  }
+  if (props.size) {
+    return SIZE_MAP[props.size]
+  }
+  return DEFAULT_SIZE
+})
+
+const iconStyles = computed(() => {
+  const styles: Record<string, string> = {}
+  
+  if (props.theme) {
+    styles.color = `rgb(var(--nyx-rgb-${props.theme}))`
+  } else {
+    styles.color = 'var(--nyx-text)'
+  }
+  
+  return styles
+})
+
+const classList = computed(() => {
+  const list = ['nyx-icon']
+  if (props.variant) list.push(`variant-${props.variant}`)
+  return list
+})
+</script>
+
+<style scoped>
+.nyx-icon {
+  display: inline-block;
+  vertical-align: middle;
+  flex-shrink: 0;
+}
+</style>

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -9,6 +9,7 @@ import NyxEditor from './NyxEditor/NyxEditor.vue'
 import NyxForm from './NyxForm/NyxForm.vue'
 import NyxFormField from './NyxForm/NyxFormField.vue'
 import NyxGrid from './NyxGrid/NyxGrid.vue'
+import NyxIcon from './NyxIcon/NyxIcon.vue'
 import NyxInput from './NyxInput/NyxInput.vue'
 import NyxMedia from './NyxMedia/NyxMedia.vue'
 import NyxModal from './NyxModal/NyxModal.vue'
@@ -36,6 +37,7 @@ export {
   NyxForm,
   NyxFormField,
   NyxGrid,
+  NyxIcon,
   NyxInput,
   NyxMedia,
   NyxModal,

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -84,7 +84,3 @@ export enum NyxGridMode {
   Masonry = 'masonry',
 }
 
-export enum NyxIconVariant {
-  Line = 'line',
-  Filled = 'filled',
-}

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -22,7 +22,8 @@ export enum NyxSize {
   Small = 'sm',
   Medium = 'md',
   Large = 'lg',
-  XLarge = 'xl'
+  XLarge = 'xl',
+  XXLarge = '2xl'
 }
 
 export enum NyxVariant {
@@ -81,4 +82,9 @@ export enum NyxEditorToolbar {
 export enum NyxGridMode {
   Grid = 'grid',
   Masonry = 'masonry',
+}
+
+export enum NyxIconVariant {
+  Line = 'line',
+  Filled = 'filled',
 }

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -1,12 +1,13 @@
 import type { NyxSize, NyxTheme, NyxVariant } from './common'
 import type { NyxColourMode } from './colour-mode'
 
-export type NyxKitPrimitive = 'all'|'button'|'input'|'select'|'textarea'|'checkbox'|'radio'|'switch'
+export type NyxKitPrimitive = 'all'|'button'|'input'|'select'|'textarea'|'checkbox'|'radio'|'switch'|'icon'
 
 export interface NyxKitDefaults {
   theme?: NyxTheme
   size?: NyxSize
   variant?: NyxVariant
+  stroke?: NyxSize
 }
 
 export type NyxColourModeOptions = {

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -9,3 +9,7 @@ export const generateRandomString = (length: number = 16): string => {
 
   return result
 }
+
+export const toPascalCase = (str: string): string => {
+  return str.split('-').map(s => s.charAt(0).toUpperCase() + s.slice(1)).join('')
+}

--- a/src/utils/string.ts
+++ b/src/utils/string.ts
@@ -10,6 +10,5 @@ export const generateRandomString = (length: number = 16): string => {
   return result
 }
 
-export const toPascalCase = (str: string): string => {
-  return str.split('-').map(s => s.charAt(0).toUpperCase() + s.slice(1)).join('')
-}
+export const toPascalCase = (str: string): string => str.split(/[-_]/)
+  .map(s => s.charAt(0).toUpperCase() + s.slice(1)).join('')


### PR DESCRIPTION
## Summary

Added a new `NyxIcon` component that wraps Lucide Vue icons with full Nyx design system integration.

### Changes

- **New component**: `NyxIcon` - wrapper for Lucide icons with:
  - String-based icon names (kebab-case → PascalCase conversion)
  - Theme support via CSS classes (`.theme-primary`, `.theme-success`, etc.)
  - Size mapping via `NyxSize` enum or custom pixel values
  - Stroke width control via `NyxSize` enum or custom values
  - Direct color prop support for custom colors
  - Fallback to `HelpCircle` for invalid icon names

- **Updated components**: Migrated internal icon usage in:
  - `NyxEditor` - toolbar icons
  - `NyxEditorToolbarContent` - action icons

- **Type additions**:
  - Added `XXLarge` to `NyxSize` enum
  - Added `icon` primitive and `stroke` to plugin types

- **Documentation**: Living spec file at `docs/specs/components/NyxIcon.spec.md`

- **Version bump**: 2.0.11 → 2.0.12

### Props

| Prop | Type | Default | Description |
|------|------|---------|-------------|
| name | string | - | Icon name in kebab-case |
| theme | NyxTheme | - | Theme color via CSS class |
| color | string | - | Direct color (overrides theme) |
| size | NyxSize \| number | - | Icon size |
| stroke | NyxSize \| number | - | Stroke width |

### Example

```vue
<nyx-icon name="arrow-right" theme="Primary" size="lg" />
<nyx-icon name="settings" color="#FF0000" :stroke="2" />
```