### PR TITLE
feat(NyxBreadcrumbs): add router support and item slots

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,10 +1,22 @@
 import '../src/styles/index.css'
 import { type Preview, setup } from '@storybook/vue3'
 import { themes } from 'storybook/theming'
+import { createMemoryHistory, createRouter } from 'vue-router'
 import { vClickOutside } from '../src/directives'
+
+const router = createRouter({
+  history: createMemoryHistory(),
+  routes: [
+    { path: '/', name: 'home', component: { template: '<div />' } },
+    { path: '/library', name: 'library', component: { template: '<div />' } },
+    { path: '/docs/breadcrumbs', name: 'breadcrumbs', component: { template: '<div />' } },
+    { path: '/:pathMatch(.*)*', name: 'fallback', component: { template: '<div />' } },
+  ],
+})
 
 setup((app) => {
   app.directive('click-outside', vClickOutside)
+  app.use(router)
 })
 
 const preview: Preview = {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,7 @@ The project constitution is at `.specify/memory/constitution.md`.
 - N/A - comment threads and persisted annotations are consumer-owned inputs (007-editor-comment-annotations)
 - TypeScript 5.x + Vue 3.5 + Vue 3, `@tiptap/vue-3`, Tiptap `StarterKit`, `tiptap-markdown`, existing internal NyxEditor sub-components/composables (008-editor-footer-info)
 - TypeScript + Vue 3.5+ + `lucide-vue-next` (already installed), Vue 3 (009-add-lucide-icon)
+- TypeScript with Vue 3.5+ single-file components + Vue 3, `lucide-vue-next`, existing `NyxIcon`, existing `useNyxProps` pipeline (010-breadcrumbs-router-icons)
 
 ## Recent Changes
 - 003-testing-improvements: Added TypeScript 5.x / Vue 3 + `@vue/test-utils`, `vitest`, `@playwright/test`, `jsdom`

--- a/docs/architecture/component-model.md
+++ b/docs/architecture/component-model.md
@@ -174,6 +174,7 @@ Both attach on `onMounted` and clean up on `onUnmounted`. Do not add `window.add
 ## Accessible Markup
 
 - Interactive elements must use semantic HTML (`<button>`, `<input>`, `<select>`, `<a>`).
+- Components may type against peer dependencies when the integration is an explicit part of the public API. When they do, the dependency expectation must be documented in the component living spec and package contract.
 - Sliders and range inputs must include `aria-valuenow`, `aria-valuemin`, `aria-valuemax`.
 - Disabled states must set both the CSS class and the native `disabled` / `aria-disabled` attribute.
 - Buttons that render as `<a>` (when `href` is provided) must open in `_blank` for external URLs; `isCurrentDomain` from `src/utils/url.ts` makes this determination.

--- a/docs/specs/components/NyxBreadcrumbs.spec.md
+++ b/docs/specs/components/NyxBreadcrumbs.spec.md
@@ -1,0 +1,89 @@
+# NyxBreadcrumbs
+
+> Navigation breadcrumb trail with optional per-item icons, URL links, Vue Router links, shared separator customization, and full item-slot replacement.
+
+## Purpose and scope
+
+`NyxBreadcrumbs` displays an ordered path of locations or hierarchy steps.
+
+Use it when consumers need:
+- simple label-only breadcrumb items
+- URL-backed breadcrumb links
+- Vue Router breadcrumb links in router-enabled applications
+- optional icon decoration on selected breadcrumb items
+- one shared separator presentation across the full trail
+
+Do not use it for:
+- nested navigation menus
+- stepper or wizard state that requires progression logic
+- per-separator custom behavior
+
+## Internal architecture
+
+- Accepts `items` as either plain strings or structured breadcrumb objects.
+- Normalizes string items into label-only breadcrumb objects before rendering.
+- Renders each breadcrumb item through an internal `NyxBreadcrumbItem` subcomponent inside the `NyxBreadcrumbs` folder.
+- Resolves each breadcrumb item into one of three wrappers around `NyxBreadcrumbItem`:
+  - `<RouterLink>` when `item.route` is present
+  - `<a>` when `item.href` is present and `item.route` is absent
+  - `<span>` when neither navigation target is present
+- Reuses one shared separator definition between adjacent breadcrumb items.
+- Uses `useNyxProps` for theme, size, and variant class resolution.
+- Uses `NyxIcon` for both item icons and icon-based separators.
+- Exposes an `item` scoped slot so consumers can fully replace breadcrumb item content while still receiving the normalized item payload.
+
+## Props
+
+| Prop | Type | Default | Description |
+|---|---|---|---|
+| `items` | `string[] \| NyxBreadcrumb[]` | — | Ordered breadcrumb trail. |
+| `separator` | `string \| { icon: string }` | `'/'` | Shared separator rendered between adjacent breadcrumb items unless the `separator` slot is provided. |
+| `theme` | `NyxTheme` | resolved by `useNyxProps` | Visual theme. |
+| `size` | `NyxSize` | resolved by `useNyxProps` | Visual size scale. |
+| `variant` | `NyxVariant.Filled \| NyxVariant.Text` | resolved by `useNyxProps` | Breadcrumb container variant. |
+
+## Item contract
+
+Each structured `NyxBreadcrumb` item supports:
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `label` | `string` | Yes | Visible breadcrumb text. |
+| `href` | `string` | No | Standard URL target. |
+| `route` | `RouteLocationRaw` | No | Vue Router navigation target. |
+| `icon` | `string` | No | Optional icon name rendered before the label. |
+
+Precedence rules:
+- `route` takes precedence over `href` when both are present.
+- Items with neither `route` nor `href` render as readable static breadcrumb items.
+- String items normalize into label-only static breadcrumb items.
+
+## Emits
+
+| Event | Payload | When |
+|---|---|---|
+| `click` | `NyxBreadcrumb` | A breadcrumb item is activated. |
+
+## Slots
+
+| Slot | Scope | Purpose |
+|---|---|---|
+| `separator` | — | Overrides the separator prop with one shared custom separator reused between all adjacent breadcrumb items. |
+| `item` | `{ item: NyxBreadcrumb }` | Replaces the rendered breadcrumb item content for each normalized item. |
+
+Separator precedence:
+- `separator` slot wins over the `separator` prop.
+- Icon separators render through `NyxIcon` using the supplied icon name.
+
+## Accessibility
+
+- Root element uses `<nav>` for breadcrumb semantics.
+- Linkable items render as semantic links.
+- Static items render as non-link text instead of broken anchors.
+- The current or trailing item must not render a trailing separator.
+- Decorative icons and separators should be hidden from assistive technology.
+
+## Known limitations
+
+- Separator customization is global to the trail, not configurable per item.
+- Vue Router integration depends on `vue-router` being available to the consuming application.

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -17,7 +17,7 @@ export default defineConfigWithVueTs(
 
   {
     name: 'app/files-to-ignore',
-    ignores: ['**/dist/**', '**/dist-ssr/**', '**/coverage/**', '**/storybook-static/**', '**/playwright-report/**', '**/test-results/**'],
+    ignores: ['**/node_modules/**', '**/build/**', '**/dist/**', '**/dist-ssr/**', '**/coverage/**', '**/storybook-static/**', '**/playwright-report/**', '**/test-results/**'],
   },
 
   pluginVue.configs['flat/essential'],

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "nyx-kit",
   "homepage": "http://nyxkit.github.io/nyx-kit",
   "author": "Arne Decant <hello@arnedecant.be>",
-  "version": "2.0.12",
+  "version": "2.0.13",
   "packageManager": "pnpm@10.18.3",
   "private": false,
   "license": "MIT",
@@ -128,6 +128,7 @@
     "vite-plugin-dts": "^4.5.0",
     "vite-plugin-vue-devtools": "^8.1.0",
     "vitest": "^3.0.5",
+    "vue-router": "^4.6.4",
     "vue-tsc": "^2.2.0"
   },
   "peerDependencies": {
@@ -136,7 +137,8 @@
     "eslint-plugin-oxlint": "^0.15.0",
     "eslint-plugin-vue": "^9.0.0",
     "typescript": "^5.0.0",
-    "vue": "^3.0.0"
+    "vue": "^3.0.0",
+    "vue-router": "^4.0.0"
   },
   "peerDependenciesMeta": {
     "@vue/eslint-config-typescript": {
@@ -149,6 +151,9 @@
       "optional": true
     },
     "eslint-plugin-vue": {
+      "optional": true
+    },
+    "vue-router": {
       "optional": true
     }
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -157,6 +157,9 @@ importers:
       vitest:
         specifier: ^3.0.5
         version: 3.2.4(@types/node@22.19.15)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.32.0)(sass@1.98.0)
+      vue-router:
+        specifier: ^4.6.4
+        version: 4.6.4(vue@3.5.30(typescript@5.7.3))
       vue-tsc:
         specifier: ^2.2.0
         version: 2.2.12(typescript@5.7.3)
@@ -1911,6 +1914,9 @@ packages:
 
   '@vue/compiler-vue2@2.7.16':
     resolution: {integrity: sha512-qYC3Psj9S/mfu9uVi5WvNZIzq+xnXMhOwbTFKKDD7b1lhpnn71jXSFdTQ+WsIEk0ONCd7VV2IMm7ONl6tbQ86A==}
+
+  '@vue/devtools-api@6.6.4':
+    resolution: {integrity: sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==}
 
   '@vue/devtools-core@8.1.0':
     resolution: {integrity: sha512-LvD1VgDpoHmYL00IgKRLKktF6SsPAb0yaV8wB8q2jRwsAWvqhS8+vsMLEGKNs7uoKyymXhT92dhxgf/wir6YGQ==}
@@ -4007,6 +4013,11 @@ packages:
     peerDependencies:
       vue: '>=2'
 
+  vue-router@4.6.4:
+    resolution: {integrity: sha512-Hz9q5sa33Yhduglwz6g9skT8OBPii+4bFn88w6J+J4MfEo4KRRpmiNG/hHHkdbRFlLBOqxN8y8gf2Fb0MTUgVg==}
+    peerDependencies:
+      vue: ^3.5.0
+
   vue-tsc@2.2.12:
     resolution: {integrity: sha512-P7OP77b2h/Pmk+lZdJ0YWs+5tJ6J2+uOQPo7tlBnY44QqQSPYvS0qVT4wqDJgwrZaLe47etJLLQRFia71GYITw==}
     hasBin: true
@@ -6084,6 +6095,8 @@ snapshots:
     dependencies:
       de-indent: 1.0.2
       he: 1.2.0
+
+  '@vue/devtools-api@6.6.4': {}
 
   '@vue/devtools-core@8.1.0(vue@3.5.30(typescript@5.7.3))':
     dependencies:
@@ -8270,6 +8283,11 @@ snapshots:
 
   vue-inbrowser-compiler-independent-utils@4.71.1(vue@3.5.30(typescript@5.7.3)):
     dependencies:
+      vue: 3.5.30(typescript@5.7.3)
+
+  vue-router@4.6.4(vue@3.5.30(typescript@5.7.3)):
+    dependencies:
+      '@vue/devtools-api': 6.6.4
       vue: 3.5.30(typescript@5.7.3)
 
   vue-tsc@2.2.12(typescript@5.7.3):

--- a/specs/010-breadcrumbs-router-icons/checklists/requirements.md
+++ b/specs/010-breadcrumbs-router-icons/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: NyxBreadcrumbs Routing and Visual Enhancements
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning  
+**Created**: 2026-04-02  
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Validation completed against `specs/010-breadcrumbs-router-icons/spec.md`.
+- No clarification markers remained after the first draft.
+- Route-target precedence and shared separator reuse were captured explicitly to avoid planning ambiguity.

--- a/specs/010-breadcrumbs-router-icons/contracts/nyx-breadcrumbs.md
+++ b/specs/010-breadcrumbs-router-icons/contracts/nyx-breadcrumbs.md
@@ -1,0 +1,56 @@
+# Contract: NyxBreadcrumbs Public Consumer Surface
+
+**Branch**: `010-breadcrumbs-router-icons` | **Date**: 2026-04-02
+
+## Purpose
+
+Define the public consumer-facing contract for the `NyxBreadcrumbs` component after adding per-item icons, route-aware items, and shared separator customization.
+
+## Component Inputs
+
+### Items
+
+`items` accepts an ordered list containing either:
+- plain text breadcrumb entries
+- structured breadcrumb items with label and optional metadata
+
+Structured breadcrumb items support:
+- `label` as the required visible breadcrumb text
+- `href` as an optional URL target
+- `route` as an optional route-driven target
+- `icon` as an optional item icon identifier
+
+## Navigation Contract
+
+1. Plain text items remain valid and render as label-only breadcrumb items.
+2. Items with `href` render as standard links.
+3. Items with `route` render as route-driven links.
+4. If both `route` and `href` are supplied, `route` takes precedence.
+5. Items with neither `href` nor `route` remain readable and non-broken.
+
+## Separator Contract
+
+The component exposes one reusable `separator` customization point.
+
+Supported forms:
+- default separator behavior
+- `separator` prop as plain text
+- `separator` prop as icon-by-name
+- `separator` slot for custom content
+
+Precedence:
+1. `separator` slot
+2. `separator` prop
+3. built-in default
+
+The same separator presentation is reused between every adjacent breadcrumb pair, and no separator appears after the final item.
+
+## Events
+
+`click` continues to emit the structured breadcrumb item associated with the activated breadcrumb entry.
+
+## Compatibility Notes
+
+- Existing string-only and `href`-based breadcrumb data remains supported.
+- The new item icon and route target fields are additive.
+- Consumers who do not use route-driven navigation are not required to adopt any router dependency.

--- a/specs/010-breadcrumbs-router-icons/data-model.md
+++ b/specs/010-breadcrumbs-router-icons/data-model.md
@@ -1,0 +1,94 @@
+# Data Model: NyxBreadcrumbs Routing and Visual Enhancements
+
+**Branch**: `010-breadcrumbs-router-icons` | **Date**: 2026-04-02
+
+## Entities
+
+### Breadcrumb Item
+
+One item in the breadcrumb trail after input normalization.
+
+**Fields**:
+- `label`: visible text for the breadcrumb item
+- `href`: optional standard navigation target
+- `route`: optional route-driven navigation target
+- `icon`: optional icon identifier for item-level decoration
+
+**Validation rules**:
+- `label` is always required after normalization
+- `href` remains optional for backward compatibility
+- `route` is optional and may coexist with `href`
+- when both `route` and `href` exist, `route` becomes the active navigation target
+- `icon` is optional and must not be required for any item shape
+
+### Route Target
+
+Consumer-provided route metadata attached to a breadcrumb item.
+
+**Fields**:
+- `value`: either a direct route string or a structured route descriptor
+
+**Validation rules**:
+- must be pass-through safe for route-driven applications
+- must not require non-router consumers to provide router-specific packages
+- must only affect items that explicitly define it
+
+### Separator Definition
+
+The shared separator presentation reused between adjacent breadcrumb items.
+
+**Fields**:
+- `text`: optional plain-text separator value
+- `icon`: optional icon identifier separator value
+- `slotContent`: optional custom separator slot content
+
+**Validation rules**:
+- separator is rendered only between adjacent breadcrumb items
+- slot content, when present, overrides prop-based separator rendering
+- prop-based separator supports text and icon modes
+- no separator is rendered after the final breadcrumb item
+
+### Breadcrumb Trail
+
+The complete normalized breadcrumb structure consumed by the component.
+
+**Fields**:
+- `items`: ordered breadcrumb items
+- `separator`: shared separator definition
+
+**Validation rules**:
+- supports mixed label-only, URL-backed, and route-backed items in the same ordered trail
+- preserves input order after normalization
+- remains renderable when the trail has zero or one item
+
+## Relationships
+
+| From | Relationship | To |
+|------|--------------|----|
+| `Breadcrumb Trail` | contains many | `Breadcrumb Item` |
+| `Breadcrumb Trail` | contains one | `Separator Definition` |
+| `Breadcrumb Item` | may contain one | `Route Target` |
+
+## State Transitions
+
+### Breadcrumb rendering flow
+
+```text
+Consumer input items
+-> normalize string items into breadcrumb objects
+-> determine item render mode (route, href, or static label)
+-> determine separator render mode (slot, icon prop, or text prop)
+-> render trail without a trailing separator
+```
+
+## Edge Rules
+
+| Case | Expected model behavior |
+|------|-------------------------|
+| String breadcrumb item | Normalizes to a label-only breadcrumb item |
+| Item with `icon` only | Renders as a readable static breadcrumb item with icon |
+| Item with `href` only | Renders as a standard link breadcrumb item |
+| Item with `route` only | Renders as a route-driven breadcrumb item |
+| Item with both `route` and `href` | Uses `route` as the active navigation target |
+| One-item trail | Renders the item with no separator |
+| Separator slot and prop both provided | Uses slot content for every separator position |

--- a/specs/010-breadcrumbs-router-icons/plan.md
+++ b/specs/010-breadcrumbs-router-icons/plan.md
@@ -1,0 +1,107 @@
+# Implementation Plan: NyxBreadcrumbs Routing and Visual Enhancements
+
+**Branch**: `010-breadcrumbs-router-icons` | **Date**: 2026-04-02 | **Spec**: `/home/arnedecant/Projects/nyxkit/nyx-kit/specs/010-breadcrumbs-router-icons/spec.md`
+**Input**: Feature specification from `/specs/010-breadcrumbs-router-icons/spec.md`
+
+## Summary
+
+Extend `NyxBreadcrumbs` so each breadcrumb item can optionally carry its own icon and route target, while preserving current string and `href`-based usage. Add one reusable separator customization surface that supports either plain text, an icon-by-name prop value, or a shared separator slot, and update the public breadcrumb type, Storybook coverage, tests, and the missing living docs spec for `NyxBreadcrumbs`.
+
+## Technical Context
+
+**Language/Version**: TypeScript with Vue 3.5+ single-file components  
+**Primary Dependencies**: Vue 3, `lucide-vue-next`, existing `NyxIcon`, existing `useNyxProps` pipeline  
+**Storage**: N/A  
+**Testing**: Vitest with `@vue/test-utils`, Storybook 10, Playwright only if browser-level routing behavior must be verified  
+**Target Platform**: Published Vue 3 component-library consumers, including apps that may use Vue Router  
+**Project Type**: Vue 3 component library (`nyx-kit`)  
+**Performance Goals**: No perceptible rendering regression for breadcrumb trails up to at least 20 items; separator and icon rendering remains linear to item count  
+**Constraints**: Must remain additive and backward-compatible; must not add a hard `vue-router` runtime dependency; must update docs before code; must preserve token-based styling and current string-item support  
+**Scale/Scope**: One existing component, one shared public breadcrumb type, one Storybook story file, one unit test file, and new `docs/specs/components/NyxBreadcrumbs.spec.md`
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Gate | Status | Notes |
+|------|--------|-------|
+| Docs before code | ✅ | Implementation must create and update `docs/specs/components/NyxBreadcrumbs.spec.md` before source changes because the living component spec is currently missing |
+| Public contract safety | ✅ | Change is additive: keep existing `href` and string-item support, add optional `icon` and `route` fields |
+| Minimal diff | ✅ | Feature is localized to `NyxBreadcrumbs`, shared breadcrumb type, docs, story, and tests |
+| Test-first for non-trivial logic | ✅ | Route precedence, icon rendering, and separator precedence require targeted Vitest coverage and Storybook variants |
+| Design token discipline | ✅ | No new style tokens are required; any styling must continue to use existing component and design-system tokens |
+| Consistency over local optimisation | ✅ | Slot naming stays `separator`, click event remains `click`, and icon naming follows existing `NyxIcon` conventions |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/010-breadcrumbs-router-icons/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── nyx-breadcrumbs.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+docs/
+├── architecture/
+│   └── component-model.md
+└── specs/
+    └── components/
+        └── NyxBreadcrumbs.spec.md
+
+src/
+├── components/
+│   └── NyxBreadcrumbs/
+│       ├── NyxBreadcrumbs.vue
+│       ├── NyxBreadcrumbs.types.ts
+│       ├── NyxBreadcrumbs.stories.ts
+│       ├── NyxBreadcrumbs.spec.ts
+│       └── NyxBreadcrumbs.scss
+└── types/
+    └── common.ts
+```
+
+**Structure Decision**: Keep the implementation entirely within the existing component and shared type locations. Add the missing living component spec under `docs/specs/components/`, update architecture docs only if the public breadcrumb contract needs cross-component documentation, and avoid introducing new modules or dependencies.
+
+## Phase 0: Research Summary
+
+1. Use a library-owned route target type on `NyxBreadcrumb` rather than importing router types directly into the public surface.
+2. Keep `route` additive and higher precedence than `href` when both are present.
+3. Expand `separator` into a minimal union that supports text or icon-by-name, while keeping the single `separator` slot as the highest-precedence customization point.
+4. Verify with docs updates, targeted Vitest coverage, and Storybook variants; skip Playwright unless the final implementation introduces browser-level routing behavior beyond render branching.
+
+## Phase 1: Design Summary
+
+1. Extend the breadcrumb item data model with optional `icon` and `route` fields while preserving string normalization.
+2. Define a breadcrumb rendering contract with three item modes: static label, URL link, and route-driven link.
+3. Define separator rendering precedence: slot first, then icon/text prop, with no trailing separator after the final item.
+4. Document the public consumer contract for the updated breadcrumb item shape and customization precedence.
+5. Plan docs-first implementation work: create `docs/specs/components/NyxBreadcrumbs.spec.md`, then update source, tests, and stories.
+
+## Post-Design Constitution Check
+
+| Gate | Status | Notes |
+|------|--------|-------|
+| Docs before code | ✅ | Design explicitly includes creating the missing living component spec before implementation |
+| Public contract safety | ✅ | Data model remains additive and preserves current item inputs |
+| Minimal diff | ✅ | No new package, entry point, or shared abstraction required |
+| Test-first for non-trivial logic | ✅ | Design artifacts identify concrete unit and story coverage for each branching path |
+| Design token discipline | ✅ | Design does not require cross-cutting style-token changes |
+| Consistency over local optimisation | ✅ | Uses existing slot and icon conventions instead of adding parallel APIs |
+
+## Complexity Tracking
+
+> **Fill ONLY if Constitution Check has violations that must be justified**
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| [e.g., 4th project] | [current need] | [why 3 projects insufficient] |
+| [e.g., Repository pattern] | [specific problem] | [why direct DB access insufficient] |

--- a/specs/010-breadcrumbs-router-icons/quickstart.md
+++ b/specs/010-breadcrumbs-router-icons/quickstart.md
@@ -1,0 +1,101 @@
+# Quickstart: NyxBreadcrumbs Routing and Visual Enhancements
+
+**Branch**: `010-breadcrumbs-router-icons` | **Date**: 2026-04-02
+
+## URL-backed breadcrumbs
+
+Use the component with simple text items or structured items that provide destination URLs.
+
+```vue
+<NyxBreadcrumbs
+  :items="[
+    { label: 'Home', href: '/' },
+    { label: 'Docs', href: '/docs' },
+    { label: 'Breadcrumbs' }
+  ]"
+/>
+```
+
+Expected behavior:
+- URL-backed items render as links
+- label-only items remain readable
+- the final item has no trailing separator
+
+## Route-aware breadcrumbs with per-item icons
+
+Use structured breadcrumb items to mix Vue Router navigation and URL-driven navigation, and attach icons only where needed.
+
+```vue
+<NyxBreadcrumbs
+  :items="[
+    { label: 'Home', icon: 'house', route: '/' },
+    { label: 'Library', icon: 'books', route: { name: 'library' } },
+    { label: 'Current page' }
+  ]"
+/>
+```
+
+Expected behavior:
+- only items with `icon` display an icon
+- route-backed items use Vue Router navigation
+- if an item provides both `route` and `href`, the route target wins
+- label-only items remain non-broken
+
+## Custom breadcrumb item slot
+
+Use the `item` slot when the full breadcrumb item content needs custom rendering.
+
+```vue
+<NyxBreadcrumbs :items="items">
+  <template #item="{ item }">
+    <span class="my-item">
+      <NyxIcon v-if="item.icon" :name="item.icon" />
+      {{ item.label.toUpperCase() }}
+    </span>
+  </template>
+</NyxBreadcrumbs>
+```
+
+Expected behavior:
+- the slot receives the normalized breadcrumb item
+- the item wrapper still follows `route` then `href` then static rendering rules
+- consumers control the inner item markup
+
+## Custom separator from prop
+
+Use one separator prop value for the full breadcrumb trail.
+
+```vue
+<NyxBreadcrumbs
+  :items="items"
+  :separator="{ icon: 'chevron-right' }"
+/>
+```
+
+Expected behavior:
+- the same icon separator appears between every adjacent breadcrumb pair
+- no separator appears after the final breadcrumb item
+
+## Custom separator slot
+
+Use one shared slot when the separator needs custom markup.
+
+```vue
+<NyxBreadcrumbs :items="items">
+  <template #separator>
+    <span class="my-separator">/</span>
+  </template>
+</NyxBreadcrumbs>
+```
+
+Expected behavior:
+- the same slot content is reused for every separator position
+- the slot overrides any separator prop value
+- the final breadcrumb item still renders without a trailing separator
+
+## Validation scenarios
+
+1. Render a mixed trail with string items, URL-backed items, and route-backed items and verify each item uses the expected navigation mode.
+2. Render a trail where only some items define `icon` and verify icons appear only for those items.
+3. Render the trail with a text separator prop, then with an icon separator prop, then with a separator slot and verify precedence and trailing-separator behavior.
+4. Trigger breadcrumb clicks and verify the component continues to emit the associated structured breadcrumb item.

--- a/specs/010-breadcrumbs-router-icons/research.md
+++ b/specs/010-breadcrumbs-router-icons/research.md
@@ -1,0 +1,45 @@
+# Research: NyxBreadcrumbs Routing and Visual Enhancements
+
+**Branch**: `010-breadcrumbs-router-icons` | **Date**: 2026-04-02
+
+## Decision 1: Own the route-target contract inside Nyx Kit
+
+**Decision**: Add an optional `route` field to the public breadcrumb item contract, but model it as a Nyx Kit-owned route target type rather than importing `vue-router` types directly into the library's public surface.
+
+**Rationale**: The library is published for general Vue consumers and currently does not include `vue-router` as a runtime dependency. A library-owned structural type preserves router support without forcing router packages or router type imports on every consumer.
+
+**Alternatives considered**:
+- Use `vue-router`'s route target type directly: rejected because it leaks router types into the published API and creates unnecessary package coupling.
+- Add `vue-router` as a peer dependency: rejected because it makes a simple breadcrumb enhancement heavier than necessary for non-router consumers.
+- Accept `unknown` or `any` for `route`: rejected because it weakens consumer guidance and testability.
+
+## Decision 2: Route target wins over href
+
+**Decision**: When both `route` and `href` are present on the same breadcrumb item, treat `route` as the active navigation target.
+
+**Rationale**: The feature request explicitly asks for rendering route-driven navigation when a route is specified. Making `route` higher precedence yields deterministic behavior and keeps the API additive instead of mutually exclusive.
+
+**Alternatives considered**:
+- Throw or warn when both values are provided: rejected because it adds friction to an otherwise straightforward precedence rule.
+- Prefer `href`: rejected because it conflicts with the requested router-first behavior.
+
+## Decision 3: Keep separator customization minimal and layered
+
+**Decision**: Keep one shared `separator` slot and expand the `separator` prop from text-only to a minimal union that supports either plain text or an icon-by-name object.
+
+**Rationale**: This preserves the current API for existing consumers, adds the requested icon case without inventing parallel props, and keeps the slot as the escape hatch for custom markup. The behavior remains easy to describe and test.
+
+**Alternatives considered**:
+- Add a second prop such as `separatorIcon`: rejected because it creates overlapping APIs and new precedence rules.
+- Support arbitrary component values in the prop: rejected because it complicates the public contract more than this feature needs.
+- Slot-only customization: rejected because the request explicitly asks for icon-name support through the prop as well.
+
+## Decision 4: Verification stays at docs, unit, and story level
+
+**Decision**: Verify this feature through docs-first updates, targeted Vitest coverage, and explicit Storybook examples. Only add Playwright coverage if implementation ends up depending on browser-level router behavior rather than simple render branching.
+
+**Rationale**: The change adds non-trivial rendering and event logic, which belongs in unit tests, while Storybook remains the visual API contract. Breadcrumb rendering does not otherwise justify E2E coverage by default.
+
+**Alternatives considered**:
+- Add Playwright by default: rejected because it would over-scope a largely render-level feature.
+- Rely on Storybook only: rejected because route precedence and emission behavior need automated assertions.

--- a/specs/010-breadcrumbs-router-icons/spec.md
+++ b/specs/010-breadcrumbs-router-icons/spec.md
@@ -1,0 +1,104 @@
+# Feature Specification: NyxBreadcrumbs Routing and Visual Enhancements
+
+**Feature Branch**: `010-breadcrumbs-router-icons`  
+**Created**: 2026-04-02  
+**Status**: Draft  
+**Input**: User description: "let's work on NyxBreadcrumbs component: allow each breadcrumb, individually, to have an icon; the separator should also be a slot (just one, reused) for custom separators; the separator prop should also allow icon name; the breadcrumb individually should support Vue Router; currently href is optional, keep it like that; add route, also optional, to pass vue router specifics; if route is specified, render a router link instead of an anchor"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Navigate with URL or app route targets (Priority: P1)
+
+As a consumer of the component library, I want each breadcrumb item to support either a standard destination URL or an in-app route target so that the same breadcrumb trail can work for both traditional navigation and route-driven applications.
+
+**Why this priority**: Navigation behavior is the core purpose of breadcrumbs, and route support changes the public contract of each breadcrumb item.
+
+**Independent Test**: Can be fully tested by rendering one breadcrumb trail with plain items, URL-backed items, and route-backed items and verifying each item uses the expected navigation behavior.
+
+**Acceptance Scenarios**:
+
+1. **Given** a breadcrumb item with a label and a destination URL, **When** the breadcrumb trail is rendered, **Then** that item is presented as a standard link using the provided URL.
+2. **Given** a breadcrumb item with a label and a route target, **When** the breadcrumb trail is rendered, **Then** that item is presented as route-driven navigation instead of a standard URL link.
+3. **Given** a breadcrumb item with both a destination URL and a route target, **When** the breadcrumb trail is rendered, **Then** the route target takes precedence and the item uses route-driven navigation.
+4. **Given** a breadcrumb item with only a label and no navigation target, **When** the breadcrumb trail is rendered, **Then** the item remains visible without behaving like a broken link.
+
+---
+
+### User Story 2 - Show icons on selected breadcrumb items (Priority: P2)
+
+As a consumer of the component library, I want to add an icon to individual breadcrumb items so that I can visually distinguish important locations such as home, dashboard, or special sections without forcing icons onto every item.
+
+**Why this priority**: Per-item icon support expands the breadcrumb data model and is a common design requirement, but it is secondary to navigation itself.
+
+**Independent Test**: Can be fully tested by rendering a breadcrumb trail where some items include icons and others do not, and verifying each item shows only the content configured for it.
+
+**Acceptance Scenarios**:
+
+1. **Given** a breadcrumb trail where some items define an icon and others do not, **When** the trail is rendered, **Then** only the configured items display an icon alongside their labels.
+2. **Given** a breadcrumb item with an icon and a label, **When** the trail is rendered, **Then** both remain understandable as a single breadcrumb item rather than separate navigation elements.
+
+---
+
+### User Story 3 - Reuse a custom separator across the trail (Priority: P3)
+
+As a consumer of the component library, I want one shared customization point for separators so that I can switch the separator to text, an icon, or custom content without redefining it for every gap in the trail.
+
+**Why this priority**: Separator customization improves visual flexibility, but it does not change the primary navigation flow.
+
+**Independent Test**: Can be fully tested by rendering the same breadcrumb trail three ways: with the default separator, with a separator defined by a prop, and with one shared custom separator slot.
+
+**Acceptance Scenarios**:
+
+1. **Given** a breadcrumb trail that defines a separator as text, **When** the trail is rendered, **Then** the same text separator appears between every adjacent breadcrumb pair.
+2. **Given** a breadcrumb trail that defines a separator as an icon identifier, **When** the trail is rendered, **Then** the same icon separator appears between every adjacent breadcrumb pair.
+3. **Given** a breadcrumb trail that provides custom separator slot content, **When** the trail is rendered, **Then** that same slot content is reused between every adjacent breadcrumb pair.
+4. **Given** custom separator slot content and a separator prop are both provided, **When** the trail is rendered, **Then** the slot content takes precedence for every separator position.
+
+### Edge Cases
+
+- When the breadcrumb trail contains zero or one item, no separator is shown.
+- When a breadcrumb item is defined as plain text rather than a structured object, it continues to render as a valid breadcrumb item without icon or navigation behavior.
+- When a breadcrumb item includes an icon but no navigation target, the item remains readable and non-broken.
+- When a separator prop references an invalid or unavailable icon name, the component falls back to a visible separator state rather than rendering an empty gap.
+- When mixed breadcrumb item types are used in the same trail, their order and labels remain unchanged.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST allow each breadcrumb item to include an optional icon in addition to its label.
+- **FR-002**: The system MUST continue to accept breadcrumb items defined as plain text values.
+- **FR-003**: The system MUST continue to support an optional destination URL for each breadcrumb item.
+- **FR-004**: The system MUST allow each breadcrumb item to define an optional route target for application navigation.
+- **FR-005**: The system MUST render a breadcrumb item using route-driven navigation whenever a route target is present.
+- **FR-006**: The system MUST treat the route target as the active navigation definition when both a route target and a destination URL are present on the same breadcrumb item.
+- **FR-007**: The system MUST render breadcrumb items without either navigation target as non-broken, readable items.
+- **FR-008**: The system MUST allow separator customization through a single reusable separator slot that is applied consistently between all adjacent breadcrumb items.
+- **FR-009**: The system MUST allow separator customization through a separator prop that supports either text content or an icon identifier.
+- **FR-010**: The system MUST apply the same separator presentation to every separator position within a single breadcrumb trail.
+- **FR-011**: The system MUST give the separator slot precedence over the separator prop when both are supplied.
+- **FR-012**: The system MUST avoid rendering a separator after the final breadcrumb item.
+- **FR-013**: The system MUST preserve existing breadcrumb click handling for structured breadcrumb items regardless of whether the item uses a destination URL or a route target.
+
+### Key Entities *(include if feature involves data)*
+
+- **Breadcrumb Item**: A single step in the breadcrumb trail with a required label and optional visual and navigation metadata, including an optional icon, optional destination URL, and optional route target.
+- **Separator Definition**: The shared presentation placed between breadcrumb items, supplied either as text, an icon identifier, or custom slot content.
+- **Breadcrumb Trail**: The ordered collection of breadcrumb items and the reusable separator behavior applied between adjacent items.
+
+### Assumptions
+
+- Existing string-based breadcrumb items remain supported for backward compatibility and are treated as label-only items.
+- Route-based navigation is an additive option and does not remove URL-based navigation support.
+- If both a route target and a destination URL are provided for the same item, the route target wins because the user explicitly requested router-first behavior.
+- Separator customization is global to the breadcrumb trail, not configurable per separator instance.
+- The separator slot is intended to be defined once and reused between all breadcrumb items in the same trail.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: In acceptance testing, a single breadcrumb trail can include at least five items containing any mix of label-only, URL-backed, and route-backed items, and each item displays the expected navigation behavior.
+- **SC-002**: In acceptance testing, 100% of breadcrumb items configured with an icon display both the icon and label, while 100% of items without an icon remain visually valid.
+- **SC-003**: Consumers can change separator presentation for an entire breadcrumb trail by defining exactly one separator prop value or exactly one separator slot, with no per-separator duplication required.
+- **SC-004**: In acceptance testing, 100% of separators in a trail use the same configured presentation, and 0 separators appear after the final breadcrumb item.

--- a/specs/010-breadcrumbs-router-icons/tasks.md
+++ b/specs/010-breadcrumbs-router-icons/tasks.md
@@ -1,0 +1,205 @@
+# Tasks: NyxBreadcrumbs Routing and Visual Enhancements
+
+**Input**: Design documents from `/specs/010-breadcrumbs-router-icons/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/, quickstart.md
+
+**Tests**: Include targeted Vitest coverage because the constitution and plan require tests for non-trivial component logic.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (`US1`, `US2`, `US3`)
+- Every task includes an exact file path
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Create the missing docs-first contract for `NyxBreadcrumbs` before implementation.
+
+- [X] T001 Create the living component spec for the updated breadcrumb API in `docs/specs/components/NyxBreadcrumbs.spec.md`
+- [X] T002 [P] Review and update shared component API guidance for breadcrumb routing and separator conventions in `docs/architecture/component-model.md`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Establish the shared public types and local prop contracts that all user stories depend on.
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete.
+
+- [X] T003 Extend the shared breadcrumb data contract with additive `icon` and library-owned `route` fields in `src/types/common.ts`
+- [X] T004 [P] Expand the local breadcrumb prop contract for route-aware items and text-or-icon separators in `src/components/NyxBreadcrumbs/NyxBreadcrumbs.types.ts`
+
+**Checkpoint**: Foundation ready - user story implementation can now begin.
+
+---
+
+## Phase 3: User Story 1 - Navigate with URL or app route targets (Priority: P1) 🎯 MVP
+
+**Goal**: Support breadcrumb items that render as URL links, route-driven links, or readable static labels while preserving existing click behavior.
+
+**Independent Test**: Render a breadcrumb trail with plain items, `href` items, and `route` items and verify each item uses the expected navigation mode, with `route` taking precedence over `href`.
+
+### Tests for User Story 1
+
+- [X] T005 [US1] Add navigation-mode, precedence, and non-link rendering coverage in `src/components/NyxBreadcrumbs/NyxBreadcrumbs.spec.ts`
+
+### Implementation for User Story 1
+
+- [X] T006 [US1] Implement breadcrumb item normalization and navigation-mode resolution in `src/components/NyxBreadcrumbs/NyxBreadcrumbs.vue`
+- [X] T007 [US1] Render route-driven, URL-driven, and static breadcrumb states while preserving `click` emissions in `src/components/NyxBreadcrumbs/NyxBreadcrumbs.vue`
+- [X] T008 [US1] Add mixed-navigation examples for route-backed and URL-backed items in `src/components/NyxBreadcrumbs/NyxBreadcrumbs.stories.ts`
+
+**Checkpoint**: User Story 1 is fully functional and independently testable.
+
+---
+
+## Phase 4: User Story 2 - Show icons on selected breadcrumb items (Priority: P2)
+
+**Goal**: Allow individual breadcrumb items to show an icon without forcing icons onto every breadcrumb item.
+
+**Independent Test**: Render a breadcrumb trail where only some items define `icon` and verify those items show both icon and label while unconfigured items remain unchanged.
+
+### Tests for User Story 2
+
+- [X] T009 [US2] Add per-item icon rendering coverage for mixed breadcrumb items in `src/components/NyxBreadcrumbs/NyxBreadcrumbs.spec.ts`
+
+### Implementation for User Story 2
+
+- [X] T010 [US2] Render optional per-item breadcrumb icons using existing icon conventions in `src/components/NyxBreadcrumbs/NyxBreadcrumbs.vue`
+- [X] T011 [US2] Add per-item icon examples for breadcrumb consumers in `src/components/NyxBreadcrumbs/NyxBreadcrumbs.stories.ts`
+
+**Checkpoint**: User Stories 1 and 2 both work independently.
+
+---
+
+## Phase 5: User Story 3 - Reuse a custom separator across the trail (Priority: P3)
+
+**Goal**: Support one shared separator customization surface that handles text, icon-by-name, or custom slot content across the full breadcrumb trail.
+
+**Independent Test**: Render the breadcrumb trail with a text separator prop, an icon separator prop, and a `separator` slot and verify reuse, precedence, and absence of a trailing separator.
+
+### Tests for User Story 3
+
+- [X] T012 [US3] Add separator text, icon, slot-precedence, and trailing-separator coverage in `src/components/NyxBreadcrumbs/NyxBreadcrumbs.spec.ts`
+
+### Implementation for User Story 3
+
+- [X] T013 [US3] Implement shared separator rendering precedence for prop and slot customization in `src/components/NyxBreadcrumbs/NyxBreadcrumbs.vue`
+- [X] T014 [US3] Adjust separator layout and icon spacing for text, icon, and custom slot states in `src/components/NyxBreadcrumbs/NyxBreadcrumbs.scss`
+- [X] T015 [US3] Add text-separator, icon-separator, and custom-slot examples in `src/components/NyxBreadcrumbs/NyxBreadcrumbs.stories.ts`
+
+**Checkpoint**: All user stories are independently functional.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final sync, validation, and consumer-facing cleanup across all stories.
+
+- [X] T016 [P] Sync final props, slots, emits, accessibility notes, and known limitations in `docs/specs/components/NyxBreadcrumbs.spec.md`
+- [X] T017 [P] Align consumer examples and acceptance scenarios with the implemented API in `specs/010-breadcrumbs-router-icons/quickstart.md`
+- [X] T018 Run final breadcrumb regression verification across `src/components/NyxBreadcrumbs/NyxBreadcrumbs.spec.ts` and `src/components/NyxBreadcrumbs/NyxBreadcrumbs.stories.ts`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1: Setup**: No dependencies - starts immediately
+- **Phase 2: Foundational**: Depends on Phase 1 completion - blocks all user stories
+- **Phase 3: User Story 1**: Depends on Phase 2 completion
+- **Phase 4: User Story 2**: Depends on Phase 2 completion and can be delivered after US1 or in parallel once the shared foundation is stable
+- **Phase 5: User Story 3**: Depends on Phase 2 completion and can be delivered after US1 or in parallel once the shared foundation is stable
+- **Phase 6: Polish**: Depends on all desired user stories being complete
+
+### User Story Dependencies
+
+- **US1 (P1)**: No dependency on other user stories
+- **US2 (P2)**: Depends on the shared breadcrumb contract from Phase 2 but not on US1 behavior beyond the same component file
+- **US3 (P3)**: Depends on the shared prop contract from Phase 2 but not on US1 or US2 behavior beyond the same component file
+
+### Within Each User Story
+
+- Add or expand tests before completing implementation in the same story
+- Update the component logic before story examples that rely on the new API
+- Finish each story at its checkpoint before moving to cross-cutting polish
+
+### Dependency Graph
+
+```text
+Phase 1 Setup
+  -> Phase 2 Foundational
+     -> US1 (MVP)
+     -> US2
+     -> US3
+        -> Phase 6 Polish
+```
+
+### Parallel Opportunities
+
+- `T001` and `T002` can run in parallel because they touch different docs files
+- `T003` and `T004` can run in parallel because they touch different type-definition files
+- After implementation stabilizes, `T016` and `T017` can run in parallel because they touch different spec artifacts
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+# After Phase 2 completes, examples and route contract review can be split:
+Task: "Implement breadcrumb item normalization and navigation-mode resolution in src/components/NyxBreadcrumbs/NyxBreadcrumbs.vue"
+Task: "Add mixed-navigation examples for route-backed and URL-backed items in src/components/NyxBreadcrumbs/NyxBreadcrumbs.stories.ts"
+```
+
+## Parallel Example: User Story 2
+
+```bash
+# Once per-item icon rendering is implemented, visual docs can proceed separately:
+Task: "Render optional per-item breadcrumb icons using existing icon conventions in src/components/NyxBreadcrumbs/NyxBreadcrumbs.vue"
+Task: "Add per-item icon examples for breadcrumb consumers in src/components/NyxBreadcrumbs/NyxBreadcrumbs.stories.ts"
+```
+
+## Parallel Example: User Story 3
+
+```bash
+# After separator behavior is settled, styles and examples can be finished independently:
+Task: "Adjust separator layout and icon spacing for text, icon, and custom slot states in src/components/NyxBreadcrumbs/NyxBreadcrumbs.scss"
+Task: "Add text-separator, icon-separator, and custom-slot examples in src/components/NyxBreadcrumbs/NyxBreadcrumbs.stories.ts"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup
+2. Complete Phase 2: Foundational
+3. Complete Phase 3: User Story 1
+4. Validate mixed `href` and `route` breadcrumb rendering independently
+5. Stop for review before icons and separator customization
+
+### Incremental Delivery
+
+1. Finish docs and shared contract groundwork
+2. Deliver US1 for mixed navigation support
+3. Deliver US2 for optional per-item icons
+4. Deliver US3 for reusable separator customization
+5. Finish with spec and quickstart sync
+
+### Suggested MVP Scope
+
+- Phase 1
+- Phase 2
+- Phase 3 (User Story 1)
+
+---
+
+## Notes
+
+- All tasks use the required checklist format with task ID, optional parallel marker, optional story label, and exact file path
+- Tasks are intentionally small and file-scoped to support minimal diffs in a shared workspace
+- `src/components/NyxBreadcrumbs/NyxBreadcrumbs.vue` is shared across all three user stories, so story phases should be implemented sequentially in one branch unless explicitly split across collaborators

--- a/src/components/NyxBreadcrumbs/NyxBreadcrumbItem.vue
+++ b/src/components/NyxBreadcrumbs/NyxBreadcrumbItem.vue
@@ -1,0 +1,23 @@
+<script setup lang="ts">
+import { NyxSize, type NyxBreadcrumb } from '@/types'
+import NyxIcon from '../NyxIcon/NyxIcon.vue'
+
+const props = defineProps<{
+  item: NyxBreadcrumb
+  size?: NyxSize
+}>()
+</script>
+
+<template>
+  <span class="nyx-breadcrumbs__item-content">
+    <NyxIcon
+      v-if="props.item.icon"
+      class="nyx-breadcrumbs__icon"
+      :name="props.item.icon"
+      :size="props.size ?? NyxSize.Medium"
+      :stroke="NyxSize.Small"
+      aria-hidden="true"
+    />
+    <span class="nyx-breadcrumbs__label">{{ props.item.label }}</span>
+  </span>
+</template>

--- a/src/components/NyxBreadcrumbs/NyxBreadcrumbs.scss
+++ b/src/components/NyxBreadcrumbs/NyxBreadcrumbs.scss
@@ -3,6 +3,7 @@
   --nyx-c-breadcrumbs-separator: var(--nyx-c-default);
   --nyx-font-size-breadcrumbs: var(--nyx-font-size-md);
   --nyx-pad-breadcrumbs: var(--nyx-pad-md);
+  --nyx-gap-breadcrumbs: var(--nyx-gap-md);
 
   color: var(--nyx-c-breadcrumbs-text);
   font-size: var(--nyx-font-size-breadcrumbs);
@@ -16,19 +17,38 @@
     fill: var(--nyx-c-breadcrumbs-separator);
     user-select: none;
     opacity: 0.5;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    margin-inline: calc(var(--nyx-pad-breadcrumbs) * 0.25);
   }
 
-  a {
+  &__item {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--nyx-gap-breadcrumbs);
     padding: calc(var(--nyx-pad-breadcrumbs) * 0.5) var(--nyx-pad-breadcrumbs);
     transition: opacity 0.2s;
+    color: inherit;
+    text-decoration: none;
+  }
 
-    &:not([href]) {
-      pointer-events: none;
-    }
+  &__item-content {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--nyx-gap-breadcrumbs);
+  }
 
-    &:hover {
-      opacity: 0.8;
-    }
+  &__icon {
+    color: inherit;
+  }
+
+  &__item--link:hover {
+    opacity: 0.8;
+  }
+
+  &__item--static {
+    cursor: default;
   }
 
   &.variant-filled {

--- a/src/components/NyxBreadcrumbs/NyxBreadcrumbs.spec.ts
+++ b/src/components/NyxBreadcrumbs/NyxBreadcrumbs.spec.ts
@@ -1,6 +1,36 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { mount } from '@vue/test-utils'
+import { defineComponent } from 'vue'
 import NyxBreadcrumbs from './NyxBreadcrumbs.vue'
+import type { RouteLocationRaw } from 'vue-router'
+
+const RouterLinkStub = defineComponent({
+  name: 'RouterLink',
+  props: {
+    to: {
+      type: [String, Object],
+      required: true,
+    },
+  },
+  template: '<a class="router-link-stub" :data-to="JSON.stringify(to)"><slot /></a>',
+})
+
+function mountBreadcrumbs (options: Parameters<typeof mount<typeof NyxBreadcrumbs>>[1] = {}) {
+  return mount(NyxBreadcrumbs, {
+    ...options,
+    global: {
+      ...(options.global ?? {}),
+      stubs: {
+        NyxIcon: {
+          props: ['name'],
+          template: '<i class="nyx-icon-stub" :data-name="name" />',
+        },
+        RouterLink: RouterLinkStub,
+        ...(options.global?.stubs ?? {}),
+      },
+    },
+  })
+}
 
 beforeEach(() => {
   vi.spyOn(console, 'warn').mockImplementation(() => {})
@@ -8,66 +38,150 @@ beforeEach(() => {
 
 describe('NyxBreadcrumbs', () => {
   it('renders without errors', () => {
-    const wrapper = mount(NyxBreadcrumbs, { props: { items: ['Home', 'About'] } })
+    const wrapper = mountBreadcrumbs({ props: { items: ['Home', 'About'] } })
     expect(wrapper.find('.nyx-breadcrumbs').exists()).toBe(true)
   })
 
-  it('renders a link for each item', () => {
-    const wrapper = mount(NyxBreadcrumbs, { props: { items: ['Home', 'Products', 'Detail'] } })
-    expect(wrapper.findAll('a').length).toBe(3)
+  it('renders string items as readable static breadcrumb items', () => {
+    const wrapper = mountBreadcrumbs({ props: { items: ['Home', 'About'] } })
+    const items = wrapper.findAll('.nyx-breadcrumbs__item')
+
+    expect(items).toHaveLength(2)
+    expect(items[0].text()).toBe('Home')
+    expect(items[1].text()).toBe('About')
+    expect(wrapper.findAll('a')).toHaveLength(0)
   })
 
-  it('renders string items as link labels', () => {
-    const wrapper = mount(NyxBreadcrumbs, { props: { items: ['Home', 'About'] } })
-    const links = wrapper.findAll('a')
-    expect(links[0].text()).toBe('Home')
-    expect(links[1].text()).toBe('About')
-  })
-
-  it('renders object items with label and href', () => {
-    const wrapper = mount(NyxBreadcrumbs, {
+  it('renders object items with label and href as anchors', () => {
+    const wrapper = mountBreadcrumbs({
       props: { items: [{ label: 'Home', href: '/' }, { label: 'About', href: '/about' }] }
     })
     const links = wrapper.findAll('a')
-    expect(links[0].text()).toBe('Home')
+
+    expect(links).toHaveLength(2)
+    expect(links[0].text()).toContain('Home')
     expect(links[0].attributes('href')).toBe('/')
     expect(links[1].attributes('href')).toBe('/about')
   })
 
-  it('renders separators between items', () => {
-    const wrapper = mount(NyxBreadcrumbs, { props: { items: ['Home', 'About', 'Contact'] } })
-    expect(wrapper.findAll('.nyx-breadcrumbs__separator').length).toBe(2)
+  it('renders route items as router links', () => {
+    const route: RouteLocationRaw = { name: 'library', query: { tab: 'all' } }
+    const wrapper = mountBreadcrumbs({
+      props: { items: [{ label: 'Library', route }] }
+    })
+    const link = wrapper.find('.router-link-stub')
+
+    expect(link.exists()).toBe(true)
+    expect(link.text()).toContain('Library')
+    expect(link.attributes('data-to')).toBe(JSON.stringify(route))
   })
 
-  it('does not render separator after last item', () => {
-    const wrapper = mount(NyxBreadcrumbs, { props: { items: ['Home', 'About'] } })
-    const separators = wrapper.findAll('.nyx-breadcrumbs__separator')
-    expect(separators.length).toBe(1)
+  it('prefers route over href when both are provided', () => {
+    const wrapper = mountBreadcrumbs({
+      props: { items: [{ label: 'Library', href: '/library', route: '/app/library' }] }
+    })
+
+    expect(wrapper.find('.router-link-stub').exists()).toBe(true)
+    expect(wrapper.find('.router-link-stub').attributes('href')).toBeUndefined()
   })
 
-  it('uses custom separator prop', () => {
-    const wrapper = mount(NyxBreadcrumbs, { props: { items: ['Home', 'About'], separator: '>' } })
+  it('renders breadcrumb items without navigation targets as non-links', () => {
+    const wrapper = mountBreadcrumbs({
+      props: { items: [{ label: 'Current page' }] }
+    })
+
+    expect(wrapper.find('.nyx-breadcrumbs__item--static').exists()).toBe(true)
+    expect(wrapper.find('a').exists()).toBe(false)
+  })
+
+  it('renders separators between items and not after the last item', () => {
+    const wrapper = mountBreadcrumbs({ props: { items: ['Home', 'About', 'Contact'] } })
+    expect(wrapper.findAll('.nyx-breadcrumbs__separator')).toHaveLength(2)
+  })
+
+  it('uses a text separator prop', () => {
+    const wrapper = mountBreadcrumbs({ props: { items: ['Home', 'About'], separator: '>' } })
     expect(wrapper.find('.nyx-breadcrumbs__separator').text()).toBe('>')
   })
 
-  it('renders separator slot content', () => {
-    const wrapper = mount(NyxBreadcrumbs, {
-      props: { items: ['Home', 'About'] },
-      slots: { separator: '<span class="custom-sep">→</span>' }
+  it('renders an icon separator from the separator prop', () => {
+    const wrapper = mountBreadcrumbs({
+      props: { items: ['Home', 'About'], separator: { icon: 'chevron-right' } }
     })
-    expect(wrapper.find('.custom-sep').exists()).toBe(true)
+
+    expect(wrapper.find('.nyx-breadcrumbs__separator .nyx-icon-stub').attributes('data-name')).toBe('chevron-right')
   })
 
-  it('emits click with item data when a link is clicked', async () => {
-    const item = { label: 'About', href: '/about' }
-    const wrapper = mount(NyxBreadcrumbs, { props: { items: [item] } })
+  it('renders separator slot content for every separator position', () => {
+    const wrapper = mountBreadcrumbs({
+      props: { items: ['Home', 'About', 'Contact'] },
+      slots: { separator: '<span class="custom-sep">→</span>' }
+    })
+
+    expect(wrapper.findAll('.custom-sep')).toHaveLength(2)
+  })
+
+  it('gives the separator slot precedence over the separator prop', () => {
+    const wrapper = mountBreadcrumbs({
+      props: { items: ['Home', 'About'], separator: { icon: 'chevron-right' } },
+      slots: { separator: '<span class="custom-sep">/</span>' }
+    })
+
+    expect(wrapper.find('.custom-sep').exists()).toBe(true)
+    expect(wrapper.find('.nyx-breadcrumbs__separator .nyx-icon-stub').exists()).toBe(false)
+  })
+
+  it('renders icons only for breadcrumb items that define them', () => {
+    const wrapper = mountBreadcrumbs({
+      props: {
+        items: [
+          { label: 'Home', icon: 'house', href: '/' },
+          { label: 'Library', href: '/library' },
+          { label: 'Current', icon: 'folder' },
+        ]
+      }
+    })
+
+    const icons = wrapper.findAll('.nyx-breadcrumbs__item .nyx-icon-stub')
+    expect(icons).toHaveLength(2)
+    expect(icons[0].attributes('data-name')).toBe('house')
+    expect(icons[1].attributes('data-name')).toBe('folder')
+  })
+
+  it('allows consumers to replace item content through the item slot', () => {
+    const wrapper = mountBreadcrumbs({
+      props: { items: [{ label: 'Home', icon: 'house', href: '/' }] },
+      slots: {
+        item: '<template #item="{ item }"><span class="custom-item">{{ item.label.toUpperCase() }}</span></template>',
+      },
+    })
+
+    expect(wrapper.find('.custom-item').text()).toBe('HOME')
+    expect(wrapper.find('.nyx-icon-stub').exists()).toBe(false)
+  })
+
+  it('emits click with item data when an anchor breadcrumb is clicked', async () => {
+    const item = { label: 'About', href: '#' }
+    const wrapper = mountBreadcrumbs({ props: { items: [item] } })
+
     await wrapper.find('a').trigger('click')
+
     expect(wrapper.emitted('click')).toBeTruthy()
     expect(wrapper.emitted('click')![0][0]).toEqual(item)
   })
 
-  it('renders as a <nav> element', () => {
-    const wrapper = mount(NyxBreadcrumbs, { props: { items: ['Home'] } })
+  it('emits click with item data when a route breadcrumb is clicked', async () => {
+    const item = { label: 'Dashboard', route: '/dashboard' }
+    const wrapper = mountBreadcrumbs({ props: { items: [item] } })
+
+    await wrapper.find('.router-link-stub').trigger('click')
+
+    expect(wrapper.emitted('click')).toBeTruthy()
+    expect(wrapper.emitted('click')![0][0]).toEqual(item)
+  })
+
+  it('renders as a nav element', () => {
+    const wrapper = mountBreadcrumbs({ props: { items: ['Home'] } })
     expect(wrapper.element.tagName).toBe('NAV')
   })
 })

--- a/src/components/NyxBreadcrumbs/NyxBreadcrumbs.stories.ts
+++ b/src/components/NyxBreadcrumbs/NyxBreadcrumbs.stories.ts
@@ -1,12 +1,22 @@
 import { defineComponent } from 'vue'
+import type { Meta, StoryObj } from '@storybook/vue3'
 import NyxBreadcrumbs from './NyxBreadcrumbs.vue'
 import { NyxTheme, NyxSize, type NyxBreadcrumb, NyxVariant } from '@/types'
 import type { NyxBreadcrumbsProps } from './NyxBreadcrumbs.types'
 
 const breadcrumbsStrings: string[] = ['lorem', 'ipsum', 'dolor', 'sit', 'amet']
 const breadcrumbs: NyxBreadcrumb[] = breadcrumbsStrings.map((b) => ({ label: b, href: '#' }))
-
-export default {
+const breadcrumbIcons: NyxBreadcrumb[] = [
+  { label: 'Home', icon: 'house', href: '/' },
+  { label: 'Library', icon: 'folder-open', href: '/library' },
+  { label: 'Breadcrumbs', icon: 'file-text' },
+]
+const breadcrumbRoutes: NyxBreadcrumb[] = [
+  { label: 'Home', icon: 'house', route: '/' },
+  { label: 'Library', route: { name: 'library', query: { filter: 'all' } } },
+  { label: 'Breadcrumbs', href: '/docs/breadcrumbs' },
+]
+const meta = {
   title: 'Components/NyxBreadcrumbs',
   component: NyxBreadcrumbs,
   argTypes: {
@@ -22,21 +32,86 @@ export default {
       control: { type: 'select' },
       options: Object.values(NyxVariant),
     },
-    onClick: { action: 'click' },
   },
   args: {
-    items: breadcrumbs
-  }
+    items: breadcrumbs,
+  },
+} satisfies Meta<typeof NyxBreadcrumbs>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+function renderBreadcrumbs (template = '<nyx-breadcrumbs v-bind="args" />') {
+  return (args: NyxBreadcrumbsProps) => defineComponent({
+    components: { NyxBreadcrumbs },
+    setup () {
+      return { args }
+    },
+    template,
+  })
 }
 
-const Template = (args: NyxBreadcrumbsProps) => defineComponent({
-  components: { NyxBreadcrumbs },
-  setup () {
-    return { args }
+export const Default: Story = {
+  render: renderBreadcrumbs(),
+  args: {
+    items: breadcrumbs,
   },
-  template: `
-    <nyx-breadcrumbs v-bind="args" @click="onClick">Button</nyx-breadcrumbs>
-  `,
-})
+}
 
-export const Default = Template({ items: breadcrumbs })
+export const WithIcons: Story = {
+  render: renderBreadcrumbs(),
+  args: {
+    items: breadcrumbIcons,
+  },
+}
+
+export const WithRouteItems: Story = {
+  render: renderBreadcrumbs(),
+  args: {
+    items: breadcrumbRoutes,
+  },
+}
+
+export const WithIconSeparator: Story = {
+  render: () => defineComponent({
+    components: { NyxBreadcrumbs },
+    setup () {
+      const args: NyxBreadcrumbsProps = {
+        items: breadcrumbIcons,
+        separator: { icon: 'chevron-right' },
+      }
+
+      return { args }
+    },
+    template: '<nyx-breadcrumbs v-bind="args" />',
+  }),
+}
+
+export const WithCustomSeparator: Story = {
+  render: renderBreadcrumbs(`
+    <nyx-breadcrumbs v-bind="args">
+      <template #separator>
+        <span class="custom-separator">|</span>
+      </template>
+    </nyx-breadcrumbs>
+  `),
+  args: {
+    items: breadcrumbIcons,
+  },
+}
+
+export const WithCustomItemSlot: Story = {
+  render: renderBreadcrumbs(`
+    <nyx-breadcrumbs v-bind="args">
+      <template #item="{ item }">
+        <span style="display:inline-flex;align-items:center;gap:0.4rem;text-transform:uppercase;letter-spacing:0.08em;">
+          <strong>{{ item.label }}</strong>
+        </span>
+      </template>
+    </nyx-breadcrumbs>
+  `),
+  args: {
+    items: breadcrumbIcons,
+  },
+}

--- a/src/components/NyxBreadcrumbs/NyxBreadcrumbs.types.ts
+++ b/src/components/NyxBreadcrumbs/NyxBreadcrumbs.types.ts
@@ -1,8 +1,14 @@
 import type { NyxBreadcrumb, NyxSize, NyxTheme, NyxVariant } from '@/types'
 
+export interface NyxBreadcrumbsIconSeparator {
+  icon: string
+}
+
+export type NyxBreadcrumbsSeparator = string | NyxBreadcrumbsIconSeparator
+
 export interface NyxBreadcrumbsProps {
   items: string[]|NyxBreadcrumb[]
-  separator?: string
+  separator?: NyxBreadcrumbsSeparator
   theme?: NyxTheme
   size?: NyxSize
   variant?: NyxVariant.Filled|NyxVariant.Text

--- a/src/components/NyxBreadcrumbs/NyxBreadcrumbs.vue
+++ b/src/components/NyxBreadcrumbs/NyxBreadcrumbs.vue
@@ -1,8 +1,16 @@
 <script setup lang="ts">
 import './NyxBreadcrumbs.scss'
 import { computed } from 'vue'
+import { RouterLink } from 'vue-router'
 import { type NyxBreadcrumb } from '@/types'
-import type { NyxBreadcrumbsEmits, NyxBreadcrumbsProps } from './NyxBreadcrumbs.types'
+import NyxIcon from '../NyxIcon/NyxIcon.vue'
+import NyxBreadcrumbItem from './NyxBreadcrumbItem.vue'
+import type {
+  NyxBreadcrumbsEmits,
+  NyxBreadcrumbsIconSeparator,
+  NyxBreadcrumbsProps,
+  NyxBreadcrumbsSeparator,
+} from './NyxBreadcrumbs.types'
 import { useNyxProps } from '@/composables'
 
 const props = withDefaults(defineProps<NyxBreadcrumbsProps>(), {
@@ -10,6 +18,10 @@ const props = withDefaults(defineProps<NyxBreadcrumbsProps>(), {
 })
 
 const emit = defineEmits<NyxBreadcrumbsEmits>()
+defineSlots<{
+  item?: (props: { item: NyxBreadcrumb }) => unknown
+  separator?: () => unknown
+}>()
 
 const { classList } = useNyxProps(props, { origin: 'NyxBreadcrumbs' })
 
@@ -17,6 +29,26 @@ const normalizedItems = computed<NyxBreadcrumb[]>(() => {
   return props.items
     .map((item: string|NyxBreadcrumb) => (typeof item === 'string') ? { label: item } : item)
 })
+
+const isSeparatorIcon = computed(() => isIconSeparator(props.separator))
+const separatorIconName = computed(() => getSeparatorIconName(props.separator))
+
+function isIconSeparator (separator: NyxBreadcrumbsSeparator): separator is NyxBreadcrumbsIconSeparator {
+  return typeof separator === 'object' && separator !== null && typeof separator.icon === 'string'
+}
+
+function getSeparatorIconName (separator: NyxBreadcrumbsSeparator): string | undefined {
+  return isIconSeparator(separator) ? separator.icon : undefined
+}
+
+function isLinkItem (item: NyxBreadcrumb): boolean {
+  return Boolean(item.route || item.href)
+}
+
+function handleItemClick (item: NyxBreadcrumb): void {
+  if (!isLinkItem(item)) return
+  emit('click', item)
+}
 
 
 </script>
@@ -27,12 +59,46 @@ const normalizedItems = computed<NyxBreadcrumb[]>(() => {
     :class="classList"
   >
     <template v-for="(item, index) in normalizedItems" :key="index">
+      <RouterLink
+        v-if="item.route"
+        :to="item.route"
+        class="nyx-breadcrumbs__item nyx-breadcrumbs__item--link"
+        @click="handleItemClick(item)"
+      >
+        <slot name="item" :item="item">
+          <NyxBreadcrumbItem :item="item" :size="props.size" />
+        </slot>
+      </RouterLink>
+
       <a
+        v-else-if="item.href"
         :href="item.href"
-        @click="() => emit('click', item)"
-      >{{ item.label }}</a>
-      <span class="nyx-breadcrumbs__separator" v-if="index < normalizedItems.length - 1">
-        <slot name="separator">{{ props.separator }}</slot>
+        class="nyx-breadcrumbs__item nyx-breadcrumbs__item--link"
+        @click="handleItemClick(item)"
+      >
+        <slot name="item" :item="item">
+          <NyxBreadcrumbItem :item="item" :size="props.size" />
+        </slot>
+      </a>
+
+      <span
+        v-else
+        class="nyx-breadcrumbs__item nyx-breadcrumbs__item--static"
+      >
+        <slot name="item" :item="item">
+          <NyxBreadcrumbItem :item="item" :size="props.size" />
+        </slot>
+      </span>
+
+      <span class="nyx-breadcrumbs__separator" v-if="index < normalizedItems.length - 1" aria-hidden="true">
+        <slot name="separator">
+          <NyxIcon
+            v-if="isSeparatorIcon"
+            :name="separatorIconName!"
+            :size="props.size"
+          />
+          <template v-else>{{ props.separator }}</template>
+        </slot>
       </span>
     </template>
   </nav>

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -1,3 +1,5 @@
+import type { RouteLocationRaw } from 'vue-router'
+
 export type KeyDict<T> = { [key: string]: T }
 
 export interface NyxComponentProps {
@@ -49,6 +51,8 @@ export enum NyxMediaType {
 
 export interface NyxBreadcrumb {
   label: string,
+  icon?: string,
+  route?: RouteLocationRaw,
   href?: string
 }
 
@@ -83,4 +87,3 @@ export enum NyxGridMode {
   Grid = 'grid',
   Masonry = 'masonry',
 }
-


### PR DESCRIPTION
## Summary
- add Vue Router-backed breadcrumb navigation using `RouteLocationRaw`, `RouterLink`, and a Storybook memory-router setup
- refactor breadcrumb item rendering through an internal `NyxBreadcrumbItem` component and add a scoped `item` slot for full item-content replacement
- extend separator customization, stories, tests, and living docs/spec artifacts for the updated breadcrumb contract

## Validation
- pnpm vitest \"src/components/NyxBreadcrumbs/NyxBreadcrumbs.spec.ts\" --run
- pnpm type-check
- pnpm storybook:build