### PR TITLE
fix(NyxSelect): sync external model updates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,7 @@ The project constitution is at `.specify/memory/constitution.md`.
 - TypeScript 5.x + Vue 3.5 + Vue 3, `@tiptap/vue-3`, Tiptap `StarterKit`, `tiptap-markdown`, existing internal NyxEditor sub-components/composables (008-editor-footer-info)
 - TypeScript + Vue 3.5+ + `lucide-vue-next` (already installed), Vue 3 (009-add-lucide-icon)
 - TypeScript with Vue 3.5+ single-file components + Vue 3, `lucide-vue-next`, existing `NyxIcon`, existing `useNyxProps` pipeline (010-breadcrumbs-router-icons)
+- TypeScript with Vue 3.5+ single-file components + Vue 3, existing `defineModel` usage, `useNyxProps`, `useTeleportPosition`, `useSelectKeyboardControls`, `v-click-outside` (011-fix-select-model-sync)
 
 ## Recent Changes
 - 003-testing-improvements: Added TypeScript 5.x / Vue 3 + `@vue/test-utils`, `vitest`, `@playwright/test`, `jsdom`

--- a/docs/specs/components/NyxSelect.spec.md
+++ b/docs/specs/components/NyxSelect.spec.md
@@ -22,6 +22,7 @@ NyxSelect is a custom select control that replaces the native `<select>` element
 - `isGrouped` detects at runtime whether `options` is `NyxSelectOption[]` or `NyxSelectOptionGroup[]` by checking for an `options` key on the first element
 - `flatOptions` flattens grouped options for value-to-label lookups (used in `selectedLabels` and `isSelected`)
 - `filteredOptions` returns the same shape as the input (`NyxSelectOption[]` or `NyxSelectOptionGroup[]`), filtering by `searchQuery` and pruning empty groups
+- The externally bound `v-model` value remains the source of truth for both the closed-control text and the selected option state shown in the dropdown
 - Group labels are rendered as non-interactive `<li class="nyx-select__group-label">` — they cannot be selected and have `pointer-events: none`
 - `v-click-outside` directive closes the dropdown when clicking outside
 - `useTeleportPosition` determines whether the dropdown opens below (`bottom`) or above (`top`) the control
@@ -53,6 +54,11 @@ None — selection is communicated exclusively through `v-model`.
 ## v-model
 
 Binds to `string` (single mode) or `string[]` (multiple mode). The value corresponds to `NyxSelectOption.value`.
+
+When the bound value changes externally after mount, `NyxSelect` must immediately update:
+- the text shown in the closed control
+- the selected option state shown in the dropdown
+- the unselected display state when the bound value is cleared
 
 ## Types
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "nyx-kit",
   "homepage": "http://nyxkit.github.io/nyx-kit",
   "author": "Arne Decant <hello@arnedecant.be>",
-  "version": "2.0.15",
+  "version": "2.0.16",
   "packageManager": "pnpm@10.18.3",
   "private": false,
   "license": "MIT",

--- a/specs/011-fix-select-model-sync/checklists/requirements.md
+++ b/specs/011-fix-select-model-sync/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: NyxSelect External Model Sync
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning  
+**Created**: 2026-04-02  
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Validation completed against `specs/011-fix-select-model-sync/spec.md`.
+- No clarification markers were needed because the bug report defines a narrow, testable synchronization issue.
+- The spec explicitly covers both single-select and multi-select behavior to prevent a partial fix.

--- a/specs/011-fix-select-model-sync/contracts/nyx-select.md
+++ b/specs/011-fix-select-model-sync/contracts/nyx-select.md
@@ -1,0 +1,38 @@
+# Contract: NyxSelect External Model Synchronization
+
+**Branch**: `011-fix-select-model-sync` | **Date**: 2026-04-02
+
+## Purpose
+
+Define the user-facing behavior of `NyxSelect` when its bound value changes from outside the component.
+
+## Controlled Value Contract
+
+1. `NyxSelect` remains controlled through `v-model`.
+2. In single-select mode, the bound value identifies one selected option.
+3. In multi-select mode, the bound value identifies zero or more selected options.
+4. Parent-driven changes to the bound value must be reflected immediately in the component’s visible state.
+
+## Display Contract
+
+When the bound value changes externally, `NyxSelect` must update:
+- the text shown in the closed control
+- the selected state shown in the dropdown list
+- the shown label set in multi-select mode without waiting for the dropdown to close
+
+This behavior applies to:
+- single-select mode
+- multi-select mode
+- flat option lists
+- grouped option lists
+
+## Reset Contract
+
+1. Clearing the external value returns the control to the unselected display state.
+2. Values that no longer match available options must not leave stale labels visible.
+3. The same reset behavior applies whether the dropdown is currently open or closed.
+
+## Compatibility Notes
+
+- No public API changes are required for this fix.
+- Existing placeholder, search, and empty-state behavior remains part of the contract.

--- a/specs/011-fix-select-model-sync/data-model.md
+++ b/specs/011-fix-select-model-sync/data-model.md
@@ -1,0 +1,86 @@
+# Data Model: NyxSelect External Model Sync
+
+**Branch**: `011-fix-select-model-sync` | **Date**: 2026-04-02
+
+## Entities
+
+### Select Value
+
+The current bound value controlled by the parent.
+
+**Fields**:
+- `mode`: single or multiple
+- `value`: one option value or a list of option values
+
+**Validation rules**:
+- single mode uses one option value
+- multiple mode uses an ordered list of option values
+- clearing the value must return the control to the unselected display state
+
+### Select Option
+
+One selectable option available in the control.
+
+**Fields**:
+- `label`: visible option text
+- `value`: stored value used for matching
+- `disabled`: optional disabled state
+
+**Validation rules**:
+- matching is based on option value
+- disabled options may still exist in the data set but are not interactable
+
+### Displayed Selection
+
+The user-visible representation of the current selection.
+
+**Fields**:
+- `closedText`: text shown in the closed control
+- `selectedMarkers`: selected state shown in the dropdown list
+
+**Validation rules**:
+- must always be derived from the current bound value and available options
+- must clear stale labels when no current option match exists
+- must stay consistent between the closed control and the open dropdown
+
+### Option Collection
+
+The set of options passed into the component, either flat or grouped.
+
+**Fields**:
+- `shape`: flat or grouped
+- `options`: selectable options used for value lookup and filtering
+
+**Validation rules**:
+- grouped and flat modes must produce the same synchronization outcome for equivalent values
+- invalid bound values must not preserve stale selection text regardless of option shape
+
+## Relationships
+
+| From | Relationship | To |
+|------|--------------|----|
+| `Select Value` | determines | `Displayed Selection` |
+| `Select Option` | contributes to | `Displayed Selection` |
+| `Option Collection` | contains many | `Select Option` |
+
+## State Transitions
+
+### External synchronization flow
+
+```text
+Parent updates bound value
+-> normalized model changes
+-> displayed selection is recalculated
+-> closed-control text updates
+-> dropdown selected markers update
+```
+
+## Edge Rules
+
+| Case | Expected model behavior |
+|------|-------------------------|
+| External single-value change | Closed text and selected marker switch to the new option |
+| External multi-value change | Closed text and selected markers switch to the new set |
+| External value cleared | Closed text returns to unselected state and markers clear |
+| External invalid value | No stale prior label remains visible |
+| Grouped options | Synchronization behavior matches flat options |

--- a/specs/011-fix-select-model-sync/plan.md
+++ b/specs/011-fix-select-model-sync/plan.md
@@ -1,0 +1,102 @@
+# Implementation Plan: NyxSelect External Model Sync
+
+**Branch**: `011-fix-select-model-sync` | **Date**: 2026-04-02 | **Spec**: `/home/arnedecant/Projects/nyxkit/nyx-kit/specs/011-fix-select-model-sync/spec.md`
+**Input**: Feature specification from `/specs/011-fix-select-model-sync/spec.md`
+
+## Summary
+
+Fix `NyxSelect` so externally controlled `v-model` changes immediately update both the displayed value and selected option state for single-select and multi-select usage. Keep the fix localized to the existing component contract, with targeted unit coverage, story validation, and a docs update to the living `NyxSelect` component spec.
+
+## Technical Context
+
+**Language/Version**: TypeScript with Vue 3.5+ single-file components  
+**Primary Dependencies**: Vue 3, existing `defineModel` usage, `useNyxProps`, `useTeleportPosition`, `useSelectKeyboardControls`, `v-click-outside`  
+**Storage**: N/A  
+**Testing**: Vitest with `@vue/test-utils`, Storybook 10, Playwright only if the bug fix alters browser-level interactive flows beyond component-local state sync  
+**Target Platform**: Published Vue 3 component-library consumers using `NyxSelect` as a controlled form input  
+**Project Type**: Vue 3 component library (`nyx-kit`)  
+**Performance Goals**: External value synchronization remains effectively immediate for normal select interactions and does not introduce redundant re-render loops for standard option list sizes  
+**Constraints**: Must remain backward-compatible; must update docs before code; must preserve current placeholder, search, grouped-option, teleport, and keyboard behavior; must prefer a minimal localized change over architectural rewrites  
+**Scale/Scope**: One existing component, one living component spec, one story file, and one unit test file
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Gate | Status | Notes |
+|------|--------|-------|
+| Docs before code | ✅ | The existing living spec at `docs/specs/components/NyxSelect.spec.md` must be updated before implementation |
+| Public contract safety | ✅ | This is a bug fix to existing `v-model` behavior with no planned API changes |
+| Minimal diff | ✅ | Scope is limited to `NyxSelect` docs, logic, tests, and stories |
+| Test-first for non-trivial logic | ✅ | External model synchronization is non-trivial component logic and requires targeted Vitest coverage |
+| Design token discipline | ✅ | No style-token changes are expected for this fix |
+| Consistency over local optimisation | ✅ | The fix should follow the repository's documented `defineModel` and normalized model patterns |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/011-fix-select-model-sync/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── nyx-select.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+docs/
+└── specs/
+    └── components/
+        └── NyxSelect.spec.md
+
+src/
+└── components/
+    └── NyxSelect/
+        ├── NyxSelect.vue
+        ├── NyxSelect.types.ts
+        ├── NyxSelect.spec.ts
+        ├── NyxSelect.stories.ts
+        └── NyxSelect.scss
+```
+
+**Structure Decision**: Keep the fix entirely within the existing `NyxSelect` component surface. Update the living component spec first, then adjust the component’s derived display-state synchronization and add regression tests and a story scenario that demonstrates external model updates.
+
+## Phase 0: Research Summary
+
+1. Keep `normalisedModel` as the single source of truth and ensure derived display state is recalculated when that model changes externally.
+2. Favor watcher-based or computed synchronization tied to the normalized model rather than duplicating selection state in a second persistent ref.
+3. Verify the fix across single-select, multi-select, grouped options, and open/closed dropdown states with unit tests.
+4. Update the `NyxSelect` living spec to document that externally controlled values must immediately update visible labels and selected option state.
+
+## Phase 1: Design Summary
+
+1. Define the external model value as the authoritative input for displayed labels and selected markers.
+2. Document synchronization rules for three derived surfaces: closed-control text, dropdown selected state, and reset-to-placeholder behavior.
+3. Add regression coverage for parent-driven model changes after mount in both single and multi-select modes.
+4. Add or update Storybook coverage so the external-sync behavior can be reviewed visually.
+
+## Post-Design Constitution Check
+
+| Gate | Status | Notes |
+|------|--------|-------|
+| Docs before code | ✅ | Design explicitly updates the existing living spec before implementation |
+| Public contract safety | ✅ | No prop, slot, emit, or export changes are required |
+| Minimal diff | ✅ | Design remains localized to the existing `NyxSelect` files |
+| Test-first for non-trivial logic | ✅ | Design calls for explicit regression tests before implementation completion |
+| Design token discipline | ✅ | No style-token or global-style changes are required |
+| Consistency over local optimisation | ✅ | Design follows the existing `defineModel` normalization pattern documented in `component-model.md` |
+
+## Complexity Tracking
+
+> **Fill ONLY if Constitution Check has violations that must be justified**
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| [e.g., 4th project] | [current need] | [why 3 projects insufficient] |
+| [e.g., Repository pattern] | [specific problem] | [why direct DB access insufficient] |

--- a/specs/011-fix-select-model-sync/quickstart.md
+++ b/specs/011-fix-select-model-sync/quickstart.md
@@ -1,0 +1,49 @@
+# Quickstart: NyxSelect External Model Sync
+
+**Branch**: `011-fix-select-model-sync` | **Date**: 2026-04-02
+
+## Single-select external updates
+
+Use `NyxSelect` in a parent-controlled setup where the selected value can change after mount.
+
+```vue
+<NyxSelect v-model="selectedTheme" :options="options" />
+```
+
+Expected behavior:
+- when `selectedTheme` changes externally, the closed control updates to the matching option label
+- opening the dropdown after that change shows the new option as selected
+- the control also shows the correct selected label on initial render when the bound value is already set
+
+## Multi-select external updates
+
+Use `NyxSelect` with a parent-controlled value array.
+
+```vue
+<NyxSelect v-model="selectedThemes" :options="options" type="multiple" />
+```
+
+Expected behavior:
+- when `selectedThemes` changes externally, the closed control updates its displayed labels
+- opening the dropdown shows the updated selected option set
+
+## Clearing the external value
+
+Clear the bound value from the parent.
+
+```vue
+selectedTheme = ''
+selectedThemes = []
+```
+
+Expected behavior:
+- the control returns to its unselected display state
+- previously selected options no longer appear selected
+- invalid externally supplied values do not leave stale labels visible
+
+## Validation scenarios
+
+1. Mount `NyxSelect` with one selected value, update that value externally, and verify both the control text and selected option marker update.
+2. Mount `NyxSelect` in multi-select mode, replace the external value array, and verify both the displayed labels and selected markers update.
+3. Repeat the same checks with grouped options.
+4. Clear the external value and verify the control does not keep showing stale labels.

--- a/specs/011-fix-select-model-sync/research.md
+++ b/specs/011-fix-select-model-sync/research.md
@@ -1,0 +1,43 @@
+# Research: NyxSelect External Model Sync
+
+**Branch**: `011-fix-select-model-sync` | **Date**: 2026-04-02
+
+## Decision 1: Treat the external model as the single source of truth
+
+**Decision**: The displayed value and selected option state should always be derived from the current normalized bound value rather than from a separate internal selection cache.
+
+**Rationale**: `NyxSelect` is a controlled form component. If a parent changes the bound value after mount, the component must reflect that change immediately and consistently everywhere it presents selection state.
+
+**Alternatives considered**:
+- Keep a second internal selected-value ref and try to synchronize it manually: rejected because it increases the chance of drift.
+- Only refresh the visible text when the dropdown closes: rejected because the bug report explicitly calls out stale state after external changes.
+
+## Decision 2: Update derived display state when the normalized model changes externally
+
+**Decision**: Recalculate closed-control text and selected markers whenever the normalized model changes, regardless of whether the change came from inside or outside the component.
+
+**Rationale**: The bug affects both the displayed text and the option list state. The fix must cover all derived surfaces tied to the bound value, not just one of them.
+
+**Alternatives considered**:
+- Recalculate only on mount or dropdown open: rejected because it leaves stale state between interactions.
+- Force consumers to remount the component after parent-driven changes: rejected because that breaks the expected `v-model` contract.
+
+## Decision 3: Verify all existing selection modes and option shapes
+
+**Decision**: Add regression coverage for single-select, multi-select, flat options, grouped options, and cleared/invalid values.
+
+**Rationale**: `NyxSelect` already supports multiple value modes and option shapes. A fix that only covers the originally reported single-value case risks leaving closely related regressions behind.
+
+**Alternatives considered**:
+- Test only the exact reported single-select case: rejected because the same derivation path is shared by other supported modes.
+- Rely on manual story review alone: rejected because this is state-sync logic and needs automated regression coverage.
+
+## Decision 4: Keep the fix local to NyxSelect
+
+**Decision**: Implement the synchronization fix inside `NyxSelect` without changing shared composables or the broader component contract.
+
+**Rationale**: The current bug is localized to one component’s state derivation. A focused fix lowers regression risk and follows the constitution’s minimal-diff requirement.
+
+**Alternatives considered**:
+- Refactor shared selection behavior into a new composable: rejected because it broadens scope without evidence of repeated need.
+- Change the public API to add explicit refresh behavior: rejected because this should work under the existing contract.

--- a/specs/011-fix-select-model-sync/spec.md
+++ b/specs/011-fix-select-model-sync/spec.md
@@ -1,0 +1,94 @@
+# Feature Specification: NyxSelect External Model Sync
+
+**Feature Branch**: `011-fix-select-model-sync`  
+**Created**: 2026-04-02  
+**Status**: Draft  
+**Input**: User description: "NyxSelect: when the modelValue changes from outside, the selected option and the value shown should update as well, this is not the case right now"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Reflect external selection changes immediately (Priority: P1)
+
+As a consumer using `NyxSelect` with external state, I want the displayed value and selected option state to update when the bound value changes outside the component so that the control always reflects the real application state.
+
+**Why this priority**: External `v-model` synchronization is a core contract for form controls. When it fails, the component shows stale information and becomes unreliable.
+
+**Independent Test**: Mount `NyxSelect` with a bound value, then update the bound value from outside the component and verify the visible label and selected option state both change to match.
+
+**Acceptance Scenarios**:
+
+1. **Given** a single-select control with an initial external value, **When** the external value changes to another valid option, **Then** the displayed text updates to the new option label.
+2. **Given** a single-select control with an initial external value, **When** the dropdown is opened after the external value changes, **Then** only the newly selected option is marked as selected.
+3. **Given** a single-select control with no internal user interaction after mount, **When** the external value changes, **Then** the control still reflects the new value without requiring the user to reopen or blur the field.
+
+---
+
+### User Story 2 - Reflect external multi-select changes consistently (Priority: P2)
+
+As a consumer using `NyxSelect` in multi-select mode, I want externally controlled value arrays to update both the shown labels and selected option states so that parent-driven changes remain trustworthy in batch-edit and reset flows.
+
+**Why this priority**: Multi-select mode depends on the same reactive contract, and stale labels or option states are especially confusing when several values change at once.
+
+**Independent Test**: Mount `NyxSelect` in multi-select mode, replace the bound array from outside the component, and verify the shown labels and selected option markers match the new array.
+
+**Acceptance Scenarios**:
+
+1. **Given** a multi-select control with an initial external value array, **When** the external array changes to a different set of valid options, **Then** the displayed labels update to match the new set.
+2. **Given** a multi-select control with the dropdown open, **When** the external array changes, **Then** the selected states in the option list update to match the new set.
+
+---
+
+### User Story 3 - Preserve search and empty-state behavior during sync (Priority: P3)
+
+As a consumer, I want external value synchronization to work without breaking search, placeholder, or empty-state behavior so that the fix does not introduce regressions in everyday select usage.
+
+**Why this priority**: This change touches how the component derives its visible text, so it must not degrade nearby behaviors that depend on the same display value.
+
+**Independent Test**: Change the external value while the control is closed, open, and filtered, and verify the component still shows the correct selection while preserving its existing search and placeholder rules.
+
+**Acceptance Scenarios**:
+
+1. **Given** a control with a placeholder and no selected value, **When** the external value is cleared, **Then** the displayed text returns to the unselected state.
+2. **Given** a control with an active search interaction, **When** the dropdown closes after an external value change, **Then** the closed control shows the current externally selected label set rather than stale text.
+
+### Edge Cases
+
+- When the external value changes to an option that is not present in the current option list, the control must not continue showing the previous selected label.
+- When the external value is cleared from outside the component, previously selected options must no longer appear selected.
+- When grouped options are used, external value changes must update selection state across groups exactly the same as in flat option lists.
+- When the external value changes while the dropdown is open, the list and the closed control must stay in sync rather than diverging.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST update the visible selected label in single-select mode when the bound value changes from outside the component.
+- **FR-002**: The system MUST update the visible selected labels in multi-select mode when the bound value array changes from outside the component.
+- **FR-003**: The system MUST update the selected option state in the dropdown when the bound value changes from outside the component.
+- **FR-004**: The system MUST update the selected option states in the dropdown when the bound value array changes from outside the component in multi-select mode.
+- **FR-005**: The system MUST clear stale displayed labels when the externally bound value no longer matches an available option.
+- **FR-006**: The system MUST return to the unselected display state when the externally bound value is cleared.
+- **FR-007**: The system MUST preserve the same external synchronization behavior for both flat and grouped option lists.
+- **FR-008**: The system MUST preserve existing placeholder, search reset, and empty-state behavior while fixing external value synchronization.
+
+### Key Entities *(include if feature involves data)*
+
+- **Select Value**: The externally controlled bound value for the component, represented as a single option value or a list of option values depending on mode.
+- **Select Option**: An available selectable item with a visible label and stored value used for display and selection matching.
+- **Displayed Selection**: The text shown in the closed control and the selected markers shown in the dropdown, derived from the current bound value and available options.
+
+### Assumptions
+
+- `NyxSelect` continues to support both single-select and multi-select modes through the existing component contract.
+- External value changes may come from parent state updates, form resets, or other application events rather than direct user interaction inside the component.
+- The fix is intended to preserve current search and dropdown behavior unless required to keep the displayed value in sync with the external state.
+- Invalid externally supplied values should not keep showing the last valid selection.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: In acceptance testing, 100% of externally triggered single-value changes are reflected in the displayed selected label without additional user interaction.
+- **SC-002**: In acceptance testing, 100% of externally triggered multi-value changes are reflected in both the displayed label set and the selected option markers.
+- **SC-003**: In acceptance testing across flat and grouped options, 0 stale selections remain visible after the externally bound value is changed or cleared.
+- **SC-004**: Existing placeholder and search-related behavior continues to work in all updated acceptance scenarios for this feature.

--- a/specs/011-fix-select-model-sync/tasks.md
+++ b/specs/011-fix-select-model-sync/tasks.md
@@ -1,0 +1,202 @@
+# Tasks: NyxSelect External Model Sync
+
+**Input**: Design documents from `/specs/011-fix-select-model-sync/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/, quickstart.md
+
+**Tests**: Include targeted Vitest regression coverage because the plan and constitution require tests for this non-trivial synchronization logic.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (`US1`, `US2`, `US3`)
+- Every task includes an exact file path
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Update the docs-first contract for `NyxSelect` before touching source code.
+
+- [X] T001 Update the living component spec to document external model synchronization in `docs/specs/components/NyxSelect.spec.md`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Establish the shared regression surface and derive the synchronization rules that all user stories depend on.
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete.
+
+- [X] T002 Expand the component contract examples for external model synchronization in `specs/011-fix-select-model-sync/contracts/nyx-select.md`
+- [X] T003 [P] Add a Storybook scenario that demonstrates parent-driven value updates in `src/components/NyxSelect/NyxSelect.stories.ts`
+
+**Checkpoint**: Foundation ready - user story implementation can now begin.
+
+---
+
+## Phase 3: User Story 1 - Reflect external selection changes immediately (Priority: P1) 🎯 MVP
+
+**Goal**: Ensure single-select `NyxSelect` updates its visible label and selected dropdown option when the bound value changes externally.
+
+**Independent Test**: Mount `NyxSelect` with a parent-controlled single value, update that value from outside the component, and verify the closed control text and selected option marker both change immediately.
+
+### Tests for User Story 1
+
+- [X] T004 [US1] Add single-select external model sync regression tests in `src/components/NyxSelect/NyxSelect.spec.ts`
+
+### Implementation for User Story 1
+
+- [X] T005 [US1] Update single-select derived display synchronization for external model changes in `src/components/NyxSelect/NyxSelect.vue`
+- [X] T006 [US1] Add a single-select external-sync example in `src/components/NyxSelect/NyxSelect.stories.ts`
+
+**Checkpoint**: User Story 1 is fully functional and independently testable.
+
+---
+
+## Phase 4: User Story 2 - Reflect external multi-select changes consistently (Priority: P2)
+
+**Goal**: Ensure multi-select `NyxSelect` updates its displayed labels and selected option markers when the external value array changes.
+
+**Independent Test**: Mount `NyxSelect` in multi-select mode, replace the bound value array from outside the component, and verify the displayed label set and selected dropdown states match the new array.
+
+### Tests for User Story 2
+
+- [X] T007 [US2] Add multi-select external model sync regression tests in `src/components/NyxSelect/NyxSelect.spec.ts`
+
+### Implementation for User Story 2
+
+- [X] T008 [US2] Update multi-select derived display synchronization for external array changes in `src/components/NyxSelect/NyxSelect.vue`
+- [X] T009 [US2] Add a multi-select external-sync example in `src/components/NyxSelect/NyxSelect.stories.ts`
+
+**Checkpoint**: User Stories 1 and 2 both work independently.
+
+---
+
+## Phase 5: User Story 3 - Preserve search and empty-state behavior during sync (Priority: P3)
+
+**Goal**: Ensure the synchronization fix does not regress placeholder, search-reset, invalid-value, or grouped-option behavior.
+
+**Independent Test**: Change the external value while the control is closed, open, cleared, and used with grouped options, then verify the correct selection is shown without stale labels or broken search/placeholder behavior.
+
+### Tests for User Story 3
+
+- [X] T010 [US3] Add grouped-option, cleared-value, and stale-label regression tests in `src/components/NyxSelect/NyxSelect.spec.ts`
+
+### Implementation for User Story 3
+
+- [X] T011 [US3] Preserve placeholder, grouped-option, and search-reset synchronization behavior in `src/components/NyxSelect/NyxSelect.vue`
+- [X] T012 [US3] Add grouped and cleared external-sync examples in `src/components/NyxSelect/NyxSelect.stories.ts`
+
+**Checkpoint**: All user stories are independently functional.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final sync and validation across docs, tests, and acceptance scenarios.
+
+- [X] T013 [P] Sync final synchronization behavior details in `docs/specs/components/NyxSelect.spec.md`
+- [X] T014 [P] Align acceptance scenarios and examples with the final behavior in `specs/011-fix-select-model-sync/quickstart.md`
+- [X] T015 Run final NyxSelect regression verification across `src/components/NyxSelect/NyxSelect.spec.ts` and `src/components/NyxSelect/NyxSelect.stories.ts`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1: Setup**: No dependencies - starts immediately
+- **Phase 2: Foundational**: Depends on Phase 1 completion - blocks all user stories
+- **Phase 3: User Story 1**: Depends on Phase 2 completion
+- **Phase 4: User Story 2**: Depends on Phase 2 completion and can be delivered after US1 or in parallel once the shared synchronization foundation is stable
+- **Phase 5: User Story 3**: Depends on Phase 2 completion and can be delivered after US1/US2 or in parallel once the shared synchronization foundation is stable
+- **Phase 6: Polish**: Depends on all desired user stories being complete
+
+### User Story Dependencies
+
+- **US1 (P1)**: No dependency on other user stories
+- **US2 (P2)**: Depends on the same component-level synchronization path established in Phase 2 but not on US1-specific acceptance scenarios
+- **US3 (P3)**: Depends on the same component-level synchronization path and validates edge behavior without requiring new public API
+
+### Within Each User Story
+
+- Expand tests before completing implementation in the same story
+- Update component logic before story examples that demonstrate the fixed behavior
+- Finish each story at its checkpoint before moving to cross-cutting polish
+
+### Dependency Graph
+
+```text
+Phase 1 Setup
+  -> Phase 2 Foundational
+     -> US1 (MVP)
+     -> US2
+     -> US3
+        -> Phase 6 Polish
+```
+
+### Parallel Opportunities
+
+- `T002` and `T003` can run in parallel because they touch different files
+- `T013` and `T014` can run in parallel because they touch different docs artifacts
+- Story-specific examples can follow component logic work independently once the underlying behavior is stable
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+# After the single-select sync logic is stable, visual docs can be updated separately:
+Task: "Update single-select derived display synchronization for external model changes in src/components/NyxSelect/NyxSelect.vue"
+Task: "Add a single-select external-sync example in src/components/NyxSelect/NyxSelect.stories.ts"
+```
+
+## Parallel Example: User Story 2
+
+```bash
+# After the multi-select sync behavior is defined, examples can be completed separately:
+Task: "Update multi-select derived display synchronization for external array changes in src/components/NyxSelect/NyxSelect.vue"
+Task: "Add a multi-select external-sync example in src/components/NyxSelect/NyxSelect.stories.ts"
+```
+
+## Parallel Example: User Story 3
+
+```bash
+# Final docs sync can proceed in parallel once the behavior is locked:
+Task: "Sync final synchronization behavior details in docs/specs/components/NyxSelect.spec.md"
+Task: "Align acceptance scenarios and examples with the final behavior in specs/011-fix-select-model-sync/quickstart.md"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup
+2. Complete Phase 2: Foundational
+3. Complete Phase 3: User Story 1
+4. Validate single-select parent-driven updates independently
+5. Stop for review before multi-select and edge-case coverage
+
+### Incremental Delivery
+
+1. Update docs and shared regression scaffolding
+2. Deliver US1 for single-select external model synchronization
+3. Deliver US2 for multi-select external model synchronization
+4. Deliver US3 for grouped, cleared, and stale-label edge cases
+5. Finish with docs and quickstart sync
+
+### Suggested MVP Scope
+
+- Phase 1
+- Phase 2
+- Phase 3 (User Story 1)
+
+---
+
+## Notes
+
+- All tasks use the required checklist format with task ID, optional parallel marker, optional story label, and exact file path
+- `src/components/NyxSelect/NyxSelect.vue`, `src/components/NyxSelect/NyxSelect.spec.ts`, and `src/components/NyxSelect/NyxSelect.stories.ts` are shared across stories, so story work should be sequenced carefully within one branch
+- The fix should remain localized and avoid introducing new shared composables unless implementation reveals a concrete repeated need

--- a/src/components/NyxSelect/NyxSelect.spec.ts
+++ b/src/components/NyxSelect/NyxSelect.spec.ts
@@ -196,6 +196,118 @@ describe('NyxSelect', () => {
     expect(optionEls[0].getAttribute('aria-selected')).toBe('false')
   })
 
+  it('updates the displayed label when the single-select model changes externally', async () => {
+    wrapper = mount(NyxSelect, {
+      attachTo: document.body,
+      props: { options: sampleOptions, modelValue: 'a' },
+      global: globalConfig
+    })
+
+    expect((wrapper.find('input').element as HTMLInputElement).value).toBe('Option A')
+
+    await wrapper.setProps({ modelValue: 'c' })
+    await nextTick()
+
+    expect((wrapper.find('input').element as HTMLInputElement).value).toBe('Option C')
+  })
+
+  it('updates the selected option marker when the single-select model changes externally', async () => {
+    wrapper = mount(NyxSelect, {
+      attachTo: document.body,
+      props: { options: sampleOptions, modelValue: 'a' },
+      global: globalConfig
+    })
+
+    await wrapper.setProps({ modelValue: 'c' })
+    await wrapper.find('.nyx-select__control').trigger('click')
+    await nextTick()
+
+    const options = document.body.querySelectorAll('.nyx-select__option')
+    expect(options[2].classList.contains('nyx-select__option--selected')).toBe(true)
+    expect(options[0].classList.contains('nyx-select__option--selected')).toBe(false)
+  })
+
+  it('updates displayed labels when the multi-select model changes externally', async () => {
+    wrapper = mount(NyxSelect, {
+      attachTo: document.body,
+      props: { options: sampleOptions, modelValue: ['a'], type: NyxSelectType.Multiple },
+      global: globalConfig
+    })
+
+    expect((wrapper.find('input').element as HTMLInputElement).value).toBe('Option A')
+
+    await wrapper.setProps({ modelValue: ['b', 'c'] })
+    await nextTick()
+
+    expect((wrapper.find('input').element as HTMLInputElement).value).toBe('Option B, Option C')
+  })
+
+  it('updates selected markers when the multi-select model changes externally', async () => {
+    wrapper = mount(NyxSelect, {
+      attachTo: document.body,
+      props: { options: sampleOptions, modelValue: ['a'], type: NyxSelectType.Multiple },
+      global: globalConfig
+    })
+
+    await wrapper.setProps({ modelValue: ['b', 'c'] })
+    await wrapper.find('.nyx-select__control').trigger('click')
+    await nextTick()
+
+    const options = document.body.querySelectorAll('.nyx-select__option')
+    expect(options[0].classList.contains('nyx-select__option--selected')).toBe(false)
+    expect(options[1].classList.contains('nyx-select__option--selected')).toBe(true)
+    expect(options[2].classList.contains('nyx-select__option--selected')).toBe(true)
+  })
+
+  it('clears stale displayed labels when the external value is invalid or cleared', async () => {
+    wrapper = mount(NyxSelect, {
+      attachTo: document.body,
+      props: { options: sampleOptions, modelValue: 'b' },
+      global: globalConfig
+    })
+
+    await wrapper.setProps({ modelValue: 'missing' })
+    await nextTick()
+    expect((wrapper.find('input').element as HTMLInputElement).value).toBe('')
+
+    await wrapper.setProps({ modelValue: '' })
+    await nextTick()
+    expect((wrapper.find('input').element as HTMLInputElement).value).toBe('')
+  })
+
+  it('updates grouped-option selection when the external value changes', async () => {
+    const groupedOptions = [
+      {
+        label: 'Group 1',
+        options: [
+          { label: 'Option A', value: 'a' },
+          { label: 'Option B', value: 'b' },
+        ]
+      },
+      {
+        label: 'Group 2',
+        options: [
+          { label: 'Option C', value: 'c' },
+        ]
+      }
+    ]
+
+    wrapper = mount(NyxSelect, {
+      attachTo: document.body,
+      props: { options: groupedOptions, modelValue: 'a' },
+      global: globalConfig
+    })
+
+    await wrapper.setProps({ modelValue: 'c' })
+    await nextTick()
+    expect((wrapper.find('input').element as HTMLInputElement).value).toBe('Option C')
+
+    await wrapper.find('.nyx-select__control').trigger('click')
+    await nextTick()
+    const options = document.body.querySelectorAll('.nyx-select__option')
+    expect(options[2].classList.contains('nyx-select__option--selected')).toBe(true)
+  })
+
   describe('keyboard navigation', () => {
     const optionsWithDisabled = [
       { label: 'Option A', value: 'a' },

--- a/src/components/NyxSelect/NyxSelect.stories.ts
+++ b/src/components/NyxSelect/NyxSelect.stories.ts
@@ -1,4 +1,4 @@
-import { defineComponent } from 'vue'
+import { defineComponent, ref } from 'vue'
 import NyxSelect from './NyxSelect.vue'
 import { NyxTheme, NyxVariant, NyxSize, NyxSelectType, type KeyDict } from '@/types'
 import type { NyxSelectProps } from './NyxSelect.types'
@@ -94,6 +94,29 @@ export const WithGroups = () => defineComponent({
     return { options: groupedOptions }
   },
   template: `<nyx-select :options="options" placeholder="NyxSelect" />`,
+})
+export const ExternalModelSync = () => defineComponent({
+  components: { NyxSelect },
+  setup () {
+    const modelValue = ref<string>(NyxTheme.Primary)
+    const cycleValue = () => {
+      modelValue.value = modelValue.value === NyxTheme.Primary ? NyxTheme.Danger : NyxTheme.Primary
+    }
+    const clearValue = () => {
+      modelValue.value = ''
+    }
+    return { modelValue, options, cycleValue, clearValue }
+  },
+  template: `
+    <div style="display:grid;gap:1rem;max-width:24rem;">
+      <div style="display:flex;gap:0.5rem;">
+        <button type="button" @click="cycleValue">Toggle value</button>
+        <button type="button" @click="clearValue">Clear</button>
+      </div>
+      <nyx-select v-model="modelValue" :options="options" placeholder="NyxSelect" />
+      <p>External value: {{ modelValue }}</p>
+    </div>
+  `,
 })
 export const Types = TemplateAll('type', NyxSelectType)
 export const Themes = TemplateAll('theme', NyxTheme)

--- a/src/components/NyxSelect/NyxSelect.vue
+++ b/src/components/NyxSelect/NyxSelect.vue
@@ -156,6 +156,12 @@ watch(isOpen, (newVal) => {
     }
   }
 })
+
+watch([normalisedModel, flatOptions], () => {
+  if (!isOpen.value) {
+    setSearchQuery()
+  }
+}, { immediate: true })
 </script>
 
 <template>


### PR DESCRIPTION
## Summary
- fix `NyxSelect` so externally controlled `v-model` changes immediately update the closed-control text and selected option state
- add regression coverage for single-select, multi-select, grouped options, and cleared or invalid values
- update the living component spec, quickstart artifacts, and Storybook with an external-model-sync scenario

## Validation
- pnpm vitest \"src/components/NyxSelect/NyxSelect.spec.ts\" --run
- pnpm type-check
- pnpm storybook:build