### PR TITLE
feat: add NyxDropdown component family

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,7 @@ The project constitution is at `.specify/memory/constitution.md`.
 - N/A — display-only, no state (014-nyx-metric-card)
 - TypeScript 5.7 / Vue 3.5 + Vue 3, `NyxTable`, `NyxTableCell`, `NyxTheme` — all already in scope (015-nyx-log-viewer)
 - N/A — display only, no state (015-nyx-log-viewer)
+- TypeScript + Vue 3 + Vue 3, SCSS, shared Nyx Kit composables and types (016-dropdown-components)
 
 ## Recent Changes
 - 003-testing-improvements: Added TypeScript 5.x / Vue 3 + `@vue/test-utils`, `vitest`, `@playwright/test`, `jsdom`

--- a/docs/specs/components/NyxButtonGroup.spec.md
+++ b/docs/specs/components/NyxButtonGroup.spec.md
@@ -1,0 +1,47 @@
+# NyxButtonGroup
+
+> A simple wrapper that visually joins adjacent `NyxButton` children into a horizontal or vertical group.
+
+## Purpose and scope
+
+`NyxButtonGroup` is a light structural component for presenting related buttons as one control cluster.
+
+**Use when:**
+- You want adjacent buttons to share borders and radii
+- You need a compact horizontal or vertical action group
+
+**Do not use when:**
+- You need spacing between unrelated controls
+- You need segmented selection state or button toggle logic
+
+## Internal architecture
+
+- Renders a single `<div>` root with the `nyx-button-group` class
+- Applies direction and variant classes directly from props
+- Relies on child `.nyx-button` elements for the visible joining effect
+- Does not manage focus, selection, or active state itself
+
+## Props
+
+| Prop | Type | Default | Description |
+|---|---|---|---|
+| `direction` | `NyxDirection` | `NyxDirection.Horizontal` | Chooses horizontal or vertical stacking |
+| `gap` | `NyxSize \| number` | — | Declared in the public props type, but currently not consumed by the component |
+| `variant` | `NyxVariant.Soft \| NyxVariant.Ghost` | `NyxVariant.Ghost` | Controls the group visual treatment |
+
+## Slots
+
+| Slot | Scope | Purpose |
+|---|---|---|
+| `default` | — | Button content, typically `NyxButton` children |
+
+## Accessibility
+
+- The component itself is non-interactive and uses a neutral `<div>` root
+- Keyboard and focus behavior are delegated to the slotted buttons
+- Consumers remain responsible for choosing meaningful button labels and disabled states
+
+## Known limitations
+
+- `gap` is present in the props type but not currently applied in the implementation
+- The component does not provide toggle-group semantics or selection state

--- a/docs/specs/components/NyxDropdown.spec.md
+++ b/docs/specs/components/NyxDropdown.spec.md
@@ -1,0 +1,70 @@
+# NyxDropdown
+
+> A trigger-driven dropdown wrapper with an optional custom panel slot and a default option-based menu.
+
+## Purpose and scope
+
+NyxDropdown provides a compact way to pair any trigger content with a floating panel. It is intended for action menus, compact command lists, and other small contextual popovers.
+
+**Use when:**
+- You need a custom trigger that opens a floating menu or panel
+- You want a default option-driven menu without building item markup yourself
+- You need to replace the default menu with custom content while keeping the same trigger wrapper
+
+**Do not use when:**
+- The content should always stay visible without a trigger
+- You need a full-page navigation pattern rather than a contextual panel
+
+## Internal architecture
+
+- The default slot acts as the trigger region.
+- The wrapper supports `hover` and `click` trigger modes, with click behavior used automatically on devices that do not support hover.
+- The wrapper accepts an initial panel position and allows the teleport-position logic to mirror it when viewport space is tight.
+- The dropdown content is teleported and positioned relative to the trigger with `useTeleportPosition`.
+- When no `dropdown` slot is provided, the component renders `NyxDropdownMenu` using the provided options.
+- The wrapper forwards its visual theme, size, and variant to the default menu so the panel matches the trigger styling.
+- When a `dropdown` slot is provided, it replaces the default option-rendered panel.
+- The panel is dismissed through outside interaction and keyboard escape handling.
+
+## Props
+
+| Prop | Type | Default | Description |
+|---|---|---|---|
+| `theme` | `NyxTheme` | inherited from library defaults | Visual theme applied to the trigger and default menu |
+| `size` | `NyxSize` | inherited from library defaults | Size token applied to the trigger and default menu |
+| `variant` | `NyxVariant` | inherited from library defaults | Visual variant applied to the trigger and default menu |
+| `position` | `NyxPosition` | `bottom` | Preferred initial position for the floating panel |
+| `trigger` | `NyxTrigger` | `hover` | Interaction mode used to open the dropdown |
+| `options` | `NyxSelectOption[]` | `[]` | Option list used by the default dropdown menu |
+
+## Emits
+
+| Event | Payload | When |
+|---|---|---|
+| `select` | `NyxSelectOption` | A default menu item is chosen |
+
+## Slots
+
+| Slot | Scope | Purpose |
+|---|---|---|
+| `default` | — | Trigger content |
+| `dropdown` | — | Optional custom dropdown panel |
+
+## Keyboard behaviour
+
+| Key | Behaviour |
+|---|---|
+| `Esc` | Closes the open panel |
+| `Enter` / `Space` | Activates the trigger or the focused item |
+| `ArrowDown` / `ArrowUp` | Moves through visible menu items when the default menu is open |
+
+## Accessibility
+
+- The trigger must remain a semantic interactive element or contain one.
+- The floating panel must be discoverable by assistive technologies when opened.
+- Disabled options remain visible but cannot be activated.
+
+## Known limitations
+
+- The component does not manage route navigation or command execution itself.
+- Custom dropdown content is responsible for its own internal accessibility semantics.

--- a/docs/specs/components/NyxDropdown.spec.md
+++ b/docs/specs/components/NyxDropdown.spec.md
@@ -25,6 +25,7 @@ NyxDropdown provides a compact way to pair any trigger content with a floating p
 - The wrapper forwards its visual theme, size, and variant to the default menu so the panel matches the trigger styling.
 - When a `dropdown` slot is provided, it replaces the default option-rendered panel.
 - The panel is dismissed through outside interaction and keyboard escape handling.
+- Menu options may include an optional icon that is shown alongside the label.
 
 ## Props
 
@@ -34,8 +35,8 @@ NyxDropdown provides a compact way to pair any trigger content with a floating p
 | `size` | `NyxSize` | inherited from library defaults | Size token applied to the trigger and default menu |
 | `variant` | `NyxVariant` | inherited from library defaults | Visual variant applied to the trigger and default menu |
 | `position` | `NyxPosition` | `bottom` | Preferred initial position for the floating panel |
-| `trigger` | `NyxTrigger` | `hover` | Interaction mode used to open the dropdown |
-| `options` | `NyxSelectOption[]` | `[]` | Option list used by the default dropdown menu |
+| `trigger` | `NyxTrigger` | `click` | Interaction mode used to open the dropdown |
+| `options` | `NyxSelectOption[]` | `[]` | Option list used by the default dropdown menu; options may include an optional icon |
 
 ## Emits
 

--- a/docs/specs/components/NyxDropdownItem.spec.md
+++ b/docs/specs/components/NyxDropdownItem.spec.md
@@ -19,12 +19,13 @@ NyxDropdownItem renders one option as an interactive row in a dropdown menu. It 
 - Renders one option value as an interactive element.
 - Reflects disabled state visually and functionally.
 - Emits activation data to the parent menu or wrapper.
+- Shows an optional icon before the label when one is provided.
 
 ## Props
 
 | Prop | Type | Default | Description |
 |---|---|---|---|
-| `option` | `NyxSelectOption` | Required | Option data for the item |
+| `option` | `NyxSelectOption` | Required | Option data for the item, including optional icon |
 
 ## Emits
 

--- a/docs/specs/components/NyxDropdownItem.spec.md
+++ b/docs/specs/components/NyxDropdownItem.spec.md
@@ -1,0 +1,51 @@
+# NyxDropdownItem
+
+> A single selectable item rendered inside a dropdown menu.
+
+## Purpose and scope
+
+NyxDropdownItem renders one option as an interactive row in a dropdown menu. It is primarily used by NyxDropdownMenu, but it can also be used in custom panels that need the same item presentation.
+
+**Use when:**
+- You need one selectable entry inside a dropdown menu
+- You want the same item style and activation behaviour as the default menu
+
+**Do not use when:**
+- The content is not selectable
+- You need a more complex composite row with multiple nested controls
+
+## Internal architecture
+
+- Renders one option value as an interactive element.
+- Reflects disabled state visually and functionally.
+- Emits activation data to the parent menu or wrapper.
+
+## Props
+
+| Prop | Type | Default | Description |
+|---|---|---|---|
+| `option` | `NyxSelectOption` | Required | Option data for the item |
+
+## Emits
+
+| Event | Payload | When |
+|---|---|---|
+| `click` | `NyxSelectOption` | The item is activated |
+
+## Slots
+
+None.
+
+## Keyboard behaviour
+
+- `Enter` and `Space` activate the item when it has focus.
+- Disabled items are skipped by normal keyboard activation.
+
+## Accessibility
+
+- Disabled items remain visible but are not focusable as active choices.
+- The item should present a clear text label and state to assistive technologies.
+
+## Known limitations
+
+- The item is intentionally narrow in scope and does not support custom sub-controls inside the row.

--- a/docs/specs/components/NyxDropdownMenu.spec.md
+++ b/docs/specs/components/NyxDropdownMenu.spec.md
@@ -1,0 +1,53 @@
+# NyxDropdownMenu
+
+> The default option-rendering panel used by NyxDropdown.
+
+## Purpose and scope
+
+NyxDropdownMenu renders a list of selectable items from a simple option array. It is useful both as the default dropdown panel and as a standalone building block for custom dropdown content.
+
+**Use when:**
+- You want the standard dropdown menu generated from options
+- You want to assemble a custom dropdown panel but still reuse the library’s menu item presentation
+
+**Do not use when:**
+- You need a custom panel that does not resemble a menu
+
+## Internal architecture
+
+- Renders one `NyxDropdownItem` per provided option.
+- Preserves option order and disabled state.
+- Forwards item activation as a menu-level selection event.
+
+## Props
+
+| Prop | Type | Default | Description |
+|---|---|---|---|
+| `theme` | `NyxTheme` | inherited from library defaults | Visual theme for the menu |
+| `size` | `NyxSize` | inherited from library defaults | Size token for the menu |
+| `variant` | `NyxVariant` | inherited from library defaults | Visual variant for the menu |
+| `options` | `NyxSelectOption[]` | `[]` | Options rendered as menu items |
+
+## Emits
+
+| Event | Payload | When |
+|---|---|---|
+| `select` | `NyxSelectOption` | A rendered item is activated |
+
+## Slots
+
+None.
+
+## Keyboard behaviour
+
+- Menu items rely on standard interactive element keyboard semantics.
+- Arrow-key navigation is handled at the dropdown wrapper level when used inside `NyxDropdown`.
+
+## Accessibility
+
+- Disabled options remain exposed but are not interactive.
+- The rendered menu should be announced as a grouped list of choices when used inside the dropdown panel.
+
+## Known limitations
+
+- The menu is intentionally option-driven; it does not support grouped data or async loading in v1.

--- a/docs/specs/components/NyxDropdownMenu.spec.md
+++ b/docs/specs/components/NyxDropdownMenu.spec.md
@@ -18,6 +18,7 @@ NyxDropdownMenu renders a list of selectable items from a simple option array. I
 - Renders one `NyxDropdownItem` per provided option.
 - Preserves option order and disabled state.
 - Forwards item activation as a menu-level selection event.
+- Passes through optional option icons so items can show a visual marker next to the label.
 
 ## Props
 
@@ -26,7 +27,7 @@ NyxDropdownMenu renders a list of selectable items from a simple option array. I
 | `theme` | `NyxTheme` | inherited from library defaults | Visual theme for the menu |
 | `size` | `NyxSize` | inherited from library defaults | Size token for the menu |
 | `variant` | `NyxVariant` | inherited from library defaults | Visual variant for the menu |
-| `options` | `NyxSelectOption[]` | `[]` | Options rendered as menu items |
+| `options` | `NyxSelectOption[]` | `[]` | Options rendered as menu items; each option may include an optional icon |
 
 ## Emits
 

--- a/docs/specs/components/NyxStatusDot.spec.md
+++ b/docs/specs/components/NyxStatusDot.spec.md
@@ -1,0 +1,40 @@
+# NyxStatusDot
+
+> A compact status indicator dot with theme, size, variant, glow, animation, and label support.
+
+## Purpose and scope
+
+Use `NyxStatusDot` when a UI needs a small, non-interactive visual status marker similar to the indicator used in `NodeCard`.
+It is intentionally decorative and does not manage status state or labels.
+
+## Internal architecture
+
+`NyxStatusDot` renders a circular indicator plus an optional label.
+It resolves shared visual props through `useNyxProps` and maps theme classes to colour tokens in `NyxStatusDot.scss`.
+The component uses an optional backlight glow, and `NyxAnimationState.Playing` pulses that glow.
+
+## Props
+
+| Prop | Type | Default | Description |
+|---|---|---|---|
+| `theme` | `NyxTheme` | `Success` | Colour theme for the dot |
+| `size` | `NyxSize` | `XSmall` | Dot size scale |
+| `variant` | `NyxVariant` | `Filled` | Visual treatment of the dot |
+| `backlight` | `boolean` | `false` | Enables a glow around the dot |
+| `animation` | `NyxAnimationState` | `Paused` | Controls whether the backlight pulses |
+| `label` | `string` | `''` | Fallback label rendered by the default slot |
+
+## Slots
+
+| Slot | Scope | Purpose |
+|---|---|---|
+| `default` | — | Custom label content; falls back to `props.label` |
+
+## Accessibility
+
+The indicator itself is decorative and renders with `aria-hidden="true"`.
+Consumers should provide label text if they need an accessible status label.
+
+## Known limitations
+
+- No built-in tooltip or semantic state mapping.

--- a/docs/specs/types/NyxTrigger.spec.md
+++ b/docs/specs/types/NyxTrigger.spec.md
@@ -1,0 +1,18 @@
+# NyxTrigger
+
+> Shared trigger mode enum used by interactive components.
+
+## Purpose and scope
+
+NyxTrigger defines the supported interaction modes for components that can be opened by user action. It currently covers hover-activated and click-activated patterns.
+
+## Values
+
+| Value | Meaning |
+|---|---|
+| `Hover` | Open on hover-capable pointer interaction, with click fallback on touch-only devices |
+| `Click` | Open and close through click/tap interaction |
+
+## Known limitations
+
+- Only hover and click are supported for now.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "nyx-kit",
   "homepage": "http://nyxkit.github.io/nyx-kit",
   "author": "Arne Decant <hello@arnedecant.be>",
-  "version": "2.0.28",
+  "version": "2.0.29",
   "packageManager": "pnpm@10.18.3",
   "private": false,
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "nyx-kit",
   "homepage": "http://nyxkit.github.io/nyx-kit",
   "author": "Arne Decant <hello@arnedecant.be>",
-  "version": "2.0.29",
+  "version": "2.0.30",
   "packageManager": "pnpm@10.18.3",
   "private": false,
   "license": "MIT",

--- a/specs/016-dropdown-components/checklists/requirements.md
+++ b/specs/016-dropdown-components/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: NyxDropdown Components
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-16
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Items marked incomplete require spec updates before `/speckit.clarify` or `/speckit.plan`

--- a/specs/016-dropdown-components/contracts/dropdown-components.md
+++ b/specs/016-dropdown-components/contracts/dropdown-components.md
@@ -1,0 +1,40 @@
+# Dropdown Component Contract
+
+## NyxDropdown
+
+### Purpose
+Wraps any trigger content and shows a floating dropdown panel.
+
+### Props
+- `theme`: forwarded visual theme for the trigger and default menu
+- `size`: forwarded size token for the trigger and default menu
+- `variant`: forwarded visual variant for the trigger and default menu
+- `options`: optional list used to render the default panel
+
+### Slots
+- `default`: trigger content
+- `dropdown`: optional custom panel content
+
+## NyxDropdownMenu
+
+### Purpose
+Renders the default option-based panel.
+
+### Props
+- `theme`: visual theme for the menu
+- `size`: size token for the menu
+- `variant`: visual variant for the menu
+- `options`: option list used to render menu items
+
+## NyxDropdownItem
+
+### Purpose
+Renders one option entry inside a dropdown menu.
+
+### Props
+- `option`: one option entry
+
+### Option shape
+- `label`: visible text
+- `value`: stable selection value
+- `disabled`: optional disabled state

--- a/specs/016-dropdown-components/data-model.md
+++ b/specs/016-dropdown-components/data-model.md
@@ -1,0 +1,42 @@
+# Data Model: NyxDropdown Components
+
+## Entities
+
+### Dropdown
+- Represents the public wrapper that binds trigger content to a floating panel.
+- Fields:
+  - `triggerContent`: user-provided default slot content
+  - `dropdownContent`: custom dropdown slot content, if provided
+  - `options`: optional list of menu options used by the default panel
+  - `isOpen`: current open/closed state
+
+### DropdownOption
+- Represents one selectable entry in the default menu.
+- Fields:
+  - `label`: visible text
+  - `value`: stable option value
+  - `disabled`: optional flag that prevents selection
+
+### DropdownMenu
+- Represents the rendered menu panel shown when no custom dropdown content is supplied.
+- Relationships:
+  - Contains zero or more `DropdownOption` entries
+  - Renders one `DropdownItem` per option
+
+### DropdownItem
+- Represents a single rendered option in the menu.
+- Relationships:
+  - Belongs to one `DropdownMenu`
+  - Reflects a single `DropdownOption`
+
+## Validation Rules
+
+- The default menu only renders when custom dropdown content is absent.
+- Options are rendered in the order provided.
+- Disabled options remain visible but cannot be selected.
+- Empty option lists produce an empty menu state rather than an error.
+
+## State Transitions
+
+- Closed -> Open when the trigger is activated.
+- Open -> Closed when the trigger is activated again, an option is chosen, or the user dismisses the panel.

--- a/specs/016-dropdown-components/plan.md
+++ b/specs/016-dropdown-components/plan.md
@@ -1,0 +1,76 @@
+# Implementation Plan: NyxDropdown Components
+
+**Branch**: `016-dropdown-components` | **Date**: 2026-04-16 | **Spec**: `/home/arnedecant/Projects/nyxkit/nyx-kit/specs/016-dropdown-components/spec.md`
+**Input**: Feature specification from `/specs/016-dropdown-components/spec.md`
+
+## Summary
+
+Add a new dropdown component family with a self-contained trigger wrapper, a default option-rendered panel, and reusable menu/item building blocks. The implementation reuses the shared teleport positioning behavior and is exported through the existing component barrels.
+
+## Technical Context
+
+**Language/Version**: TypeScript + Vue 3  
+**Primary Dependencies**: Vue 3, SCSS, shared Nyx Kit composables and types  
+**Storage**: N/A  
+**Testing**: Vitest, Storybook, Playwright  
+**Target Platform**: Browser-based Vue applications
+**Project Type**: Library  
+**Performance Goals**: Dropdown opens and positions without visible lag during normal interaction  
+**Constraints**: Preserve existing library patterns, use shared positioning behavior, avoid breaking public exports  
+**Scale/Scope**: One new component family with three public exports
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+Pass.
+
+- Docs remain the source of truth and the feature spec was written before implementation.
+- The change is additive and keeps public contracts explicit.
+- The design uses existing component patterns and shared composables rather than introducing a new architecture.
+- Styling will continue to use existing design tokens and component conventions.
+- Tests are required for interactive behavior and story/API coverage.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/016-dropdown-components/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── dropdown-components.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+src/
+├── components/
+│   ├── NyxDropdown/
+│   │   ├── NyxDropdown.vue
+│   │   ├── NyxDropdownMenu.vue
+│   │   ├── NyxDropdownItem.vue
+│   │   ├── NyxDropdown.stories.ts
+│   │   ├── NyxDropdownMenu.stories.ts
+│   │   ├── NyxDropdownItem.stories.ts
+│   │   └── NyxDropdown.spec.ts
+│   └── index.ts
+├── composables/
+│   └── useTeleportPosition.ts
+├── types/
+│   └── select.ts
+└── index.ts
+```
+
+**Structure Decision**: Add a new `src/components/NyxDropdown/` component family with three public exports, reuse the shared teleport positioning composable, and wire the new symbols through the existing component barrel exports.
+
+## Complexity Tracking
+
+> **Fill ONLY if Constitution Check has violations that must be justified**
+
+No constitution violations requiring justification.

--- a/specs/016-dropdown-components/quickstart.md
+++ b/specs/016-dropdown-components/quickstart.md
@@ -1,0 +1,45 @@
+# Quickstart: NyxDropdown Components
+
+## Import
+
+Import the dropdown family from the library’s component exports.
+
+## Default dropdown
+
+```vue
+<script setup lang="ts">
+import { ref } from 'vue'
+import { NyxDropdown } from 'nyx-kit'
+import type { NyxSelectOption } from 'nyx-kit'
+
+const options: NyxSelectOption[] = [
+  { label: 'Edit', value: 'edit' },
+  { label: 'Duplicate', value: 'duplicate' },
+  { label: 'Delete', value: 'delete', disabled: true },
+]
+</script>
+
+<template>
+  <NyxDropdown :options="options">
+    <button type="button">Actions</button>
+  </NyxDropdown>
+</template>
+```
+
+## Custom dropdown content
+
+```vue
+<NyxDropdown>
+  <button type="button">Open menu</button>
+
+  <template #dropdown>
+    <div class="custom-panel">
+      Custom content goes here.
+    </div>
+  </template>
+</NyxDropdown>
+```
+
+## Standalone menu building blocks
+
+Use `NyxDropdownMenu` and `NyxDropdownItem` when you want to build a custom panel while keeping the library’s item styling and selection affordances.

--- a/specs/016-dropdown-components/research.md
+++ b/specs/016-dropdown-components/research.md
@@ -1,0 +1,26 @@
+# Research: NyxDropdown Components
+
+## Decision 1: Public component family
+- Decision: Expose a wrapper component plus separate menu and item components.
+- Rationale: This gives consumers a simple default path while still allowing advanced composition.
+- Alternatives considered: A single monolithic dropdown component; rejected because it would make custom content harder to compose cleanly.
+
+## Decision 2: Default option model
+- Decision: Build the default dropdown menu from the existing select option shape.
+- Rationale: Reusing the same option vocabulary keeps the API consistent across related components and lowers consumer learning cost.
+- Alternatives considered: A new dropdown-specific option schema; rejected because it would duplicate concepts already present in the library.
+
+## Decision 3: Custom dropdown content precedence
+- Decision: If custom dropdown content is supplied, it replaces the default option-rendered panel.
+- Rationale: Consumers need a predictable override path for advanced panels, commands, or mixed content.
+- Alternatives considered: Merging custom content with the default menu; rejected because it is harder to reason about and test.
+
+## Decision 4: Shared positioning behavior
+- Decision: Use the shared teleport-position behavior for the floating panel.
+- Rationale: The dropdown should behave like other floating UI in the library and stay anchored to its trigger as the viewport changes.
+- Alternatives considered: Inline positioning logic inside the component; rejected because it would duplicate existing library behavior.
+
+## Decision 5: Trigger-driven open state
+- Decision: Keep open/close behavior local to the dropdown wrapper and let the trigger control visibility.
+- Rationale: This matches the component’s role as a self-contained interaction pattern and keeps consumer usage simple.
+- Alternatives considered: Requiring external open-state control; rejected because it would make the common case more verbose.

--- a/specs/016-dropdown-components/spec.md
+++ b/specs/016-dropdown-components/spec.md
@@ -1,0 +1,128 @@
+# Feature Specification: NyxDropdown Components
+
+**Feature Branch**: `016-dropdown-components`  
+**Created**: 2026-04-16  
+**Status**: Draft  
+**Input**: User description: "Add a NyxDropdown with a trigger slot, an optional custom dropdown slot, and a default option-based menu exposed through NyxDropdown, NyxDropdownMenu, and NyxDropdownItem."
+
+## User Scenarios & Testing *(mandatory)*
+
+<!--
+  IMPORTANT: User stories should be PRIORITIZED as user journeys ordered by importance.
+  Each user story/journey must be INDEPENDENTLY TESTABLE - meaning if you implement just ONE of them,
+  you should still have a viable MVP (Minimum Viable Product) that delivers value.
+  
+  Assign priorities (P1, P2, P3, etc.) to each story, where P1 is the most critical.
+  Think of each story as a standalone slice of functionality that can be:
+  - Developed independently
+  - Tested independently
+  - Deployed independently
+  - Demonstrated to users independently
+-->
+
+### User Story 1 - Triggered Dropdown (Priority: P1)
+
+A developer can wrap any trigger content in a dropdown so users can open the panel from a visible control.
+
+**Why this priority**: The trigger is the entry point for the entire component and delivers the core value of the feature.
+
+**Independent Test**: Render the component with trigger content and verify that activating the trigger opens and closes the panel.
+
+**Acceptance Scenarios**:
+
+1. **Given** trigger content is provided, **When** the trigger is activated, **Then** the dropdown panel becomes visible beside the trigger.
+2. **Given** the dropdown is open, **When** the trigger is activated again, **Then** the dropdown panel closes.
+
+---
+
+### User Story 2 - Default Menu Options (Priority: P2)
+
+A developer can supply a list of select-style options and get a ready-made menu without building item markup manually.
+
+**Why this priority**: Most dropdowns need a standard menu, so the built-in option rendering should be available immediately after the trigger behavior.
+
+**Independent Test**: Render the component with an options array and verify that each option appears as an item in the default panel.
+
+**Acceptance Scenarios**:
+
+1. **Given** an options array is provided and no custom dropdown content is supplied, **When** the dropdown opens, **Then** each option is rendered as a menu item.
+2. **Given** an option is marked as disabled, **When** the dropdown opens, **Then** the option is shown but cannot be selected.
+
+---
+
+### User Story 3 - Custom Dropdown Content (Priority: P3)
+
+A developer can replace the default menu with arbitrary content while keeping the same trigger and positioning behavior.
+
+**Why this priority**: Custom content is important for advanced use cases, but the default menu is the primary path.
+
+**Independent Test**: Render the component with custom dropdown content and verify that the custom content appears instead of the default menu.
+
+**Acceptance Scenarios**:
+
+1. **Given** custom dropdown content is provided, **When** the dropdown opens, **Then** the custom content is shown in the panel.
+2. **Given** custom dropdown content is provided, **When** the panel is rendered, **Then** the default option-based menu is not rendered.
+
+---
+
+### Edge Cases
+
+- An empty options array still opens a panel, but no menu items are shown.
+- Disabled options remain visible but do not respond to selection.
+- Long labels remain readable without forcing the panel off-screen.
+- A custom dropdown panel can be larger than the trigger and still remain anchored to it.
+- Trigger content can be any valid interactive or non-interactive element.
+
+## Assumptions
+
+- Opening and closing the dropdown is handled by the component itself when the trigger is activated.
+- The default dropdown panel closes after an option is chosen.
+- `NyxDropdownMenu` and `NyxDropdownItem` are publicly usable building blocks, but they are primarily intended to support the default dropdown panel.
+- Each option provides a visible label, a stable value, and an optional disabled state.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The library MUST expose `NyxDropdown`, `NyxDropdownMenu`, and `NyxDropdownItem` as public components.
+- **FR-002**: `NyxDropdown` MUST render its default slot as the trigger region.
+- **FR-003**: `NyxDropdown` MUST render the `dropdown` slot when it is provided.
+- **FR-004**: When no `dropdown` slot is provided, `NyxDropdown` MUST render a default panel built from the provided options data.
+- **FR-005**: `NyxDropdown` MUST accept theme, size, and variant props and forward them to the default menu.
+- **FR-006**: The default panel MUST render one `NyxDropdownItem` per provided option.
+- **FR-007**: Each option MUST preserve its visible label, value, and disabled state in the rendered menu.
+- **FR-008**: Disabled options MUST be visible but not selectable.
+- **FR-009**: The dropdown panel MUST stay anchored to the trigger and remain within the visible screen area during common viewport changes.
+- **FR-010**: Developers MUST be able to replace the default menu with custom dropdown content without changing the trigger markup.
+- **FR-011**: `NyxDropdownMenu` and `NyxDropdownItem` MUST be usable independently for custom dropdown compositions.
+
+### Key Entities *(include if feature involves data)*
+
+- **Dropdown Trigger**: The content shown in the default slot that opens and closes the panel.
+- **Dropdown Panel**: The floating content area shown beside the trigger.
+- **Dropdown Option**: A selectable entry defined by label, value, and disabled state.
+- **Dropdown Menu**: The default option-rendering panel used when custom dropdown content is not supplied.
+- **Dropdown Item**: The visual representation of one option inside the menu.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A developer can build a dropdown with a custom trigger and default option list without creating separate positioning logic.
+- **SC-002**: In representative testing, 100% of supplied options appear in the default menu with the correct labels and disabled state.
+- **SC-003**: In representative desktop and mobile viewport tests, the dropdown remains attached to its trigger and stays visible at the screen edges.
+- **SC-004**: A developer can replace the default menu with custom dropdown content and still reuse the same trigger wrapper in a single component.
+
+## Keyboard Behaviour
+
+- `Esc` closes an open dropdown.
+- `ArrowDown` and `ArrowUp` move through visible dropdown items when the menu is open.
+- `Enter` and `Space` activate the focused item or toggle the dropdown when the trigger is focused.
+- Keyboard interaction must not prevent custom trigger content from handling its own semantics.
+
+## Accessibility
+
+- The trigger must remain a real interactive control or contain one.
+- The dropdown panel must expose its expanded/collapsed state to assistive technologies.
+- Disabled menu items must remain discoverable but should not be focusable as active choices.
+- Custom dropdown content must still be reachable by keyboard if the consumer makes it interactive.

--- a/specs/016-dropdown-components/tasks.md
+++ b/specs/016-dropdown-components/tasks.md
@@ -1,0 +1,165 @@
+---
+
+description: "Task list for NyxDropdown Components"
+---
+
+# Tasks: NyxDropdown Components
+
+**Input**: Design documents from `/specs/016-dropdown-components/`
+**Prerequisites**: plan.md (required), spec.md (required for user stories), research.md, data-model.md, contracts/, quickstart.md
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Project initialization and component-family scaffold
+
+- [X] T001 [P] Create the NyxDropdown component folder and source files in `src/components/NyxDropdown/NyxDropdown.vue`, `src/components/NyxDropdown/NyxDropdownMenu.vue`, and `src/components/NyxDropdown/NyxDropdownItem.vue`
+- [X] T002 [P] Create the initial Storybook story files in `src/components/NyxDropdown/NyxDropdown.stories.ts`, `src/components/NyxDropdown/NyxDropdownMenu.stories.ts`, and `src/components/NyxDropdown/NyxDropdownItem.stories.ts`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Shared contracts and exports required before any user story can be completed
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete
+
+- [X] T003 [P] Define the shared dropdown props and emitted selection shape in `src/components/NyxDropdown/NyxDropdown.types.ts`
+- [X] T004 [P] Add the shared dropdown styling scaffold in `src/components/NyxDropdown/NyxDropdown.scss`
+- [X] T005 Update `src/components/index.ts` to export `NyxDropdown`, `NyxDropdownMenu`, and `NyxDropdownItem`
+
+**Checkpoint**: Dropdown family is scaffolded and publicly exported; story work can now begin
+
+---
+
+## Phase 3: User Story 1 - Triggered Dropdown (Priority: P1) 🎯 MVP
+
+**Goal**: Let consumers wrap any trigger content and toggle the floating dropdown panel.
+
+**Independent Test**: Render `NyxDropdown` with a custom trigger and verify the panel opens, closes, and stays anchored to the trigger.
+
+### Implementation for User Story 1
+
+- [X] T006 [US1] Implement trigger-slot rendering and open/close state in `src/components/NyxDropdown/NyxDropdown.vue`
+- [X] T007 [P] [US1] Add teleported panel positioning and outside-dismiss behavior in `src/components/NyxDropdown/NyxDropdown.vue` using `useTeleportPosition`
+- [X] T008 [US1] Add the trigger-driven dropdown usage example in `src/components/NyxDropdown/NyxDropdown.stories.ts`
+
+**Checkpoint**: Trigger-driven dropdown interaction works on its own
+
+---
+
+## Phase 4: User Story 2 - Default Menu Options (Priority: P2)
+
+**Goal**: Render a default option-based menu when no custom dropdown slot is provided.
+
+**Independent Test**: Render `NyxDropdown` with an `options` array and confirm each option appears as a selectable menu item with disabled states preserved.
+
+### Implementation for User Story 2
+
+- [X] T009 [P] [US2] Implement option-to-item rendering in `src/components/NyxDropdown/NyxDropdownMenu.vue`
+- [X] T010 [P] [US2] Implement the individual item rendering and disabled presentation in `src/components/NyxDropdown/NyxDropdownItem.vue`
+- [X] T011 [US2] Wire `src/components/NyxDropdown/NyxDropdown.vue` to render `NyxDropdownMenu` when no `#dropdown` slot is supplied
+- [X] T012 [US2] Add the default option-menu examples in `src/components/NyxDropdown/NyxDropdown.stories.ts` and `src/components/NyxDropdown/NyxDropdownMenu.stories.ts`
+
+**Checkpoint**: Default option-driven dropdown works independently of custom panel content
+
+---
+
+## Phase 5: User Story 3 - Custom Dropdown Content (Priority: P3)
+
+**Goal**: Allow consumers to replace the default menu with arbitrary panel content while still reusing the same wrapper.
+
+**Independent Test**: Render `NyxDropdown` with a custom `#dropdown` slot and confirm the custom panel replaces the default menu while the trigger behavior remains unchanged.
+
+### Implementation for User Story 3
+
+- [X] T013 [P] [US3] Implement the `#dropdown` slot override path in `src/components/NyxDropdown/NyxDropdown.vue`
+- [X] T014 [P] [US3] Keep `NyxDropdownMenu` and `NyxDropdownItem` usable as standalone building blocks in `src/components/NyxDropdown/NyxDropdownMenu.vue` and `src/components/NyxDropdown/NyxDropdownItem.vue`
+- [X] T015 [US3] Add the custom-panel and standalone-building-block examples in `src/components/NyxDropdown/NyxDropdownMenu.stories.ts` and `src/components/NyxDropdown/NyxDropdownItem.stories.ts`
+
+**Checkpoint**: Custom panel composition works independently from the default menu path
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final consistency and documentation alignment
+
+- [X] T016 [P] Update `docs/specs/components/NyxDropdown.spec.md`, `docs/specs/components/NyxDropdownMenu.spec.md`, and `docs/specs/components/NyxDropdownItem.spec.md` if implementation changes any documented contract details
+- [X] T017 Confirm the public component surface is aligned in `src/components/index.ts` and the shared option type remains available through `src/types/index.ts`
+- [X] T018 Verify the feature compiles cleanly with `pnpm type-check` and fix any typing issues introduced by the dropdown family in `src/components/NyxDropdown/*.vue` and `src/components/NyxDropdown/*.ts`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies - can start immediately
+- **Foundational (Phase 2)**: Depends on Setup completion - blocks all user stories
+- **User Stories (Phase 3+)**: Depend on Foundational phase completion
+- **Polish (Final Phase)**: Depends on all desired user stories being complete
+
+### User Story Dependencies
+
+- **User Story 1 (P1)**: Can start after Foundational (Phase 2) - no dependencies on other stories
+- **User Story 2 (P2)**: Can start after Foundational (Phase 2) - may build on US1 wrapper, but remains independently testable
+- **User Story 3 (P3)**: Can start after Foundational (Phase 2) - reuses the same wrapper but remains independently testable
+
+### Within Each User Story
+
+- Shared scaffolding before story-specific implementation
+- Wrapper behavior before menu composition
+- Default menu before custom panel override
+- Story complete before moving to the next priority
+
+### Parallel Opportunities
+
+- T001 and T002 can run in parallel during setup
+- T003 and T004 can run in parallel during foundation work
+- T007 can run in parallel with T006 after the wrapper exists
+- T009 and T010 can run in parallel during default menu work
+- T013 and T014 can run in parallel during custom panel work
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+Task: "Implement trigger-slot rendering and open/close state in src/components/NyxDropdown/NyxDropdown.vue"
+Task: "Add teleported panel positioning and outside-dismiss behavior in src/components/NyxDropdown/NyxDropdown.vue using useTeleportPosition"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup
+2. Complete Phase 2: Foundational
+3. Complete Phase 3: User Story 1
+4. Stop and validate the trigger-driven dropdown on its own
+
+### Incremental Delivery
+
+1. Complete Setup + Foundational
+2. Add User Story 1 for the core wrapper interaction
+3. Add User Story 2 for the default menu path
+4. Add User Story 3 for custom dropdown composition
+5. Finish with polish and contract alignment
+
+### Parallel Team Strategy
+
+With multiple developers:
+
+1. One developer can scaffold the component files while another prepares the shared props and styles
+2. After foundation work, one developer can finish the wrapper interaction while another builds the default menu pieces
+3. Custom panel support can proceed once the wrapper and menu building blocks are stable

--- a/src/components/NyxButtonGroup/NyxButtonGroup.stories.ts
+++ b/src/components/NyxButtonGroup/NyxButtonGroup.stories.ts
@@ -1,0 +1,63 @@
+import { defineComponent } from 'vue'
+import type { Meta, StoryObj } from '@storybook/vue3'
+import NyxButtonGroup from './NyxButtonGroup.vue'
+import NyxButton from '../NyxButton/NyxButton.vue'
+import { NyxDirection, NyxVariant } from '@/types'
+import type { NyxButtonGroupProps } from './NyxButtonGroup.types'
+
+const labels = ['Primary', 'Secondary', 'Tertiary']
+
+const meta = {
+  title: 'Components/NyxButtonGroup',
+  component: NyxButtonGroup,
+  argTypes: {
+    direction: {
+      control: { type: 'select' },
+      options: Object.values(NyxDirection),
+    },
+    variant: {
+      control: { type: 'select' },
+      options: [NyxVariant.Soft, NyxVariant.Ghost],
+    },
+  },
+  args: {
+    direction: NyxDirection.Horizontal,
+    variant: NyxVariant.Ghost,
+  },
+} satisfies Meta<typeof NyxButtonGroup>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+const renderGroup = (args: NyxButtonGroupProps) => defineComponent({
+  components: { NyxButtonGroup, NyxButton },
+  setup () {
+    return { args, labels }
+  },
+  template: `
+    <nyx-button-group v-bind="args">
+      <nyx-button v-for="label in labels" :key="label">
+        {{ label }}
+      </nyx-button>
+    </nyx-button-group>
+  `,
+})
+
+export const Default: Story = {
+  render: (args: NyxButtonGroupProps) => renderGroup(args),
+}
+
+export const Vertical: Story = {
+  args: {
+    direction: NyxDirection.Vertical,
+  },
+  render: (args: NyxButtonGroupProps) => renderGroup(args),
+}
+
+export const Soft: Story = {
+  args: {
+    variant: NyxVariant.Soft,
+  },
+  render: (args: NyxButtonGroupProps) => renderGroup(args),
+}

--- a/src/components/NyxDropdown/NyxDropdown.scss
+++ b/src/components/NyxDropdown/NyxDropdown.scss
@@ -236,4 +236,9 @@
     opacity: 0.5;
     background-color: transparent;
   }
+
+  .nyx-icon {
+    flex-shrink: 0;
+    margin-right: var(--nyx-gap-dropdown);
+  }
 }

--- a/src/components/NyxDropdown/NyxDropdown.scss
+++ b/src/components/NyxDropdown/NyxDropdown.scss
@@ -1,0 +1,286 @@
+.nyx-dropdown,
+.nyx-dropdown__panel,
+.nyx-dropdown-menu,
+.nyx-dropdown-item {
+  --nyx-c-dropdown-text: var(--nyx-c-white-soft);
+  --nyx-c-dropdown: var(--nyx-c-default);
+  --nyx-c-dropdown-highlight: var(--nyx-c-default-highlight);
+  --nyx-c-dropdown-alt: var(--nyx-c-default-alt);
+  --nyx-rgb-dropdown: var(--nyx-rgb-default);
+  --nyx-gap-dropdown: var(--nyx-gap-md);
+  --nyx-pad-dropdown: var(--nyx-pad-md);
+  --nyx-font-size-dropdown: var(--nyx-font-size-md);
+  --nyx-border-size-dropdown: 1px;
+  --nyx-radius-dropdown: var(--nyx-radius-md);
+}
+
+.nyx-dropdown,
+.nyx-dropdown__panel,
+.nyx-dropdown-menu {
+  &.theme-primary {
+    --nyx-c-dropdown: var(--nyx-c-primary);
+    --nyx-c-dropdown-highlight: var(--nyx-c-primary-highlight);
+    --nyx-c-dropdown-alt: var(--nyx-c-primary-alt);
+    --nyx-rgb-dropdown: var(--nyx-rgb-primary);
+  }
+
+  &.theme-secondary {
+    --nyx-c-dropdown: var(--nyx-c-secondary);
+    --nyx-c-dropdown-highlight: var(--nyx-c-secondary-highlight);
+    --nyx-c-dropdown-alt: var(--nyx-c-secondary-alt);
+    --nyx-rgb-dropdown: var(--nyx-rgb-secondary);
+  }
+
+  &.theme-info {
+    --nyx-c-dropdown: var(--nyx-c-info);
+    --nyx-c-dropdown-highlight: var(--nyx-c-info-highlight);
+    --nyx-c-dropdown-alt: var(--nyx-c-info-alt);
+    --nyx-rgb-dropdown: var(--nyx-rgb-info);
+  }
+
+  &.theme-success {
+    --nyx-c-dropdown: var(--nyx-c-success);
+    --nyx-c-dropdown-highlight: var(--nyx-c-success-highlight);
+    --nyx-c-dropdown-alt: var(--nyx-c-success-alt);
+    --nyx-rgb-dropdown: var(--nyx-rgb-success);
+  }
+
+  &.theme-warning {
+    --nyx-c-dropdown: var(--nyx-c-warning);
+    --nyx-c-dropdown-highlight: var(--nyx-c-warning-highlight);
+    --nyx-c-dropdown-alt: var(--nyx-c-warning-alt);
+    --nyx-rgb-dropdown: var(--nyx-rgb-warning);
+  }
+
+  &.theme-danger {
+    --nyx-c-dropdown: var(--nyx-c-danger);
+    --nyx-c-dropdown-highlight: var(--nyx-c-danger-highlight);
+    --nyx-c-dropdown-alt: var(--nyx-c-danger-alt);
+    --nyx-rgb-dropdown: var(--nyx-rgb-danger);
+  }
+
+  &.size-xs {
+    --nyx-gap-dropdown: var(--nyx-gap-xs);
+    --nyx-pad-dropdown: var(--nyx-pad-xs);
+    --nyx-font-size-dropdown: var(--nyx-font-size-xs);
+    --nyx-border-size-dropdown: 1px;
+  }
+
+  &.size-sm {
+    --nyx-gap-dropdown: var(--nyx-gap-sm);
+    --nyx-pad-dropdown: var(--nyx-pad-sm);
+    --nyx-font-size-dropdown: var(--nyx-font-size-sm);
+    --nyx-border-size-dropdown: 1px;
+  }
+
+  &.size-lg {
+    --nyx-gap-dropdown: var(--nyx-gap-lg);
+    --nyx-pad-dropdown: var(--nyx-pad-lg);
+    --nyx-font-size-dropdown: var(--nyx-font-size-lg);
+    --nyx-border-size-dropdown: 2px;
+  }
+
+  &.size-xl {
+    --nyx-gap-dropdown: var(--nyx-gap-xl);
+    --nyx-pad-dropdown: var(--nyx-pad-xl);
+    --nyx-font-size-dropdown: var(--nyx-font-size-xl);
+    --nyx-border-size-dropdown: 3px;
+  }
+}
+
+.nyx-dropdown {
+  display: inline-flex;
+  align-items: flex-start;
+  justify-content: flex-start;
+
+  &__trigger {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    outline: none;
+
+    &:focus-visible {
+      outline: 2px solid var(--nyx-c-dropdown-highlight);
+      outline-offset: 2px;
+    }
+  }
+
+  &__panel {
+    position: fixed;
+    top: var(--top, 0);
+    left: var(--left, 0);
+    width: var(--width, auto);
+    z-index: var(--nyx-z-index-overlay);
+    opacity: 0;
+    transform: translateY(-0.75rem);
+    pointer-events: none;
+    transition: opacity 0.2s, transform 0.2s;
+
+    &--open {
+      opacity: 1;
+      transform: translateY(0);
+      pointer-events: all;
+    }
+
+    &--top {
+      transform: translateY(0.75rem);
+    }
+
+    &--open.nyx-dropdown__panel--top {
+      transform: translateY(0);
+    }
+
+    &[data-position^="top"] {
+      transform: translateY(0.75rem);
+    }
+
+    &[data-position^="bottom"] {
+      transform: translateY(-0.75rem);
+    }
+
+    &[data-position^="left"] {
+      transform: translateX(0.75rem);
+    }
+
+    &[data-position^="right"] {
+      transform: translateX(-0.75rem);
+    }
+  }
+}
+
+.nyx-dropdown-menu {
+  display: flex;
+  flex-direction: column;
+  min-width: 10rem;
+  overflow: hidden;
+  font-size: var(--nyx-font-size-dropdown);
+  background-color: var(--nyx-c-dropdown);
+  border: var(--nyx-border-size-dropdown) solid var(--nyx-c-dropdown);
+  border-radius: var(--nyx-radius-dropdown);
+  box-shadow: var(--nyx-shadow-md);
+  position: relative;
+
+  &::after {
+    content: '';
+    position: absolute;
+    z-index: -1;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: var(--nyx-c-bg);
+  }
+
+  &.variant-outline {
+    background-color: transparent;
+    color: var(--nyx-c-dropdown-alt);
+    border-color: rgba(var(--nyx-rgb-dropdown), 0.4);
+  }
+
+  &.variant-ghost {
+    background-color: transparent;
+    border-color: transparent;
+    color: var(--nyx-c-dropdown-alt);
+  }
+
+  &.variant-soft {
+    background-color: rgba(var(--nyx-rgb-dropdown), 0.24);
+    border-color: transparent;
+    color: var(--nyx-c-dropdown-alt);
+  }
+
+  &.variant-subtle {
+    background-color: rgba(var(--nyx-rgb-dropdown), 0.12);
+    border-color: transparent;
+    color: var(--nyx-c-dropdown-alt);
+  }
+
+  &.variant-text {
+    background-color: transparent;
+    border-color: transparent;
+    color: var(--nyx-c-dropdown-highlight);
+  }
+}
+
+.nyx-dropdown__panel-transition-enter-active,
+.nyx-dropdown__panel-transition-leave-active {
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.nyx-dropdown__panel-transition-enter-from,
+.nyx-dropdown__panel-transition-leave-to {
+  opacity: 0;
+}
+
+.nyx-dropdown__panel-transition-enter-to,
+.nyx-dropdown__panel-transition-leave-from {
+  opacity: 1;
+}
+
+.nyx-dropdown__panel-transition-enter-from[data-position^="top"],
+.nyx-dropdown__panel-transition-leave-to[data-position^="bottom"] {
+  transform: translateY(0.75rem);
+}
+
+.nyx-dropdown__panel-transition-enter-from[data-position^="bottom"],
+.nyx-dropdown__panel-transition-leave-to[data-position^="top"] {
+  transform: translateY(-0.75rem);
+}
+
+.nyx-dropdown__panel-transition-enter-from[data-position^="left"],
+.nyx-dropdown__panel-transition-leave-to[data-position^="right"] {
+  transform: translateX(0.75rem);
+}
+
+.nyx-dropdown__panel-transition-enter-from[data-position^="right"],
+.nyx-dropdown__panel-transition-leave-to[data-position^="left"] {
+  transform: translateX(-0.75rem);
+}
+
+.nyx-dropdown__panel-transition-enter-to,
+.nyx-dropdown__panel-transition-leave-from {
+  transform: translate(0, 0);
+}
+
+.nyx-dropdown-item {
+  appearance: none;
+  display: flex;
+  align-items: center;
+  width: 100%;
+  padding: calc(var(--nyx-pad-dropdown) * 0.75) var(--nyx-pad-dropdown);
+  border: 0;
+  background: transparent;
+  color: var(--nyx-c-dropdown-text);
+  font: inherit;
+  text-align: left;
+  line-height: 1;
+  cursor: pointer;
+  transition: background-color 0.2s, color 0.2s;
+
+  .nyx-dropdown-menu.variant-outline &,
+  .nyx-dropdown-menu.variant-ghost &,
+  .nyx-dropdown-menu.variant-soft &,
+  .nyx-dropdown-menu.variant-subtle &,
+  .nyx-dropdown-menu.variant-text & {
+    color: var(--nyx-c-dropdown-alt);
+  }
+
+  &:hover,
+  &:focus-visible {
+    background-color: rgba(var(--nyx-rgb-dropdown), 0.16);
+    outline: none;
+  }
+
+  .nyx-dropdown-menu.variant-text &:hover,
+  .nyx-dropdown-menu.variant-text &:focus-visible {
+    background-color: rgba(var(--nyx-rgb-dropdown), 0.12);
+  }
+
+  &--disabled,
+  &:disabled {
+    cursor: not-allowed;
+    opacity: 0.5;
+    background-color: transparent;
+  }
+}

--- a/src/components/NyxDropdown/NyxDropdown.scss
+++ b/src/components/NyxDropdown/NyxDropdown.scss
@@ -113,38 +113,31 @@
     width: var(--width, auto);
     z-index: var(--nyx-z-index-overlay);
     opacity: 0;
-    transform: translateY(-0.75rem);
     pointer-events: none;
-    transition: opacity 0.2s, transform 0.2s;
-
-    &--open {
-      opacity: 1;
-      transform: translateY(0);
-      pointer-events: all;
-    }
-
-    &--top {
-      transform: translateY(0.75rem);
-    }
-
-    &--open.nyx-dropdown__panel--top {
-      transform: translateY(0);
-    }
+    visibility: hidden;
+    transition: opacity 0.2s, transform 0.2s, visibility 0.2s;
 
     &[data-position^="top"] {
-      transform: translateY(0.75rem);
-    }
-
-    &[data-position^="bottom"] {
       transform: translateY(-0.75rem);
     }
 
+    &[data-position^="bottom"] {
+      transform: translateY(0.75rem);
+    }
+
     &[data-position^="left"] {
-      transform: translateX(0.75rem);
+      transform: translateX(-0.75rem);
     }
 
     &[data-position^="right"] {
-      transform: translateX(-0.75rem);
+      transform: translateX(0.75rem);
+    }
+
+    &.nyx-dropdown__panel--open[data-position] {
+      opacity: 1;
+      transform: translate(0, 0);
+      pointer-events: all;
+      visibility: visible;
     }
   }
 }
@@ -158,7 +151,7 @@
   background-color: var(--nyx-c-dropdown);
   border: var(--nyx-border-size-dropdown) solid var(--nyx-c-dropdown);
   border-radius: var(--nyx-radius-dropdown);
-  box-shadow: var(--nyx-shadow-md);
+  box-shadow: var(--nyx-shadow-sm);
   position: relative;
 
   &::after {
@@ -201,46 +194,6 @@
     border-color: transparent;
     color: var(--nyx-c-dropdown-highlight);
   }
-}
-
-.nyx-dropdown__panel-transition-enter-active,
-.nyx-dropdown__panel-transition-leave-active {
-  transition: opacity 0.2s ease, transform 0.2s ease;
-}
-
-.nyx-dropdown__panel-transition-enter-from,
-.nyx-dropdown__panel-transition-leave-to {
-  opacity: 0;
-}
-
-.nyx-dropdown__panel-transition-enter-to,
-.nyx-dropdown__panel-transition-leave-from {
-  opacity: 1;
-}
-
-.nyx-dropdown__panel-transition-enter-from[data-position^="top"],
-.nyx-dropdown__panel-transition-leave-to[data-position^="bottom"] {
-  transform: translateY(0.75rem);
-}
-
-.nyx-dropdown__panel-transition-enter-from[data-position^="bottom"],
-.nyx-dropdown__panel-transition-leave-to[data-position^="top"] {
-  transform: translateY(-0.75rem);
-}
-
-.nyx-dropdown__panel-transition-enter-from[data-position^="left"],
-.nyx-dropdown__panel-transition-leave-to[data-position^="right"] {
-  transform: translateX(0.75rem);
-}
-
-.nyx-dropdown__panel-transition-enter-from[data-position^="right"],
-.nyx-dropdown__panel-transition-leave-to[data-position^="left"] {
-  transform: translateX(-0.75rem);
-}
-
-.nyx-dropdown__panel-transition-enter-to,
-.nyx-dropdown__panel-transition-leave-from {
-  transform: translate(0, 0);
 }
 
 .nyx-dropdown-item {

--- a/src/components/NyxDropdown/NyxDropdown.spec.ts
+++ b/src/components/NyxDropdown/NyxDropdown.spec.ts
@@ -40,11 +40,14 @@ describe('NyxDropdown', () => {
     })
 
     await wrapper.get('.nyx-dropdown__trigger').trigger('click')
-    expect(document.body.querySelector('.nyx-dropdown__panel')).not.toBeNull()
+    const panel = document.body.querySelector('.nyx-dropdown__panel')
+    expect(panel).not.toBeNull()
+    expect(panel?.className).toContain('nyx-dropdown__panel--open')
 
     await wrapper.get('.nyx-dropdown__trigger').trigger('click')
     await nextTick()
-    expect(document.body.querySelector('.nyx-dropdown__panel')).toBeNull()
+    expect(document.body.querySelector('.nyx-dropdown__panel')).not.toBeNull()
+    expect(document.body.querySelector('.nyx-dropdown__panel')?.className).not.toContain('nyx-dropdown__panel--open')
   })
 
   it('renders the default option menu when no custom dropdown slot is provided', async () => {
@@ -112,7 +115,7 @@ describe('NyxDropdown', () => {
     document.body.dispatchEvent(new MouseEvent('click', { bubbles: true }))
     await nextTick()
 
-    expect(document.body.querySelector('.nyx-dropdown__panel')).toBeNull()
+    expect(document.body.querySelector('.nyx-dropdown__panel')?.className).not.toContain('nyx-dropdown__panel--open')
   })
 
   it('forwards theme, size, and variant props to the default menu', async () => {
@@ -168,7 +171,7 @@ describe('NyxDropdown', () => {
     await nextTick()
 
     expect(wrapper.emitted('select')?.[0]?.[0]).toEqual(sampleOptions[0])
-    expect(document.body.querySelector('.nyx-dropdown__panel')).toBeNull()
+    expect(document.body.querySelector('.nyx-dropdown__panel')?.className).not.toContain('nyx-dropdown__panel--open')
   })
 
   it('renders custom dropdown content when the dropdown slot is provided', async () => {

--- a/src/components/NyxDropdown/NyxDropdown.spec.ts
+++ b/src/components/NyxDropdown/NyxDropdown.spec.ts
@@ -1,0 +1,190 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { nextTick } from 'vue'
+import NyxDropdown from './NyxDropdown.vue'
+import { NyxPosition, NyxSize, NyxTheme, NyxTrigger, NyxVariant } from '@/types'
+
+const sampleOptions = [
+  { label: 'Edit', value: 'edit' },
+  { label: 'Duplicate', value: 'duplicate' },
+  { label: 'Delete', value: 'delete', disabled: true },
+]
+
+let wrapper: ReturnType<typeof mount>
+
+beforeEach(() => {
+  vi.spyOn(console, 'warn').mockImplementation(() => {})
+  vi.stubGlobal('matchMedia', vi.fn(() => ({
+    matches: true,
+    media: '',
+    onchange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })))
+})
+
+afterEach(() => {
+  wrapper?.unmount()
+  vi.unstubAllGlobals()
+})
+
+describe('NyxDropdown', () => {
+  it('opens and closes when the trigger is activated', async () => {
+    wrapper = mount(NyxDropdown, {
+      attachTo: document.body,
+      props: { options: sampleOptions },
+      slots: { default: '<button type="button">Actions</button>' },
+    })
+
+    await wrapper.get('.nyx-dropdown__trigger').trigger('click')
+    expect(document.body.querySelector('.nyx-dropdown__panel')).not.toBeNull()
+
+    await wrapper.get('.nyx-dropdown__trigger').trigger('click')
+    await nextTick()
+    expect(document.body.querySelector('.nyx-dropdown__panel')).toBeNull()
+  })
+
+  it('renders the default option menu when no custom dropdown slot is provided', async () => {
+    wrapper = mount(NyxDropdown, {
+      attachTo: document.body,
+      props: { options: sampleOptions },
+      slots: { default: '<button type="button">Actions</button>' },
+    })
+
+    await wrapper.get('.nyx-dropdown__trigger').trigger('click')
+    await nextTick()
+
+    const items = document.body.querySelectorAll('.nyx-dropdown-item')
+    expect(items.length).toBe(3)
+    expect(items[0].textContent).toContain('Edit')
+  })
+
+  it('opens on hover when hover is supported', async () => {
+    wrapper = mount(NyxDropdown, {
+      attachTo: document.body,
+      props: { options: sampleOptions, trigger: NyxTrigger.Hover },
+      slots: { default: '<button type="button">Actions</button>' },
+    })
+
+    await wrapper.get('.nyx-dropdown__trigger').trigger('pointerenter')
+    await nextTick()
+
+    expect(document.body.querySelector('.nyx-dropdown__panel')).not.toBeNull()
+  })
+
+  it('falls back to click when hover is unavailable', async () => {
+    vi.stubGlobal('matchMedia', vi.fn(() => ({
+      matches: false,
+      media: '',
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })))
+
+    wrapper = mount(NyxDropdown, {
+      attachTo: document.body,
+      props: { options: sampleOptions, trigger: NyxTrigger.Hover },
+      slots: { default: '<button type="button">Actions</button>' },
+    })
+
+    await wrapper.get('.nyx-dropdown__trigger').trigger('click')
+    await nextTick()
+
+    expect(document.body.querySelector('.nyx-dropdown__panel')).not.toBeNull()
+  })
+
+  it('closes when clicking outside the dropdown', async () => {
+    wrapper = mount(NyxDropdown, {
+      attachTo: document.body,
+      props: { options: sampleOptions, trigger: NyxTrigger.Click },
+      slots: { default: '<button type="button">Actions</button>' },
+    })
+
+    await wrapper.get('.nyx-dropdown__trigger').trigger('click')
+    await nextTick()
+
+    document.body.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await nextTick()
+
+    expect(document.body.querySelector('.nyx-dropdown__panel')).toBeNull()
+  })
+
+  it('forwards theme, size, and variant props to the default menu', async () => {
+    wrapper = mount(NyxDropdown, {
+      attachTo: document.body,
+      props: {
+        options: sampleOptions,
+        theme: NyxTheme.Secondary,
+        size: NyxSize.Small,
+        variant: NyxVariant.Outline,
+      },
+      slots: { default: '<button type="button">Actions</button>' },
+    })
+
+    await wrapper.get('.nyx-dropdown__trigger').trigger('click')
+    await nextTick()
+
+    const menu = document.body.querySelector('.nyx-dropdown-menu')
+    expect(menu?.className).toContain('theme-secondary')
+    expect(menu?.className).toContain('size-sm')
+    expect(menu?.className).toContain('variant-outline')
+  })
+
+  it('forwards the position prop to the teleported panel', async () => {
+    wrapper = mount(NyxDropdown, {
+      attachTo: document.body,
+      props: {
+        options: sampleOptions,
+        position: NyxPosition.Top,
+      },
+      slots: { default: '<button type="button">Actions</button>' },
+    })
+
+    await wrapper.get('.nyx-dropdown__trigger').trigger('click')
+    await nextTick()
+
+    const panel = document.body.querySelector('.nyx-dropdown__panel')
+    expect(panel?.getAttribute('data-position')).toBe('top')
+  })
+
+  it('emits select and closes when a menu item is activated', async () => {
+    wrapper = mount(NyxDropdown, {
+      attachTo: document.body,
+      props: { options: sampleOptions },
+      slots: { default: '<button type="button">Actions</button>' },
+    })
+
+    await wrapper.get('.nyx-dropdown__trigger').trigger('click')
+    await nextTick()
+
+    const firstItem = document.body.querySelector<HTMLButtonElement>('.nyx-dropdown-item')
+    firstItem?.click()
+    await nextTick()
+
+    expect(wrapper.emitted('select')?.[0]?.[0]).toEqual(sampleOptions[0])
+    expect(document.body.querySelector('.nyx-dropdown__panel')).toBeNull()
+  })
+
+  it('renders custom dropdown content when the dropdown slot is provided', async () => {
+    wrapper = mount(NyxDropdown, {
+      attachTo: document.body,
+      props: { options: sampleOptions },
+      slots: {
+        default: '<button type="button">Actions</button>',
+        dropdown: '<div class="custom-panel">Custom content</div>',
+      },
+    })
+
+    await wrapper.get('.nyx-dropdown__trigger').trigger('click')
+    await nextTick()
+
+    expect(document.body.querySelector('.custom-panel')).not.toBeNull()
+    expect(document.body.querySelector('.nyx-dropdown-item')).toBeNull()
+  })
+})

--- a/src/components/NyxDropdown/NyxDropdown.stories.ts
+++ b/src/components/NyxDropdown/NyxDropdown.stories.ts
@@ -1,0 +1,113 @@
+import { defineComponent, onMounted, ref } from 'vue'
+import NyxDropdown from './NyxDropdown.vue'
+import { NyxTheme, NyxVariant, NyxSize, NyxTrigger, NyxPosition, type KeyDict } from '@/types'
+import { getKeyDictKeyByValue } from '@/utils'
+import type { NyxDropdownProps } from './NyxDropdown.types'
+
+const sampleOptions = [
+  { label: 'Edit', value: 'edit' },
+  { label: 'Duplicate', value: 'duplicate' },
+  { label: 'Delete', value: 'delete', disabled: true },
+]
+
+export default {
+  title: 'Components/NyxDropdown',
+  component: NyxDropdown,
+  argTypes: {
+    theme: {
+      control: { type: 'select' },
+      options: Object.values(NyxTheme),
+    },
+    variant: {
+      control: { type: 'select' },
+      options: Object.values(NyxVariant),
+    },
+    size: {
+      control: { type: 'select' },
+      options: Object.values(NyxSize),
+    },
+    position: {
+      control: { type: 'select' },
+      options: Object.values(NyxPosition),
+    },
+    trigger: {
+      control: { type: 'select' },
+      options: Object.values(NyxTrigger),
+    },
+  },
+}
+
+const Template = (args: NyxDropdownProps) => defineComponent({
+  components: { NyxDropdown },
+  setup () {
+    return { args }
+  },
+  template: `
+    <nyx-dropdown v-bind="args">
+      <button type="button">Actions</button>
+    </nyx-dropdown>
+  `,
+})
+
+export const Default = Template({
+  options: sampleOptions,
+  theme: NyxTheme.Primary,
+  size: NyxSize.Medium,
+  variant: NyxVariant.Filled,
+  position: NyxPosition.Bottom,
+  trigger: NyxTrigger.Hover,
+})
+
+export const InteractivePreview = () => defineComponent({
+  components: { NyxDropdown },
+  setup () {
+    const triggerRef = ref<HTMLButtonElement | null>(null)
+    onMounted(() => {
+      window.setTimeout(() => triggerRef.value?.click(), 0)
+    })
+    return { sampleOptions, triggerRef }
+  },
+  template: `
+    <nyx-dropdown :options="sampleOptions" trigger="click">
+      <button ref="triggerRef" type="button">Open menu</button>
+    </nyx-dropdown>
+  `,
+})
+
+export const CustomDropdown = () => defineComponent({
+  components: { NyxDropdown },
+  template: `
+    <nyx-dropdown>
+      <button type="button">Open menu</button>
+      <template #dropdown>
+        <div style="padding: 1rem; min-width: 14rem; background: var(--nyx-c-bg-soft); border: 1px solid var(--nyx-c-divider); border-radius: var(--nyx-radius-md);">
+          Custom dropdown content
+        </div>
+      </template>
+    </nyx-dropdown>
+  `,
+})
+
+const TemplateAll = (prop: string, dict: KeyDict<string>) => () => defineComponent({
+  components: { NyxDropdown },
+  setup () {
+    const values = Object.values(dict)
+    const getLabel = (value: string) => getKeyDictKeyByValue(dict, value)
+    return { prop, values, getLabel, sampleOptions }
+  },
+  template: `
+    <div class="flex-col" style="gap: 1rem; align-items: flex-start;">
+      <nyx-dropdown
+        v-for="value of values"
+        :key="value"
+        v-bind="{ [prop]: value, options: sampleOptions }"
+      >
+        <button type="button">{{ getLabel(value) }}</button>
+      </nyx-dropdown>
+    </div>
+  `,
+})
+
+export const Themes = TemplateAll('theme', NyxTheme)
+export const Variants = TemplateAll('variant', NyxVariant)
+export const Sizes = TemplateAll('size', NyxSize)

--- a/src/components/NyxDropdown/NyxDropdown.stories.ts
+++ b/src/components/NyxDropdown/NyxDropdown.stories.ts
@@ -1,4 +1,5 @@
 import { defineComponent } from 'vue'
+import type { Meta, StoryObj } from '@storybook/vue3'
 import NyxDropdown from './NyxDropdown.vue'
 import { NyxTheme, NyxVariant, NyxSize, NyxTrigger, NyxPosition, type KeyDict } from '@/types'
 import { getKeyDictKeyByValue } from '@/utils'
@@ -11,7 +12,7 @@ const sampleOptions = [
   { label: 'Delete', value: 'delete', disabled: true, icon: 'trash' },
 ]
 
-export default {
+const meta = {
   title: 'Components/NyxDropdown',
   component: NyxDropdown,
   argTypes: {
@@ -36,7 +37,11 @@ export default {
       options: Object.values(NyxTrigger),
     },
   },
-}
+} satisfies Meta<typeof NyxDropdown>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
 
 const Template = (args: NyxDropdownProps) => defineComponent({
   components: { NyxDropdown, NyxIcon },
@@ -53,16 +58,19 @@ const Template = (args: NyxDropdownProps) => defineComponent({
   `,
 })
 
-export const Default = Template({
-  options: sampleOptions,
-  theme: NyxTheme.Primary,
-  size: NyxSize.Medium,
-  variant: NyxVariant.Filled,
-  position: NyxPosition.Bottom,
-  trigger: NyxTrigger.Click,
-})
+export const Default: Story = {
+  render: () => Template({
+    options: sampleOptions,
+    theme: NyxTheme.Primary,
+    size: NyxSize.Medium,
+    variant: NyxVariant.Filled,
+    position: NyxPosition.Bottom,
+    trigger: NyxTrigger.Click,
+  }),
+}
 
-export const InteractivePreview = () => defineComponent({
+export const InteractivePreview: Story = {
+  render: () => defineComponent({
   components: { NyxDropdown, NyxIcon },
   setup () {
     return { sampleOptions }
@@ -75,9 +83,11 @@ export const InteractivePreview = () => defineComponent({
       </button>
     </nyx-dropdown>
   `,
-})
+  }),
+}
 
-export const CustomDropdown = () => defineComponent({
+export const CustomDropdown: Story = {
+  render: () => defineComponent({
   components: { NyxDropdown, NyxIcon },
   template: `
     <nyx-dropdown>
@@ -93,7 +103,8 @@ export const CustomDropdown = () => defineComponent({
       </template>
     </nyx-dropdown>
   `,
-})
+  }),
+}
 
 const TemplateAll = (prop: string, dict: KeyDict<string>) => () => defineComponent({
   components: { NyxDropdown, NyxIcon },
@@ -118,6 +129,6 @@ const TemplateAll = (prop: string, dict: KeyDict<string>) => () => defineCompone
   `,
 })
 
-export const Themes = TemplateAll('theme', NyxTheme)
-export const Variants = TemplateAll('variant', NyxVariant)
-export const Sizes = TemplateAll('size', NyxSize)
+export const Themes: Story = { render: TemplateAll('theme', NyxTheme) }
+export const Variants: Story = { render: TemplateAll('variant', NyxVariant) }
+export const Sizes: Story = { render: TemplateAll('size', NyxSize) }

--- a/src/components/NyxDropdown/NyxDropdown.stories.ts
+++ b/src/components/NyxDropdown/NyxDropdown.stories.ts
@@ -1,13 +1,14 @@
-import { defineComponent, onMounted, ref } from 'vue'
+import { defineComponent } from 'vue'
 import NyxDropdown from './NyxDropdown.vue'
 import { NyxTheme, NyxVariant, NyxSize, NyxTrigger, NyxPosition, type KeyDict } from '@/types'
 import { getKeyDictKeyByValue } from '@/utils'
 import type { NyxDropdownProps } from './NyxDropdown.types'
+import NyxIcon from '../NyxIcon/NyxIcon.vue'
 
 const sampleOptions = [
-  { label: 'Edit', value: 'edit' },
-  { label: 'Duplicate', value: 'duplicate' },
-  { label: 'Delete', value: 'delete', disabled: true },
+  { label: 'Edit', value: 'edit', icon: 'edit' },
+  { label: 'Duplicate', value: 'duplicate', icon: 'plus' },
+  { label: 'Delete', value: 'delete', disabled: true, icon: 'trash' },
 ]
 
 export default {
@@ -38,13 +39,16 @@ export default {
 }
 
 const Template = (args: NyxDropdownProps) => defineComponent({
-  components: { NyxDropdown },
+  components: { NyxDropdown, NyxIcon },
   setup () {
     return { args }
   },
   template: `
     <nyx-dropdown v-bind="args">
-      <button type="button">Actions</button>
+      <button type="button" style="display:inline-flex;align-items:center;gap:0.5rem;">
+        <nyx-icon name="menu" />
+        <span>Actions</span>
+      </button>
     </nyx-dropdown>
   `,
 })
@@ -55,32 +59,35 @@ export const Default = Template({
   size: NyxSize.Medium,
   variant: NyxVariant.Filled,
   position: NyxPosition.Bottom,
-  trigger: NyxTrigger.Hover,
+  trigger: NyxTrigger.Click,
 })
 
 export const InteractivePreview = () => defineComponent({
-  components: { NyxDropdown },
+  components: { NyxDropdown, NyxIcon },
   setup () {
-    const triggerRef = ref<HTMLButtonElement | null>(null)
-    onMounted(() => {
-      window.setTimeout(() => triggerRef.value?.click(), 0)
-    })
-    return { sampleOptions, triggerRef }
+    return { sampleOptions }
   },
   template: `
-    <nyx-dropdown :options="sampleOptions" trigger="click">
-      <button ref="triggerRef" type="button">Open menu</button>
+    <nyx-dropdown :options="sampleOptions" trigger="hover">
+      <button type="button" style="display:inline-flex;align-items:center;gap:0.5rem;">
+        <nyx-icon name="chevron-down" />
+        <span>Open menu</span>
+      </button>
     </nyx-dropdown>
   `,
 })
 
 export const CustomDropdown = () => defineComponent({
-  components: { NyxDropdown },
+  components: { NyxDropdown, NyxIcon },
   template: `
     <nyx-dropdown>
-      <button type="button">Open menu</button>
+      <button type="button" style="display:inline-flex;align-items:center;gap:0.5rem;">
+        <nyx-icon name="settings" />
+        <span>Open menu</span>
+      </button>
       <template #dropdown>
-        <div style="padding: 1rem; min-width: 14rem; background: var(--nyx-c-bg-soft); border: 1px solid var(--nyx-c-divider); border-radius: var(--nyx-radius-md);">
+        <div style="padding: 1rem; min-width: 14rem; display:flex;align-items:center;gap:0.5rem; background: var(--nyx-c-bg-soft); border: 1px solid var(--nyx-c-divider); border-radius: var(--nyx-radius-md);">
+          <nyx-icon name="settings" />
           Custom dropdown content
         </div>
       </template>
@@ -89,7 +96,7 @@ export const CustomDropdown = () => defineComponent({
 })
 
 const TemplateAll = (prop: string, dict: KeyDict<string>) => () => defineComponent({
-  components: { NyxDropdown },
+  components: { NyxDropdown, NyxIcon },
   setup () {
     const values = Object.values(dict)
     const getLabel = (value: string) => getKeyDictKeyByValue(dict, value)
@@ -102,7 +109,10 @@ const TemplateAll = (prop: string, dict: KeyDict<string>) => () => defineCompone
         :key="value"
         v-bind="{ [prop]: value, options: sampleOptions }"
       >
-        <button type="button">{{ getLabel(value) }}</button>
+        <button type="button" style="display:inline-flex;align-items:center;gap:0.5rem;">
+          <nyx-icon name="arrow-right" />
+          <span>{{ getLabel(value) }}</span>
+        </button>
       </nyx-dropdown>
     </div>
   `,

--- a/src/components/NyxDropdown/NyxDropdown.types.ts
+++ b/src/components/NyxDropdown/NyxDropdown.types.ts
@@ -26,6 +26,7 @@ export interface NyxDropdownMenuEmits {
 
 export interface NyxDropdownItemProps {
   option: NyxSelectOption
+  size?: NyxSize
 }
 
 export interface NyxDropdownItemEmits {

--- a/src/components/NyxDropdown/NyxDropdown.types.ts
+++ b/src/components/NyxDropdown/NyxDropdown.types.ts
@@ -1,0 +1,33 @@
+import type { NyxPosition, NyxSelectOption, NyxSize, NyxTheme, NyxTrigger, NyxVariant } from '@/types'
+
+export interface NyxDropdownProps {
+  theme?: NyxTheme
+  size?: NyxSize
+  variant?: NyxVariant
+  trigger?: NyxTrigger
+  position?: NyxPosition
+  options?: NyxSelectOption[]
+}
+
+export interface NyxDropdownEmits {
+  (event: 'select', option: NyxSelectOption): void
+}
+
+export interface NyxDropdownMenuProps {
+  theme?: NyxTheme
+  size?: NyxSize
+  variant?: NyxVariant
+  options?: NyxSelectOption[]
+}
+
+export interface NyxDropdownMenuEmits {
+  (event: 'select', option: NyxSelectOption): void
+}
+
+export interface NyxDropdownItemProps {
+  option: NyxSelectOption
+}
+
+export interface NyxDropdownItemEmits {
+  (event: 'click', option: NyxSelectOption): void
+}

--- a/src/components/NyxDropdown/NyxDropdown.vue
+++ b/src/components/NyxDropdown/NyxDropdown.vue
@@ -7,7 +7,7 @@ import NyxDropdownMenu from './NyxDropdownMenu.vue'
 import type { NyxDropdownEmits, NyxDropdownProps } from './NyxDropdown.types'
 
 const props = withDefaults(defineProps<NyxDropdownProps>(), {
-  trigger: NyxTrigger.Hover,
+  trigger: NyxTrigger.Click,
   position: NyxPosition.BottomRight,
   options: () => []
 })
@@ -48,7 +48,7 @@ const clearCloseTimer = () => {
 const scheduleClose = () => {
   clearCloseTimer()
   closeTimer = window.setTimeout(() => {
-    void closeDropdown()
+    void closeDropdown({ blurTrigger: true })
   }, 120)
 }
 
@@ -76,32 +76,40 @@ const openDropdown = async (focusIndex?: number) => {
   }
 }
 
-const closeDropdown = async () => {
+const closeDropdown = async (options?: { focusTrigger?: boolean, blurTrigger?: boolean }) => {
   clearCloseTimer()
   if (!isOpen.value) return
   isOpen.value = false
   await nextTick()
-  elTrigger.value?.focus()
+  if (options?.focusTrigger) {
+    elTrigger.value?.focus()
+  } else if (options?.blurTrigger) {
+    elTrigger.value?.blur()
+  }
 }
 
-const toggleDropdown = async () => {
+const toggleDropdown = async (options?: { focusTrigger?: boolean, blurTrigger?: boolean }) => {
   if (isOpen.value) {
-    await closeDropdown()
+    await closeDropdown(options)
     return
   }
   await openDropdown()
 }
 
+const onTriggerClick = async () => {
+  await toggleDropdown({ blurTrigger: true })
+}
+
 const onTriggerKeydown = async (event: KeyboardEvent) => {
   if (event.key === 'Escape') {
     event.preventDefault()
-    await closeDropdown()
+    await closeDropdown({ focusTrigger: true })
     return
   }
 
   if (event.key === 'Enter' || event.key === ' ') {
     event.preventDefault()
-    await toggleDropdown()
+    await toggleDropdown({ focusTrigger: true })
     return
   }
 
@@ -152,7 +160,7 @@ const onPanelKeydown = async (event: KeyboardEvent) => {
 
   if (event.key === 'Escape') {
     event.preventDefault()
-    await closeDropdown()
+    await closeDropdown({ focusTrigger: true })
     return
   }
 
@@ -169,7 +177,7 @@ const onPanelKeydown = async (event: KeyboardEvent) => {
 
 const onSelectOption = async (option: NonNullable<NyxDropdownProps['options']>[number]) => {
   emit('select', option)
-  await closeDropdown()
+  await closeDropdown({ blurTrigger: true })
 }
 
 const getOwnerDocument = () => elTrigger.value?.ownerDocument ?? document
@@ -179,7 +187,7 @@ const onDocumentClick = (event: MouseEvent) => {
   const target = event.target as Node | null
   if (!target) return
   if (elTrigger.value?.contains(target) || elDropdown.value?.contains(target)) return
-  void closeDropdown()
+  void closeDropdown({ blurTrigger: true })
 }
 
 onMounted(() => {
@@ -209,7 +217,7 @@ onBeforeUnmount(() => {
       aria-haspopup="menu"
       :aria-expanded="isOpen"
       :aria-controls="dropdownId"
-      @click="toggleDropdown"
+      @click="onTriggerClick"
       @keydown="onTriggerKeydown"
       @pointerenter="onTriggerPointerEnter"
       @pointerleave="onTriggerPointerLeave"

--- a/src/components/NyxDropdown/NyxDropdown.vue
+++ b/src/components/NyxDropdown/NyxDropdown.vue
@@ -1,0 +1,253 @@
+<script setup lang="ts">
+import './NyxDropdown.scss'
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, useId, useSlots, useTemplateRef } from 'vue'
+import { NyxPosition, NyxSize, NyxTrigger } from '@/types'
+import { useNyxProps, useTeleportPosition } from '@/composables'
+import NyxDropdownMenu from './NyxDropdownMenu.vue'
+import type { NyxDropdownEmits, NyxDropdownProps } from './NyxDropdown.types'
+
+const props = withDefaults(defineProps<NyxDropdownProps>(), {
+  trigger: NyxTrigger.Hover,
+  position: NyxPosition.BottomRight,
+  options: () => []
+})
+
+const emit = defineEmits<NyxDropdownEmits>()
+const slots = useSlots()
+
+const { classList } = useNyxProps(props, { origin: 'NyxDropdown' })
+
+const isOpen = ref(false)
+const elTrigger = useTemplateRef<HTMLDivElement>('elTrigger')
+const elDropdown = useTemplateRef<HTMLDivElement>('elDropdown')
+const dropdownId = useId()
+const triggerId = useId()
+const supportsHover = ref(false)
+let closeTimer: number | null = null
+
+const { cssVariables, computedPosition } = useTeleportPosition(elTrigger, elDropdown, {
+  position: computed(() => props.position),
+  gap: ref(NyxSize.Medium),
+  isUpdateAllowed: isOpen,
+})
+
+const hasCustomDropdown = computed(() => !!slots.dropdown)
+const isHoverTrigger = computed(() => props.trigger === NyxTrigger.Hover)
+
+const getMenuItems = (): HTMLButtonElement[] => {
+  if (!elDropdown.value) return []
+  return Array.from(elDropdown.value.querySelectorAll<HTMLButtonElement>('[data-nyx-dropdown-item]'))
+}
+
+const clearCloseTimer = () => {
+  if (!closeTimer) return
+  window.clearTimeout(closeTimer)
+  closeTimer = null
+}
+
+const scheduleClose = () => {
+  clearCloseTimer()
+  closeTimer = window.setTimeout(() => {
+    void closeDropdown()
+  }, 120)
+}
+
+const focusMenuItem = async (index: number) => {
+  await nextTick()
+  getMenuItems()[index]?.focus()
+}
+
+const focusAdjacentItem = async (direction: 1 | -1) => {
+  const items = getMenuItems()
+  if (!items.length) return
+  const currentIndex = items.findIndex(item => item === document.activeElement)
+  const nextIndex = currentIndex === -1
+    ? (direction > 0 ? 0 : items.length - 1)
+    : (currentIndex + direction + items.length) % items.length
+  items[nextIndex]?.focus()
+}
+
+const openDropdown = async (focusIndex?: number) => {
+  clearCloseTimer()
+  if (isOpen.value) return
+  isOpen.value = true
+  if (focusIndex !== undefined && !hasCustomDropdown.value) {
+    await focusMenuItem(focusIndex)
+  }
+}
+
+const closeDropdown = async () => {
+  clearCloseTimer()
+  if (!isOpen.value) return
+  isOpen.value = false
+  await nextTick()
+  elTrigger.value?.focus()
+}
+
+const toggleDropdown = async () => {
+  if (isOpen.value) {
+    await closeDropdown()
+    return
+  }
+  await openDropdown()
+}
+
+const onTriggerKeydown = async (event: KeyboardEvent) => {
+  if (event.key === 'Escape') {
+    event.preventDefault()
+    await closeDropdown()
+    return
+  }
+
+  if (event.key === 'Enter' || event.key === ' ') {
+    event.preventDefault()
+    await toggleDropdown()
+    return
+  }
+
+  if (hasCustomDropdown.value) return
+
+  if (event.key === 'ArrowDown') {
+    event.preventDefault()
+    if (!isOpen.value) {
+      await openDropdown(0)
+    } else {
+      await focusAdjacentItem(1)
+    }
+  }
+
+  if (event.key === 'ArrowUp') {
+    event.preventDefault()
+    if (!isOpen.value) {
+      const items = getMenuItems()
+      await openDropdown(Math.max(items.length - 1, 0))
+    } else {
+      await focusAdjacentItem(-1)
+    }
+  }
+}
+
+const onTriggerPointerEnter = () => {
+  if (!isHoverTrigger.value || !supportsHover.value) return
+  void openDropdown()
+}
+
+const onTriggerPointerLeave = () => {
+  if (!isHoverTrigger.value || !supportsHover.value) return
+  scheduleClose()
+}
+
+const onPanelPointerEnter = () => {
+  if (!isHoverTrigger.value || !supportsHover.value) return
+  clearCloseTimer()
+}
+
+const onPanelPointerLeave = () => {
+  if (!isHoverTrigger.value || !supportsHover.value) return
+  scheduleClose()
+}
+
+const onPanelKeydown = async (event: KeyboardEvent) => {
+  if (hasCustomDropdown.value) return
+
+  if (event.key === 'Escape') {
+    event.preventDefault()
+    await closeDropdown()
+    return
+  }
+
+  if (event.key === 'ArrowDown') {
+    event.preventDefault()
+    await focusAdjacentItem(1)
+  }
+
+  if (event.key === 'ArrowUp') {
+    event.preventDefault()
+    await focusAdjacentItem(-1)
+  }
+}
+
+const onSelectOption = async (option: NonNullable<NyxDropdownProps['options']>[number]) => {
+  emit('select', option)
+  await closeDropdown()
+}
+
+const getOwnerDocument = () => elTrigger.value?.ownerDocument ?? document
+
+const onDocumentClick = (event: MouseEvent) => {
+  if (!isOpen.value) return
+  const target = event.target as Node | null
+  if (!target) return
+  if (elTrigger.value?.contains(target) || elDropdown.value?.contains(target)) return
+  void closeDropdown()
+}
+
+onMounted(() => {
+  supportsHover.value = typeof window !== 'undefined'
+    ? window.matchMedia?.('(hover: hover) and (pointer: fine)')?.matches ?? false
+    : false
+  getOwnerDocument().addEventListener('click', onDocumentClick)
+})
+
+onBeforeUnmount(() => {
+  clearCloseTimer()
+  getOwnerDocument().removeEventListener('click', onDocumentClick)
+})
+</script>
+
+<template>
+  <div
+    class="nyx-dropdown"
+    :class="classList"
+  >
+    <div
+      ref="elTrigger"
+      class="nyx-dropdown__trigger"
+      :id="triggerId"
+      role="button"
+      tabindex="0"
+      aria-haspopup="menu"
+      :aria-expanded="isOpen"
+      :aria-controls="dropdownId"
+      @click="toggleDropdown"
+      @keydown="onTriggerKeydown"
+      @pointerenter="onTriggerPointerEnter"
+      @pointerleave="onTriggerPointerLeave"
+    >
+      <slot />
+    </div>
+
+    <Teleport to="body">
+      <Transition name="nyx-dropdown__panel-transition">
+        <div
+          v-if="isOpen"
+          ref="elDropdown"
+          class="nyx-dropdown__panel"
+          :class="[
+            ...classList,
+            `nyx-dropdown__panel--${computedPosition}`,
+            { 'nyx-dropdown__panel--open': isOpen }
+          ]"
+          :data-position="computedPosition"
+          :id="dropdownId"
+          :style="cssVariables"
+          role="menu"
+          :aria-labelledby="triggerId"
+          @keydown="onPanelKeydown"
+          @pointerenter="onPanelPointerEnter"
+          @pointerleave="onPanelPointerLeave"
+        >
+          <slot name="dropdown">
+            <NyxDropdownMenu
+              :theme="props.theme"
+              :size="props.size"
+              :variant="props.variant"
+              :options="props.options"
+              @select="onSelectOption"
+            />
+          </slot>
+        </div>
+      </Transition>
+    </Teleport>
+  </div>
+</template>

--- a/src/components/NyxDropdown/NyxDropdown.vue
+++ b/src/components/NyxDropdown/NyxDropdown.vue
@@ -218,36 +218,33 @@ onBeforeUnmount(() => {
     </div>
 
     <Teleport to="body">
-      <Transition name="nyx-dropdown__panel-transition">
-        <div
-          v-if="isOpen"
-          ref="elDropdown"
-          class="nyx-dropdown__panel"
-          :class="[
-            ...classList,
-            `nyx-dropdown__panel--${computedPosition}`,
-            { 'nyx-dropdown__panel--open': isOpen }
-          ]"
-          :data-position="computedPosition"
-          :id="dropdownId"
-          :style="cssVariables"
-          role="menu"
-          :aria-labelledby="triggerId"
-          @keydown="onPanelKeydown"
-          @pointerenter="onPanelPointerEnter"
-          @pointerleave="onPanelPointerLeave"
-        >
-          <slot name="dropdown">
-            <NyxDropdownMenu
-              :theme="props.theme"
-              :size="props.size"
-              :variant="props.variant"
-              :options="props.options"
-              @select="onSelectOption"
-            />
-          </slot>
-        </div>
-      </Transition>
+      <div
+        ref="elDropdown"
+        class="nyx-dropdown__panel"
+        :class="[
+          ...classList,
+          `nyx-dropdown__panel--${computedPosition}`,
+          { 'nyx-dropdown__panel--open': isOpen }
+        ]"
+        :data-position="computedPosition"
+        :id="dropdownId"
+        :style="cssVariables"
+        role="menu"
+        :aria-labelledby="triggerId"
+        @keydown="onPanelKeydown"
+        @pointerenter="onPanelPointerEnter"
+        @pointerleave="onPanelPointerLeave"
+      >
+        <slot name="dropdown">
+          <NyxDropdownMenu
+            :theme="props.theme"
+            :size="props.size"
+            :variant="props.variant"
+            :options="props.options"
+            @select="onSelectOption"
+          />
+        </slot>
+      </div>
     </Teleport>
   </div>
 </template>

--- a/src/components/NyxDropdown/NyxDropdownItem.stories.ts
+++ b/src/components/NyxDropdown/NyxDropdownItem.stories.ts
@@ -1,0 +1,26 @@
+import { defineComponent } from 'vue'
+import NyxDropdownItem from './NyxDropdownItem.vue'
+
+export default {
+  title: 'Components/NyxDropdownItem',
+  component: NyxDropdownItem,
+}
+
+export const Default = () => defineComponent({
+  components: { NyxDropdownItem },
+  template: `
+    <div style="min-width: 12rem; background: var(--nyx-c-bg-soft); border: 1px solid var(--nyx-c-divider); border-radius: var(--nyx-radius-md); overflow: hidden;">
+      <nyx-dropdown-item :option="{ label: 'Open', value: 'open' }" />
+      <nyx-dropdown-item :option="{ label: 'Disabled', value: 'disabled', disabled: true }" />
+    </div>
+  `,
+})
+
+export const LongLabel = () => defineComponent({
+  components: { NyxDropdownItem },
+  template: `
+    <div style="min-width: 18rem; background: var(--nyx-c-bg-soft); border: 1px solid var(--nyx-c-divider); border-radius: var(--nyx-radius-md); overflow: hidden;">
+      <nyx-dropdown-item :option="{ label: 'A very long menu label that should still read cleanly', value: 'long' }" />
+    </div>
+  `,
+})

--- a/src/components/NyxDropdown/NyxDropdownItem.stories.ts
+++ b/src/components/NyxDropdown/NyxDropdownItem.stories.ts
@@ -10,8 +10,8 @@ export const Default = () => defineComponent({
   components: { NyxDropdownItem },
   template: `
     <div style="min-width: 12rem; background: var(--nyx-c-bg-soft); border: 1px solid var(--nyx-c-divider); border-radius: var(--nyx-radius-md); overflow: hidden;">
-      <nyx-dropdown-item :option="{ label: 'Open', value: 'open' }" />
-      <nyx-dropdown-item :option="{ label: 'Disabled', value: 'disabled', disabled: true }" />
+      <nyx-dropdown-item :option="{ label: 'Open', value: 'open', icon: 'check-circle' }" />
+      <nyx-dropdown-item :option="{ label: 'Disabled', value: 'disabled', disabled: true, icon: 'x-circle' }" />
     </div>
   `,
 })
@@ -20,7 +20,7 @@ export const LongLabel = () => defineComponent({
   components: { NyxDropdownItem },
   template: `
     <div style="min-width: 18rem; background: var(--nyx-c-bg-soft); border: 1px solid var(--nyx-c-divider); border-radius: var(--nyx-radius-md); overflow: hidden;">
-      <nyx-dropdown-item :option="{ label: 'A very long menu label that should still read cleanly', value: 'long' }" />
+      <nyx-dropdown-item :option="{ label: 'A very long menu label that should still read cleanly', value: 'long', icon: 'home' }" />
     </div>
   `,
 })

--- a/src/components/NyxDropdown/NyxDropdownItem.vue
+++ b/src/components/NyxDropdown/NyxDropdownItem.vue
@@ -1,0 +1,33 @@
+<script setup lang="ts">
+import './NyxDropdown.scss'
+import { useNyxProps } from '@/composables'
+import type { NyxDropdownItemEmits, NyxDropdownItemProps } from './NyxDropdown.types'
+
+const props = defineProps<NyxDropdownItemProps>()
+const emit = defineEmits<NyxDropdownItemEmits>()
+
+const { classList } = useNyxProps(props, { origin: 'NyxDropdownItem' })
+
+const onClick = () => {
+  if (props.option.disabled) return
+  emit('click', props.option)
+}
+</script>
+
+<template>
+  <button
+    type="button"
+    class="nyx-dropdown-item"
+    data-nyx-dropdown-item
+    :class="[
+      ...classList,
+      { 'nyx-dropdown-item--disabled': props.option.disabled }
+    ]"
+    :disabled="props.option.disabled"
+    :aria-disabled="props.option.disabled || undefined"
+    role="menuitem"
+    @click="onClick"
+  >
+    <span>{{ props.option.label }}</span>
+  </button>
+</template>

--- a/src/components/NyxDropdown/NyxDropdownItem.vue
+++ b/src/components/NyxDropdown/NyxDropdownItem.vue
@@ -1,12 +1,13 @@
 <script setup lang="ts">
 import './NyxDropdown.scss'
 import { useNyxProps } from '@/composables'
+import NyxIcon from '../NyxIcon/NyxIcon.vue'
 import type { NyxDropdownItemEmits, NyxDropdownItemProps } from './NyxDropdown.types'
 
 const props = defineProps<NyxDropdownItemProps>()
 const emit = defineEmits<NyxDropdownItemEmits>()
 
-const { classList } = useNyxProps(props, { origin: 'NyxDropdownItem' })
+const { classList, nyxSize } = useNyxProps(props, { origin: 'NyxDropdownItem' })
 
 const onClick = () => {
   if (props.option.disabled) return
@@ -28,6 +29,7 @@ const onClick = () => {
     role="menuitem"
     @click="onClick"
   >
+    <NyxIcon v-if="props.option.icon" :name="props.option.icon" :size="nyxSize" />
     <span>{{ props.option.label }}</span>
   </button>
 </template>

--- a/src/components/NyxDropdown/NyxDropdownMenu.stories.ts
+++ b/src/components/NyxDropdown/NyxDropdownMenu.stories.ts
@@ -5,9 +5,9 @@ import { getKeyDictKeyByValue } from '@/utils'
 import type { NyxDropdownMenuProps } from './NyxDropdown.types'
 
 const sampleOptions = [
-  { label: 'View', value: 'view' },
-  { label: 'Rename', value: 'rename' },
-  { label: 'Archive', value: 'archive', disabled: true },
+  { label: 'View', value: 'view', icon: 'search' },
+  { label: 'Rename', value: 'rename', icon: 'edit' },
+  { label: 'Archive', value: 'archive', disabled: true, icon: 'alert-circle' },
 ]
 
 export default {

--- a/src/components/NyxDropdown/NyxDropdownMenu.stories.ts
+++ b/src/components/NyxDropdown/NyxDropdownMenu.stories.ts
@@ -1,0 +1,75 @@
+import { defineComponent } from 'vue'
+import NyxDropdownMenu from './NyxDropdownMenu.vue'
+import { NyxTheme, NyxVariant, NyxSize, type KeyDict } from '@/types'
+import { getKeyDictKeyByValue } from '@/utils'
+import type { NyxDropdownMenuProps } from './NyxDropdown.types'
+
+const sampleOptions = [
+  { label: 'View', value: 'view' },
+  { label: 'Rename', value: 'rename' },
+  { label: 'Archive', value: 'archive', disabled: true },
+]
+
+export default {
+  title: 'Components/NyxDropdownMenu',
+  component: NyxDropdownMenu,
+  argTypes: {
+    theme: {
+      control: { type: 'select' },
+      options: Object.values(NyxTheme),
+    },
+    variant: {
+      control: { type: 'select' },
+      options: Object.values(NyxVariant),
+    },
+    size: {
+      control: { type: 'select' },
+      options: Object.values(NyxSize),
+    },
+  },
+}
+
+const Template = (args: NyxDropdownMenuProps) => defineComponent({
+  components: { NyxDropdownMenu },
+  setup () {
+    return { args }
+  },
+  template: `
+    <div style="padding: 1rem; background: var(--nyx-c-bg-soft);">
+      <nyx-dropdown-menu v-bind="args" />
+    </div>
+  `,
+})
+
+export const Default = Template({
+  options: sampleOptions,
+  theme: NyxTheme.Primary,
+  size: NyxSize.Medium,
+  variant: NyxVariant.Filled,
+})
+
+const TemplateAll = (prop: string, dict: KeyDict<string>) => () => defineComponent({
+  components: { NyxDropdownMenu },
+  setup () {
+    const values = Object.values(dict)
+    const getLabel = (value: string) => getKeyDictKeyByValue(dict, value)
+    return { prop, values, getLabel, sampleOptions }
+  },
+  template: `
+    <div class="flex-col" style="gap: 1rem; align-items: flex-start;">
+      <div
+        v-for="value of values"
+        :key="value"
+        :class="{ 'flex-col': true }"
+        style="gap: 0.5rem;"
+      >
+        <strong>{{ getLabel(value) }}</strong>
+        <nyx-dropdown-menu v-bind="{ [prop]: value, options: sampleOptions }" />
+      </div>
+    </div>
+  `,
+})
+
+export const Themes = TemplateAll('theme', NyxTheme)
+export const Variants = TemplateAll('variant', NyxVariant)
+export const Sizes = TemplateAll('size', NyxSize)

--- a/src/components/NyxDropdown/NyxDropdownMenu.vue
+++ b/src/components/NyxDropdown/NyxDropdownMenu.vue
@@ -27,6 +27,7 @@ const onItemClick = (option: NonNullable<NyxDropdownMenuProps['options']>[number
       v-for="option in props.options"
       :key="option.value"
       :option="option"
+      :size="props.size"
       @click="onItemClick"
     />
   </div>

--- a/src/components/NyxDropdown/NyxDropdownMenu.vue
+++ b/src/components/NyxDropdown/NyxDropdownMenu.vue
@@ -1,0 +1,33 @@
+<script setup lang="ts">
+import './NyxDropdown.scss'
+import { useNyxProps } from '@/composables'
+import NyxDropdownItem from './NyxDropdownItem.vue'
+import type { NyxDropdownMenuEmits, NyxDropdownMenuProps } from './NyxDropdown.types'
+
+const props = withDefaults(defineProps<NyxDropdownMenuProps>(), {
+  options: () => []
+})
+
+const emit = defineEmits<NyxDropdownMenuEmits>()
+
+const { classList } = useNyxProps(props, { origin: 'NyxDropdownMenu' })
+
+const onItemClick = (option: NonNullable<NyxDropdownMenuProps['options']>[number]) => {
+  emit('select', option)
+}
+</script>
+
+<template>
+  <div
+    class="nyx-dropdown-menu"
+    :class="classList"
+    role="menu"
+  >
+    <NyxDropdownItem
+      v-for="option in props.options"
+      :key="option.value"
+      :option="option"
+      @click="onItemClick"
+    />
+  </div>
+</template>

--- a/src/components/NyxStatusDot/NyxStatusDot.scss
+++ b/src/components/NyxStatusDot/NyxStatusDot.scss
@@ -1,0 +1,210 @@
+.nyx-status-dot {
+  --nyx-gap-status-dot: var(--nyx-gap-md);
+  --nyx-c-status-dot: var(--nyx-c-success);
+  --nyx-c-status-dot-highlight: var(--nyx-c-success-highlight);
+  --nyx-c-status-dot-alt: var(--nyx-c-success-alt);
+  --nyx-rgb-status-dot: var(--nyx-rgb-success);
+  --nyx-status-dot-size: 0.375rem;
+  --nyx-status-dot-border-size: 1px;
+  --nyx-status-dot-glow: calc(var(--nyx-backlight-size) * 0.5);
+  --nyx-status-dot-backlight-opacity: 0;
+  --nyx-status-dot-backlight-scale: 1;
+
+  display: inline-flex;
+  align-items: center;
+  gap: var(--nyx-gap-status-dot);
+  line-height: 1;
+  vertical-align: middle;
+
+  &__indicator {
+    width: var(--nyx-status-dot-size);
+    height: var(--nyx-status-dot-size);
+    border-radius: var(--nyx-radius-max);
+    background-color: var(--nyx-c-status-dot);
+    border: var(--nyx-status-dot-border-size) solid transparent;
+    box-shadow: 0 0 var(--nyx-status-dot-glow) rgba(var(--nyx-rgb-status-dot), 0.45);
+    position: relative;
+    display: inline-block;
+    vertical-align: middle;
+    overflow: visible;
+    transition:
+      background-color var(--nyx-speed-fast),
+      border-color var(--nyx-speed-fast),
+      box-shadow var(--nyx-speed-slow),
+      filter var(--nyx-speed-slow),
+      opacity var(--nyx-speed-fast);
+
+    &::after {
+      content: '';
+      position: absolute;
+      inset: calc(var(--nyx-status-dot-size) * -0.4);
+      border-radius: inherit;
+      background: radial-gradient(circle, rgba(var(--nyx-rgb-status-dot), 0.38) 0%, rgba(var(--nyx-rgb-status-dot), 0) 70%);
+      opacity: var(--nyx-status-dot-backlight-opacity);
+      transform: scale(var(--nyx-status-dot-backlight-scale));
+      pointer-events: none;
+      transition:
+        opacity var(--nyx-speed-fast),
+        transform var(--nyx-speed-fast),
+        filter var(--nyx-speed-fast);
+    }
+  }
+
+  &__label {
+    font-size: var(--nyx-font-size-sm);
+    color: var(--nyx-c-text-1);
+    line-height: 1;
+  }
+
+  &.variant-filled {
+    .nyx-status-dot__indicator {
+      background-color: var(--nyx-c-status-dot);
+      border-color: rgba(var(--nyx-rgb-status-dot), 0.12);
+    }
+  }
+
+  &.variant-soft {
+    .nyx-status-dot__indicator {
+      background-color: rgba(var(--nyx-rgb-status-dot), 0.22);
+      border-color: rgba(var(--nyx-rgb-status-dot), 0.14);
+      box-shadow: 0 0 calc(var(--nyx-status-dot-glow) * 0.8) rgba(var(--nyx-rgb-status-dot), 0.22);
+    }
+  }
+
+  &.variant-subtle {
+    .nyx-status-dot__indicator {
+      background-color: rgba(var(--nyx-rgb-status-dot), 0.14);
+      border-color: transparent;
+      box-shadow: none;
+    }
+  }
+
+  &.variant-outline {
+    .nyx-status-dot__indicator {
+      background-color: transparent;
+      border-color: rgba(var(--nyx-rgb-status-dot), 0.9);
+      box-shadow: inset 0 0 0 var(--nyx-status-dot-border-size) rgba(var(--nyx-rgb-status-dot), 0.18);
+    }
+  }
+
+  &.variant-ghost,
+  &.variant-text {
+    .nyx-status-dot__indicator {
+      background-color: transparent;
+      border-color: transparent;
+      box-shadow: none;
+      opacity: 0.9;
+    }
+  }
+
+  &.size-xs {
+    --nyx-status-dot-size: 0.25rem;
+    --nyx-status-dot-border-size: 1px;
+  }
+
+  &.size-sm {
+    --nyx-status-dot-size: 0.3125rem;
+    --nyx-status-dot-border-size: 1px;
+  }
+
+  &.size-md {
+    --nyx-status-dot-size: 0.375rem;
+    --nyx-status-dot-border-size: 1px;
+  }
+
+  &.size-lg {
+    --nyx-status-dot-size: 0.5rem;
+    --nyx-status-dot-border-size: 1px;
+  }
+
+  &.size-xl {
+    --nyx-status-dot-size: 0.625rem;
+    --nyx-status-dot-border-size: 1px;
+  }
+
+  &.size-2xl {
+    --nyx-status-dot-size: 0.875rem;
+    --nyx-status-dot-border-size: 2px;
+  }
+
+  &.theme-primary {
+    --nyx-c-status-dot: var(--nyx-c-primary);
+    --nyx-c-status-dot-highlight: var(--nyx-c-primary-highlight);
+    --nyx-c-status-dot-alt: var(--nyx-c-primary-alt);
+    --nyx-rgb-status-dot: var(--nyx-rgb-primary);
+  }
+
+  &.theme-secondary {
+    --nyx-c-status-dot: var(--nyx-c-secondary);
+    --nyx-c-status-dot-highlight: var(--nyx-c-secondary-highlight);
+    --nyx-c-status-dot-alt: var(--nyx-c-secondary-alt);
+    --nyx-rgb-status-dot: var(--nyx-rgb-secondary);
+  }
+
+  &.theme-success {
+    --nyx-c-status-dot: var(--nyx-c-success);
+    --nyx-c-status-dot-highlight: var(--nyx-c-success-highlight);
+    --nyx-c-status-dot-alt: var(--nyx-c-success-alt);
+    --nyx-rgb-status-dot: var(--nyx-rgb-success);
+  }
+
+  &.theme-warning {
+    --nyx-c-status-dot: var(--nyx-c-warning);
+    --nyx-c-status-dot-highlight: var(--nyx-c-warning-highlight);
+    --nyx-c-status-dot-alt: var(--nyx-c-warning-alt);
+    --nyx-rgb-status-dot: var(--nyx-rgb-warning);
+  }
+
+  &.theme-danger {
+    --nyx-c-status-dot: var(--nyx-c-danger);
+    --nyx-c-status-dot-highlight: var(--nyx-c-danger-highlight);
+    --nyx-c-status-dot-alt: var(--nyx-c-danger-alt);
+    --nyx-rgb-status-dot: var(--nyx-rgb-danger);
+  }
+
+  &.theme-info {
+    --nyx-c-status-dot: var(--nyx-c-info);
+    --nyx-c-status-dot-highlight: var(--nyx-c-info-highlight);
+    --nyx-c-status-dot-alt: var(--nyx-c-info-alt);
+    --nyx-rgb-status-dot: var(--nyx-rgb-info);
+  }
+
+  &.theme-default {
+    --nyx-c-status-dot: var(--nyx-c-default);
+    --nyx-c-status-dot-highlight: var(--nyx-c-default-highlight);
+    --nyx-c-status-dot-alt: var(--nyx-c-default-alt);
+    --nyx-rgb-status-dot: var(--nyx-rgb-default);
+  }
+
+  &[class*='backlight-'] {
+    .nyx-status-dot__indicator {
+      --nyx-status-dot-backlight-opacity: 0.85;
+      filter: drop-shadow(0 0 var(--nyx-backlight-size) rgba(var(--nyx-rgb-status-dot), var(--nyx-backlight-intensity)));
+    }
+  }
+
+  &.animation-playing {
+    .nyx-status-dot__indicator::after {
+      animation: nyx-status-dot-pulse 1.8s infinite ease-out;
+    }
+  }
+
+  &.animation-paused {
+    .nyx-status-dot__indicator::after {
+      animation: none;
+    }
+  }
+}
+
+@keyframes nyx-status-dot-pulse {
+  0%,
+  100% {
+    transform: scale(1);
+    opacity: 0.35;
+  }
+
+  50% {
+    transform: scale(1.9);
+    opacity: 0.9;
+  }
+}

--- a/src/components/NyxStatusDot/NyxStatusDot.spec.ts
+++ b/src/components/NyxStatusDot/NyxStatusDot.spec.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { NyxAnimationState, NyxSize, NyxTheme, NyxVariant } from '@/types'
+import NyxStatusDot from './NyxStatusDot.vue'
+
+beforeEach(() => {
+  vi.spyOn(console, 'warn').mockImplementation(() => {})
+})
+
+describe('NyxStatusDot', () => {
+  it('renders without errors', () => {
+    const wrapper = mount(NyxStatusDot)
+    expect(wrapper.find('.nyx-status-dot').exists()).toBe(true)
+  })
+
+  it('renders as a decorative span', () => {
+    const wrapper = mount(NyxStatusDot)
+    expect(wrapper.find('span.nyx-status-dot').exists()).toBe(true)
+    expect(wrapper.find('.nyx-status-dot').attributes('aria-hidden')).toBe('true')
+    expect(wrapper.find('.nyx-status-dot__indicator').attributes('aria-hidden')).toBe('true')
+  })
+
+  it('applies the default theme, size, and variant classes', () => {
+    const wrapper = mount(NyxStatusDot)
+    expect(wrapper.find('.nyx-status-dot').classes()).toEqual(
+      expect.arrayContaining(['theme-success', 'size-xs', 'variant-filled'])
+    )
+  })
+
+  it('applies custom props through useNyxProps', () => {
+    const wrapper = mount(NyxStatusDot, {
+      props: {
+        theme: NyxTheme.Danger,
+        size: NyxSize.Large,
+        variant: NyxVariant.Outline,
+        backlight: true,
+      },
+    })
+
+    const classes = wrapper.find('.nyx-status-dot').classes()
+    expect(classes).toEqual(expect.arrayContaining([
+      'theme-danger',
+      'size-lg',
+      'variant-outline',
+      'backlight-danger',
+    ]))
+  })
+
+  it('renders the label prop when no slot is provided', () => {
+    const wrapper = mount(NyxStatusDot, { props: { label: 'Online' } })
+    expect(wrapper.find('.nyx-status-dot__label').text()).toBe('Online')
+  })
+
+  it('prefers the default slot over the label prop', () => {
+    const wrapper = mount(NyxStatusDot, {
+      props: { label: 'Online' },
+      slots: { default: 'Custom status' },
+    })
+
+    expect(wrapper.find('.nyx-status-dot__label').text()).toBe('Custom status')
+  })
+
+  it('pauses animation when animation is paused', () => {
+    const wrapper = mount(NyxStatusDot, { props: { animation: NyxAnimationState.Paused } })
+    expect(wrapper.find('.nyx-status-dot').classes()).toContain('animation-paused')
+  })
+
+  it('defaults animation to paused', () => {
+    const wrapper = mount(NyxStatusDot)
+    expect(wrapper.find('.nyx-status-dot').classes()).toContain('animation-paused')
+  })
+
+  it('adds the playing class when animation is playing', () => {
+    const wrapper = mount(NyxStatusDot, { props: { animation: NyxAnimationState.Playing } })
+    expect(wrapper.find('.nyx-status-dot').classes()).toContain('animation-playing')
+  })
+})

--- a/src/components/NyxStatusDot/NyxStatusDot.stories.ts
+++ b/src/components/NyxStatusDot/NyxStatusDot.stories.ts
@@ -1,0 +1,97 @@
+import { defineComponent } from 'vue'
+import NyxStatusDot from './NyxStatusDot.vue'
+import { NyxAnimationState, NyxTheme, NyxVariant, NyxSize, type KeyDict } from '@/types'
+import type { NyxStatusDotProps } from './NyxStatusDot.types'
+import { getKeyDictKeyByValue } from '@/utils'
+
+export default {
+  title: 'Components/NyxStatusDot',
+  component: NyxStatusDot,
+  argTypes: {
+    theme: {
+      control: { type: 'select' },
+      options: Object.values(NyxTheme),
+    },
+    variant: {
+      control: { type: 'select' },
+      options: Object.values(NyxVariant),
+    },
+    size: {
+      control: { type: 'select' },
+      options: Object.values(NyxSize),
+    },
+    animation: {
+      control: { type: 'select' },
+      options: Object.values(NyxAnimationState),
+    },
+    backlight: {
+      control: { type: 'boolean' },
+    },
+    label: {
+      control: { type: 'text' },
+    },
+  },
+}
+
+const Template = (args: NyxStatusDotProps) => defineComponent({
+  components: { NyxStatusDot },
+  setup () {
+    return { args }
+  },
+  template: `
+    <nyx-status-dot v-bind="args" />
+  `,
+})
+
+const TemplateAllProp = (prop: string, dict: KeyDict<string>) => () => defineComponent({
+  components: { NyxStatusDot },
+  setup () {
+    const values = Object.values(dict)
+    const getLabel = (value: string) => getKeyDictKeyByValue(dict, value)
+    return { prop, values, getLabel }
+  },
+  template: `
+    <div class="flex-col">
+      <div class="flex" style="align-items: center; gap: 1rem; flex-wrap: wrap;">
+        <div v-for="value of values" :key="value" class="flex" style="align-items: center; gap: 0.5rem; min-width: 8rem;">
+          <nyx-status-dot v-bind="{ [prop]: value, label: getLabel(value) }" />
+        </div>
+      </div>
+    </div>
+  `,
+})
+
+const LabelsTemplate = () => () => defineComponent({
+  components: { NyxStatusDot },
+  template: `
+    <div class="flex-col">
+      <div class="flex" style="align-items: center; gap: 1.5rem; flex-wrap: wrap;">
+        <nyx-status-dot label="Online" :backlight="true" />
+        <nyx-status-dot :backlight="true">
+          Custom slot label
+        </nyx-status-dot>
+        <nyx-status-dot theme="info" label="Offline" variant="soft" />
+      </div>
+    </div>
+  `,
+})
+
+const AnimationTemplate = () => () => defineComponent({
+  components: { NyxStatusDot },
+  template: `
+    <div class="flex-col">
+      <div class="flex" style="align-items: center; gap: 1.5rem; flex-wrap: wrap;">
+        <nyx-status-dot label="Paused" :backlight="true" animation="paused" />
+        <nyx-status-dot label="Playing" :backlight="true" animation="playing" />
+      </div>
+    </div>
+  `,
+})
+
+export const Default = Template({})
+export const Labels = LabelsTemplate()
+export const Animation = AnimationTemplate()
+export const Themes = TemplateAllProp('theme', NyxTheme)
+export const Variants = TemplateAllProp('variant', NyxVariant)
+export const Sizes = TemplateAllProp('size', NyxSize)
+export const Animations = TemplateAllProp('animation', NyxAnimationState)

--- a/src/components/NyxStatusDot/NyxStatusDot.types.ts
+++ b/src/components/NyxStatusDot/NyxStatusDot.types.ts
@@ -1,0 +1,10 @@
+import type { NyxAnimationState, NyxSize, NyxTheme, NyxVariant } from '@/types'
+
+export interface NyxStatusDotProps {
+  theme?: NyxTheme,
+  size?: NyxSize,
+  variant?: NyxVariant,
+  backlight?: boolean,
+  animation?: NyxAnimationState,
+  label?: string
+}

--- a/src/components/NyxStatusDot/NyxStatusDot.vue
+++ b/src/components/NyxStatusDot/NyxStatusDot.vue
@@ -1,0 +1,35 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useNyxProps } from '@/composables'
+import { NyxAnimationState, NyxSize, NyxTheme, NyxVariant } from '@/types'
+import type { NyxStatusDotProps } from './NyxStatusDot.types'
+import { useSlots } from 'vue'
+import './NyxStatusDot.scss'
+
+const props = withDefaults(defineProps<NyxStatusDotProps>(), {
+  theme: NyxTheme.Success,
+  size: NyxSize.XSmall,
+  variant: NyxVariant.Filled,
+  backlight: false,
+  animation: NyxAnimationState.Paused,
+})
+
+const { classList } = useNyxProps(props, { origin: 'NyxStatusDot' })
+
+const animationClass = computed(() => `animation-${ props.animation }`)
+const slots = useSlots()
+const isDecorative = computed(() => !slots.default && !props.label)
+</script>
+
+<template>
+  <span
+    class="nyx-status-dot"
+    :class="[...classList, animationClass]"
+    :aria-hidden="isDecorative ? 'true' : undefined"
+  >
+    <span class="nyx-status-dot__indicator" aria-hidden="true" />
+    <span v-if="$slots.default || props.label" class="nyx-status-dot__label">
+      <slot>{{ props.label }}</slot>
+    </span>
+  </span>
+</template>

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -23,6 +23,7 @@ import NyxProgress from './NyxProgress/NyxProgress.vue'
 import NyxSelect from './NyxSelect/NyxSelect.vue'
 import NyxSlider from './NyxSlider/NyxSlider.vue'
 import NyxSpinner from './NyxSpinner/NyxSpinner.vue'
+import NyxStatusDot from './NyxStatusDot/NyxStatusDot.vue'
 import NyxSwitch from './NyxSwitch/NyxSwitch.vue'
 import NyxTable from './NyxTable/NyxTable.vue'
 import NyxTableCell from './NyxTable/NyxTableCell.vue'
@@ -57,6 +58,7 @@ export {
   NyxSelect,
   NyxSlider,
   NyxSpinner,
+  NyxStatusDot,
   NyxSwitch,
   NyxTable,
   NyxTableCell,

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -6,6 +6,9 @@ import NyxButton from './NyxButton/NyxButton.vue'
 import NyxCard from './NyxCard/NyxCard.vue'
 import NyxCarousel from './NyxCarousel/NyxCarousel.vue'
 import NyxCheckbox from './NyxCheckbox/NyxCheckbox.vue'
+import NyxDropdown from './NyxDropdown/NyxDropdown.vue'
+import NyxDropdownItem from './NyxDropdown/NyxDropdownItem.vue'
+import NyxDropdownMenu from './NyxDropdown/NyxDropdownMenu.vue'
 import NyxEditor from './NyxEditor/NyxEditor.vue'
 import NyxForm from './NyxForm/NyxForm.vue'
 import NyxFormField from './NyxForm/NyxFormField.vue'
@@ -37,6 +40,9 @@ export {
   NyxCard,
   NyxCarousel,
   NyxCheckbox,
+  NyxDropdown,
+  NyxDropdownItem,
+  NyxDropdownMenu,
   NyxEditor,
   NyxForm,
   NyxFormField,

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -38,6 +38,11 @@ export enum NyxVariant {
   Text = 'text',
 }
 
+export enum NyxAnimationState {
+  Playing = 'playing',
+  Paused = 'paused',
+}
+
 export enum NyxTrigger {
   Hover = 'hover',
   Click = 'click',

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -6,6 +6,7 @@ export interface NyxComponentProps {
   theme?: NyxTheme
   size?: NyxSize
   variant?: NyxVariant
+  trigger?: NyxTrigger
   shape?: NyxShape
   pixel?: boolean
 }
@@ -35,6 +36,11 @@ export enum NyxVariant {
   Outline = 'outline',
   Ghost = 'ghost',
   Text = 'text',
+}
+
+export enum NyxTrigger {
+  Hover = 'hover',
+  Click = 'click',
 }
 
 export enum NyxShape {

--- a/src/types/select.ts
+++ b/src/types/select.ts
@@ -12,4 +12,5 @@ export interface NyxSelectOption {
   label: string,
   value: string,
   disabled?: boolean
+  icon?: string
 }


### PR DESCRIPTION
## Summary
- Add `NyxDropdown`, `NyxDropdownMenu`, and `NyxDropdownItem` with shared trigger, position, and menu composition behavior.
- Wire theme, size, variant, trigger, and position props through the wrapper and default menu.
- Add docs, stories, and unit coverage for hover/click behavior, mobile fallback, outside clicks, and positioning.

## Validation
- `pnpm exec vitest run src/components/NyxDropdown/NyxDropdown.spec.ts`
- `pnpm type-check`